### PR TITLE
Add PS3 Memory Card Adaptor driver and PS1 system handler

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -46,6 +46,19 @@ SOFTWARE.
 
 ================================================================================
 
+ps3mca-ps1
+https://github.com/paolo-caroni/ps3mca-ps1
+
+PS3 Memory Card Adaptor protocol (command framing, opcodes, PS1 frame
+read/response layout) in src/lib/drivers/ps3-mca/ was ported from the
+paolo-caroni ps3mca-ps1 libusb driver.
+
+License: GNU General Public License v3.0
+
+See LICENSE in this repository (same license applies to nabu as a whole).
+
+================================================================================
+
 AmiiboAPI
 https://github.com/N3evin/AmiiboAPI
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -151,11 +151,15 @@ function App() {
             reason,
           });
           setSelectedSystem(null);
+          setAutoDetected(null);
+          setConfigValues({});
           return;
         }
 
         if (!result) {
           log("No cartridge detected", "warn");
+          setAutoDetected(null);
+          setConfigValues({});
           // If the driver has exactly one dumpable system, pre-select it so
           // the user has a Start Dump button once they insert the right card.
           const dumpableIds = new Set(
@@ -243,6 +247,15 @@ function App() {
     if (connection.driver) return "configuring" as const;
     return "idle" as const;
   }, [dumpJob.state, connection.driver]);
+
+  // Decoding the PS1 dump summary allocates fresh icon arrays per call, which
+  // would restart the IconCanvas animation on every unrelated re-render
+  // (e.g. log-panel updates). Memoize on the rom data reference.
+  const dumpSummary = useMemo(() => {
+    const data = dumpJob.result?.rom?.data;
+    if (!data) return null;
+    return selectedSystem?.summarizeDump?.(data) ?? null;
+  }, [selectedSystem, dumpJob.result?.rom?.data]);
 
   const handleSelectSystem = useCallback(
     async (system: SystemHandler) => {
@@ -509,13 +522,7 @@ function App() {
                         .find((c) => c.systemId === selectedSystem?.systemId)
                         ?.operations.includes("dump_rom")
                     }
-                    summary={
-                      dumpJob.result.rom
-                        ? (selectedSystem?.summarizeDump?.(
-                            dumpJob.result.rom.data,
-                          ) ?? null)
-                        : null
-                    }
+                    summary={dumpSummary}
                   />
                 )}
               </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
+import { Button } from "@/components/ui/button";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { ScanlineOverlay } from "@/components/shared/scanline-overlay";
 import { StatusBadge } from "@/components/shared/status-badge";
@@ -15,12 +16,15 @@ import { useConnection } from "@/hooks/use-connection";
 import { DatabasePanel } from "@/components/shared/database-panel";
 import { GBSystemHandler } from "@/lib/systems/gb/gb-system-handler";
 import { GBASystemHandler } from "@/lib/systems/gba/gba-system-handler";
+import { Ps1SystemHandler } from "@/lib/systems/ps1/ps1-system-handler";
+import { NOINTRO_SYSTEM_NAMES } from "@/lib/core/nointro";
 import { AmiiboScanner } from "@/components/wizard/amiibo-scanner";
 import { InfinityScanner } from "@/components/wizard/infinity-scanner";
 import type { InfinityDriver } from "@/lib/drivers/infinity/infinity-driver";
 import type {
   DeviceDriver,
   DeviceInfo,
+  DeviceCapability,
   SystemHandler,
   ConfigValues,
   CartridgeInfo,
@@ -32,7 +36,14 @@ const ALL_SYSTEMS: SystemHandler[] = [
   new GBSystemHandler("gb"),
   new GBSystemHandler("gbc"),
   new GBASystemHandler(),
+  new Ps1SystemHandler(),
 ];
+
+/** True when the driver exposes both ROM and save dumping as separate ops. */
+const hasSeparateSaveRead = (cap: DeviceCapability | undefined): boolean =>
+  !!cap &&
+  cap.operations.includes("dump_rom") &&
+  cap.operations.includes("dump_save");
 
 const ACTIVE_STATES: ReadonlySet<DumpJobState> = new Set<DumpJobState>([
   "dumping_rom",
@@ -72,16 +83,26 @@ function App() {
   const [configValues, setConfigValues] = useState<ConfigValues>({});
   const [autoDetected, setAutoDetected] = useState<CartridgeInfo | null>(null);
   const [detecting, setDetecting] = useState(false);
+  const [unsupportedDetection, setUnsupportedDetection] = useState<{
+    title: string;
+    reason: string;
+  } | null>(null);
 
   /** Build prefilled config values from detected CartridgeInfo. */
   const prefillFromCartInfo = useCallback(
-    (system: SystemHandler, info: CartridgeInfo): ConfigValues => {
+    (
+      system: SystemHandler,
+      info: CartridgeInfo,
+      hasSeparateSaveRead: boolean,
+    ): ConfigValues => {
       const prefilled: ConfigValues = {};
       if (info.romSize) prefilled.romSizeBytes = info.romSize;
       if (info.saveSize) {
         prefilled.saveSizeBytes = info.saveSize;
-        // Save-only systems use readROM() for save data — don't trigger a second read
-        if (system.fileExtension !== ".sav") {
+        // Only request a second readSave() pass when the driver declares
+        // dump_rom and dump_save as separate operations. Save-only drivers
+        // (e.g. PS3 MCA) emit the save image directly from readROM().
+        if (hasSeparateSaveRead) {
           prefilled.backupSave = info.saveSize > 0;
         }
       }
@@ -111,11 +132,43 @@ function App() {
   const autoDetectSystem = useCallback(
     async (drv: DeviceDriver) => {
       setDetecting(true);
+      setUnsupportedDetection(null);
       log("Auto-detecting cartridge system...");
       try {
-        const result = await drv.detectSystem();
+        let result: Awaited<ReturnType<DeviceDriver["detectSystem"]>> = null;
+        try {
+          result = await drv.detectSystem();
+        } catch (e) {
+          log((e as Error).message, "error");
+        }
+
+        // Driver flagged the cartridge as detectable but not dumpable.
+        if (result?.unsupported) {
+          const reason = result.unsupported.reason;
+          log(reason, "warn");
+          setUnsupportedDetection({
+            title: result.cartInfo.title ?? "Unsupported cartridge",
+            reason,
+          });
+          setSelectedSystem(null);
+          return;
+        }
+
         if (!result) {
-          log("No cartridge detected — select system manually", "warn");
+          log("No cartridge detected", "warn");
+          // If the driver has exactly one dumpable system, pre-select it so
+          // the user has a Start Dump button once they insert the right card.
+          const dumpableIds = new Set(
+            drv.capabilities
+              .filter((c) => c.operations.length > 0)
+              .map((c) => c.systemId),
+          );
+          const dumpable = ALL_SYSTEMS.filter((s) =>
+            dumpableIds.has(s.systemId),
+          );
+          if (dumpable.length === 1) {
+            setSelectedSystem(dumpable[0]);
+          }
           return;
         }
 
@@ -123,9 +176,16 @@ function App() {
         if (!system) return;
 
         log(
-          `Detected: ${result.cartInfo.title ?? "Unknown"} (${result.cartInfo.mapper?.name ?? "unknown mapper"})`,
+          result.cartInfo.mapper
+            ? `Detected: ${result.cartInfo.title ?? "Unknown"} (${result.cartInfo.mapper.name ?? "unknown mapper"})`
+            : `Detected: ${result.cartInfo.title ?? "Unknown"}`,
         );
-        const prefilled = prefillFromCartInfo(system, result.cartInfo);
+        const cap = drv.capabilities.find((c) => c.systemId === result.systemId);
+        const prefilled = prefillFromCartInfo(
+          system,
+          result.cartInfo,
+          hasSeparateSaveRead(cap),
+        );
         const seeded = seedConfigDefaults(system, prefilled, result.cartInfo);
 
         setSelectedSystem(system);
@@ -156,6 +216,7 @@ function App() {
     setSelectedSystem(null);
     setConfigValues({});
     setAutoDetected(null);
+    setUnsupportedDetection(null);
     dumpJob.reset();
   }, [connection, dumpJob]);
 
@@ -193,18 +254,21 @@ function App() {
       let prefilled: ConfigValues = {};
 
       if (connection.driver) {
-        const canAutoDetect = connection.driver.capabilities.some(
-          (c) => c.systemId === system.systemId && c.autoDetect,
+        const cap = connection.driver.capabilities.find(
+          (c) => c.systemId === system.systemId,
         );
+        const canAutoDetect = !!cap?.autoDetect;
         if (canAutoDetect) {
           log(`Auto-detecting ${system.displayName} cartridge...`);
           const info = await connection.driver.detectCartridge(system.systemId);
           if (info) {
             detected = info;
             log(
-              `Detected: ${info.title ?? "Unknown"} (${info.mapper?.name ?? "unknown mapper"})`,
+              info.mapper
+                ? `Detected: ${info.title ?? "Unknown"} (${info.mapper.name ?? "unknown mapper"})`
+                : `Detected: ${info.title ?? "Unknown"}`,
             );
-            prefilled = prefillFromCartInfo(system, info);
+            prefilled = prefillFromCartInfo(system, info, hasSeparateSaveRead(cap));
           } else {
             log("No cartridge detected", "warn");
           }
@@ -273,6 +337,18 @@ function App() {
     await handleDisconnect();
   }, [dumpJob, handleDisconnect]);
 
+  /** Re-run cartridge detection on hot-swap devices. Resets any prior dump
+   *  result so transitioning from a completed dump back to detect feels
+   *  natural. */
+  const handleScan = useCallback(() => {
+    dumpJob.reset();
+    setAutoDetected(null);
+    setUnsupportedDetection(null);
+    if (connection.driver) autoDetectSystem(connection.driver);
+  }, [dumpJob, connection.driver, autoDetectSystem]);
+
+  const hotSwap = connection.deviceInfo?.hotSwap === true;
+
   return (
     <TooltipProvider>
       <ScanlineOverlay />
@@ -333,29 +409,74 @@ function App() {
               />
             ) : (
               <div className="flex flex-col gap-6">
-                <ConfigureStep
-                  deviceInfo={connection.deviceInfo}
-                  systems={availableSystems}
-                  selectedSystem={selectedSystem}
-                  onSelectSystem={handleSelectSystem}
-                  configValues={configValues}
-                  onConfigChange={handleConfigChange}
-                  autoDetected={autoDetected}
-                  hasVerificationDb={
-                    selectedSystem
-                      ? !!nointro.getDb(selectedSystem.systemId)
-                      : false
-                  }
-                  detecting={detecting}
-                  busy={
-                    dumpJob.state !== "idle" &&
-                    dumpJob.state !== "complete" &&
-                    dumpJob.state !== "error" &&
-                    dumpJob.state !== "aborted"
-                  }
-                  onStartDump={handleStartDump}
-                  onDisconnect={handleDisconnect}
-                />
+                {/* Persistent device header — Disconnect (and Scan, on
+                    hot-swap devices) stays visible across all wizard states. */}
+                <div className="flex items-center justify-between text-sm">
+                  {connection.deviceInfo && (
+                    <span className="text-muted-foreground">
+                      {connection.deviceInfo.deviceName}
+                      {connection.deviceInfo.firmwareVersion && (
+                        <span className="ml-2 text-muted-foreground/50">
+                          fw {connection.deviceInfo.firmwareVersion}
+                        </span>
+                      )}
+                    </span>
+                  )}
+                  <div className="flex items-center gap-2">
+                    {hotSwap && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={handleScan}
+                        disabled={
+                          detecting ||
+                          (dumpJob.state !== "idle" &&
+                            dumpJob.state !== "complete" &&
+                            dumpJob.state !== "error" &&
+                            dumpJob.state !== "aborted")
+                        }
+                      >
+                        Scan
+                      </Button>
+                    )}
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleDisconnect}
+                    >
+                      Disconnect
+                    </Button>
+                  </div>
+                </div>
+                {dumpJob.state !== "complete" && (
+                  <ConfigureStep
+                    systems={availableSystems}
+                    selectedSystem={selectedSystem}
+                    onSelectSystem={handleSelectSystem}
+                    configValues={configValues}
+                    onConfigChange={handleConfigChange}
+                    autoDetected={autoDetected}
+                    unsupportedDetection={unsupportedDetection}
+                    suggestLoadDat={
+                      !!selectedSystem &&
+                      NOINTRO_SYSTEM_NAMES[selectedSystem.systemId] !==
+                        undefined &&
+                      !nointro.getDb(selectedSystem.systemId) &&
+                      !!connection.driver?.capabilities
+                        .find((c) => c.systemId === selectedSystem.systemId)
+                        ?.operations.includes("dump_rom")
+                    }
+                    detecting={detecting}
+                    busy={
+                      dumpJob.state !== "idle" &&
+                      dumpJob.state !== "error" &&
+                      dumpJob.state !== "aborted"
+                    }
+                    onStartDump={handleStartDump}
+                    hotSwap={hotSwap}
+                    compatibilityNote={connection.deviceInfo?.compatibilityNote}
+                  />
+                )}
                 {isDumping(dumpJob.state) && (
                   <DumpStep
                     state={dumpJob.state}
@@ -382,7 +503,19 @@ function App() {
                     deviceInfo={connection.deviceInfo}
                     cartInfo={autoDetected}
                     systemDisplayName={selectedSystem?.displayName ?? ""}
-                    onReset={handleReset}
+                    hotSwap={hotSwap}
+                    saveOnly={
+                      !connection.driver?.capabilities
+                        .find((c) => c.systemId === selectedSystem?.systemId)
+                        ?.operations.includes("dump_rom")
+                    }
+                    summary={
+                      dumpJob.result.rom
+                        ? (selectedSystem?.summarizeDump?.(
+                            dumpJob.result.rom.data,
+                          ) ?? null)
+                        : null
+                    }
                   />
                 )}
               </div>

--- a/src/components/wizard/complete-step.tsx
+++ b/src/components/wizard/complete-step.tsx
@@ -1,10 +1,58 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import type { DumpResult, DeviceInfo, CartridgeInfo } from "@/lib/types";
+import type {
+  DumpResult,
+  DeviceInfo,
+  CartridgeInfo,
+  DumpSummary,
+  DumpSummaryCell,
+} from "@/lib/types";
 import { hexStr, formatBytes } from "@/lib/core/hashing";
 import { saveFile } from "@/lib/core/file-save";
 import { generateDumpReport } from "@/lib/core/dump-report";
+
+type IconCell = Extract<DumpSummaryCell, { kind: "icon" }>;
+
+function IconCanvas({ cell }: { cell: IconCell }) {
+  const ref = useRef<HTMLCanvasElement | null>(null);
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const draw = (i: number) => {
+      ctx.putImageData(
+        new ImageData(cell.frames[i], cell.width, cell.height),
+        0,
+        0,
+      );
+    };
+    draw(0);
+    if (cell.frames.length <= 1) return;
+    let i = 0;
+    const id = window.setInterval(() => {
+      i = (i + 1) % cell.frames.length;
+      draw(i);
+    }, cell.frameDurationMs ?? 320);
+    return () => window.clearInterval(id);
+  }, [cell]);
+  return (
+    <canvas
+      ref={ref}
+      width={cell.width}
+      height={cell.height}
+      aria-label={cell.alt}
+      role={cell.alt ? "img" : undefined}
+      className="block"
+      style={{
+        imageRendering: "pixelated",
+        width: cell.width * cell.displayScale,
+        height: cell.height * cell.displayScale,
+      }}
+    />
+  );
+}
 
 interface CompleteStepProps {
   result: DumpResult;
@@ -13,7 +61,12 @@ interface CompleteStepProps {
   deviceInfo: DeviceInfo | null;
   cartInfo: CartridgeInfo | null;
   systemDisplayName: string;
-  onReset: () => void;
+  /** Device supports re-detection without a full USB reconnect. */
+  hotSwap: boolean;
+  /** True when the dump output is save data, not a ROM (no verification DB applies). */
+  saveOnly: boolean;
+  /** Optional system-specific breakdown of the dump's contents. */
+  summary?: DumpSummary | null;
 }
 
 export function CompleteStep({
@@ -23,13 +76,39 @@ export function CompleteStep({
   deviceInfo,
   cartInfo,
   systemDisplayName,
-  onReset,
+  hotSwap,
+  saveOnly,
+  summary,
 }: CompleteStepProps) {
   const verified = result.verification.matched;
   const verifiedName = result.verification.entry?.name;
+  const integrityFailed = summary?.integrity?.ok === false;
+  const ok = saveOnly ? !integrityFailed : verified;
+  const headingText = saveOnly
+    ? integrityFailed
+      ? "Unverified"
+      : "Complete"
+    : verified
+      ? "Verified"
+      : "Unverified";
+  const subText = saveOnly
+    ? integrityFailed
+      ? (summary?.integrity?.message ?? "Integrity check failed")
+      : "Dump complete"
+    : verified
+      ? verifiedName
+      : "No match in verification database";
 
   const baseName = verifiedName ?? (title || "dump");
-  const romFilename = baseName + fileExtension;
+  // Save-only systems (e.g. PS1 memory card) have no verification DB and
+  // their handlers build a sensible date-stamped filename in `buildOutputFile`.
+  // ROM systems use the cartridge title (or verified name when available).
+  const romFilename =
+    verifiedName !== undefined
+      ? verifiedName + fileExtension
+      : saveOnly && result.rom
+        ? result.rom.filename
+        : (title || "dump") + fileExtension;
   const saveFilename = baseName + ".sav";
 
   const handleSaveReport = useCallback(() => {
@@ -45,73 +124,44 @@ export function CompleteStep({
     saveFile(data, baseName + ".txt", [".txt"]);
   }, [result, deviceInfo, cartInfo, systemDisplayName, romFilename, baseName]);
 
-  const isSaveOnly = fileExtension === ".sav";
-
   return (
     <Card
       className={
-        verified
+        ok
           ? "border-primary/40 bg-primary/5"
-          : isSaveOnly
-            ? "border-primary/40 bg-primary/5"
-            : "border-chart-3/30 bg-chart-3/5"
+          : "border-chart-3/30 bg-chart-3/5"
       }
     >
       <CardContent className="flex flex-col gap-4 pt-5">
-        {/* Verification status — not applicable for save-only systems */}
-        {isSaveOnly ? (
-          <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/20 text-xl text-primary">
-              {"\u2713"}
-            </div>
-            <div>
-              <div className="font-display font-bold text-primary">
-                Complete
-              </div>
-              <div className="text-sm text-card-foreground">
-                Save data backed up successfully
-              </div>
-            </div>
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xl ${
+              ok ? "bg-primary/20 text-primary" : "bg-chart-3/20 text-chart-3"
+            }`}
+          >
+            {ok ? "\u2713" : "?"}
           </div>
-        ) : (
-          <div className="flex items-center gap-3">
+          <div>
             <div
-              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-xl ${
-                verified
-                  ? "bg-primary/20 text-primary"
-                  : "bg-chart-3/20 text-chart-3"
-              }`}
+              className={`font-display font-bold ${ok ? "text-primary" : "text-chart-3"}`}
             >
-              {verified ? "\u2713" : "?"}
+              {headingText}
             </div>
-            <div>
-              <div
-                className={`font-display font-bold ${verified ? "text-primary" : "text-chart-3"}`}
-              >
-                {verified ? "Verified" : "Unverified"}
-              </div>
-              <div className="text-sm text-card-foreground">
-                {verified ? verifiedName : "No match in verification database"}
-              </div>
-            </div>
+            <div className="text-sm text-card-foreground">{subText}</div>
           </div>
-        )}
+        </div>
 
         {/* Hashes */}
         <div className="flex flex-col gap-1 font-mono text-xs">
           <div>
             <span className="text-muted-foreground">CRC32: </span>
-            <span
-              className={verified ? "text-primary" : "text-card-foreground"}
-            >
+            <span className={ok ? "text-primary" : "text-card-foreground"}>
               {hexStr(result.hashes.crc32)}
             </span>
           </div>
           <div className="break-all">
             <span className="text-muted-foreground">SHA-1: </span>
-            <span
-              className={verified ? "text-primary" : "text-card-foreground"}
-            >
+            <span className={ok ? "text-primary" : "text-card-foreground"}>
               {result.hashes.sha1}
             </span>
           </div>
@@ -123,12 +173,64 @@ export function CompleteStep({
           </div>
         </div>
 
-        {!verified && result.verification.suggestions && (
+        {!verified && !saveOnly && result.verification.suggestions && (
           <ul className="list-inside list-disc text-[11px] text-muted-foreground">
             {result.verification.suggestions.map((s, i) => (
               <li key={i}>{s}</li>
             ))}
           </ul>
+        )}
+
+        {summary && (
+          <div className="flex flex-col gap-2">
+            <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
+              {summary.title}
+            </div>
+            <div className="overflow-hidden rounded-md border border-border">
+              <table className="w-full text-xs">
+                <thead className="bg-muted/50 text-[10px] uppercase tracking-wider text-muted-foreground">
+                  <tr>
+                    {summary.columns.map((c, i) => (
+                      <th
+                        key={i}
+                        className="px-3 py-1.5 text-left font-normal"
+                      >
+                        {c}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {summary.rows.map((row, i) => (
+                    <tr key={i}>
+                      {row.map((cell, j) => {
+                        const mono = summary.monoColumns?.includes(j) ?? false;
+                        const muted =
+                          summary.mutedColumns?.includes(j) ?? false;
+                        return (
+                          <td
+                            key={j}
+                            className={`px-3 py-1 ${mono ? "font-mono" : ""} ${muted ? "text-muted-foreground" : ""}`}
+                          >
+                            {typeof cell === "string" ? (
+                              cell
+                            ) : (
+                              <IconCanvas cell={cell} />
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {summary.footer && (
+              <div className="text-[11px] text-muted-foreground">
+                {summary.footer}
+              </div>
+            )}
+          </div>
         )}
 
         {/* Actions */}
@@ -137,12 +239,16 @@ export function CompleteStep({
             <Button
               size="sm"
               onClick={() =>
-                saveFile(result.rom!.data, romFilename, [
-                  result.rom!.filename.match(/\.[^.]+$/)?.[0] ?? ".bin",
-                ])
+                saveFile(
+                  result.rom!.data,
+                  romFilename,
+                  result.rom!.acceptExtensions ?? [
+                    result.rom!.filename.match(/\.[^.]+$/)?.[0] ?? ".bin",
+                  ],
+                )
               }
             >
-              {isSaveOnly ? "Save File" : "Save ROM"}
+              {result.rom.actionLabel ?? (saveOnly ? "Save File" : "Save ROM")}
             </Button>
           )}
           {result.save && (
@@ -156,19 +262,25 @@ export function CompleteStep({
               Save SRAM
             </Button>
           )}
-          <Button variant="outline" size="sm" onClick={handleSaveReport}>
-            Save Report
-          </Button>
-          <Button variant="outline" size="sm" onClick={onReset}>
-            Swap Cartridge
-          </Button>
+          {!saveOnly && (
+            <Button variant="outline" size="sm" onClick={handleSaveReport}>
+              Save Report
+            </Button>
+          )}
         </div>
 
-        <p className="text-[11px] text-muted-foreground">
-          To dump another cartridge, unplug the{" "}
-          {deviceInfo?.deviceName ?? "device"} from USB, swap the cartridge,
-          then plug it back in.
-        </p>
+        {!hotSwap && (
+          <p className="text-[11px] text-muted-foreground">
+            {saveOnly
+              ? `Disconnect the ${deviceInfo?.deviceName ?? "device"} from USB to back up another save.`
+              : `To dump another cartridge, unplug the ${deviceInfo?.deviceName ?? "device"} from USB, swap the cartridge, then plug it back in.`}
+          </p>
+        )}
+        {hotSwap && (
+          <p className="text-[11px] text-muted-foreground">
+            Swap the cartridge and click Scan to back up another.
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/wizard/configure-step.tsx
+++ b/src/components/wizard/configure-step.tsx
@@ -14,37 +14,42 @@ import type {
   SystemHandler,
   ConfigValues,
   CartridgeInfo,
-  DeviceInfo,
 } from "@/lib/types";
 
 interface ConfigureStepProps {
-  deviceInfo: DeviceInfo | null;
   systems: SystemHandler[];
   selectedSystem: SystemHandler | null;
   onSelectSystem: (system: SystemHandler) => void;
   configValues: ConfigValues;
   onConfigChange: (key: string, value: unknown) => void;
   autoDetected: CartridgeInfo | null;
-  hasVerificationDb: boolean;
+  /** A cartridge was detected that the adapter can't read; render an explanation instead of the dump UI. */
+  unsupportedDetection?: { title: string; reason: string } | null;
+  /** Whether to hint that the user should load a No-Intro DAT. */
+  suggestLoadDat: boolean;
   detecting: boolean;
   busy: boolean;
   onStartDump: () => void;
-  onDisconnect: () => void;
+  /** Whether the device supports re-detection after a physical cart swap. */
+  hotSwap: boolean;
+  /** Optional cartridge-compatibility note shown under the "insert" prompt. */
+  compatibilityNote?: string;
 }
 
 export function ConfigureStep({
-  deviceInfo,
   systems,
   selectedSystem,
   onSelectSystem,
   configValues,
   onConfigChange,
   autoDetected,
-  hasVerificationDb,
+  unsupportedDetection,
+  suggestLoadDat,
   detecting,
   busy,
   onStartDump,
-  onDisconnect,
+  hotSwap,
+  compatibilityNote,
 }: ConfigureStepProps) {
   const fields = useMemo(
     () =>
@@ -84,22 +89,33 @@ export function ConfigureStep({
 
   return (
     <div className="flex flex-col gap-6">
-      {/* Device info — compact header line */}
-      <div className="flex items-center justify-between text-sm">
-        {deviceInfo && (
-          <span className="text-muted-foreground">
-            {deviceInfo.deviceName}
-            <span className="ml-2 text-muted-foreground/50">
-              fw {deviceInfo.firmwareVersion}
-            </span>
-          </span>
-        )}
-        <Button variant="outline" size="sm" onClick={onDisconnect}>
-          Swap Cartridge
-        </Button>
-      </div>
+      {/* Unsupported cartridge detected — show explanation instead of dump UI */}
+      {unsupportedDetection && !detecting && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm uppercase tracking-wider text-muted-foreground">
+              Detected
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <label className="text-[10px] uppercase tracking-widest text-muted-foreground">
+                Cartridge
+              </label>
+              <div className="font-mono text-sm">
+                {unsupportedDetection.title}
+              </div>
+            </div>
+            <div className="flex gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-xs text-destructive">
+              <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+              <span>{unsupportedDetection.reason}</span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* System + Configuration — single card */}
+      {!unsupportedDetection && (
       <Card>
         <CardHeader>
           <CardTitle className="text-sm uppercase tracking-wider text-muted-foreground">
@@ -214,21 +230,37 @@ export function ConfigureStep({
                     )}
 
                   <div className="mt-2 flex flex-col gap-2">
-                    <Button
-                      className="w-full"
-                      size="lg"
-                      onClick={onStartDump}
-                      disabled={validation && !validation.valid}
-                    >
-                      Start Dump{dumpSizeLabel && ` (${dumpSizeLabel})`}
-                    </Button>
-                    {!hasVerificationDb &&
-                      selectedSystem?.fileExtension !== ".sav" && (
-                        <p className="text-center text-[11px] text-muted-foreground">
-                          Load a No-Intro DAT in the sidebar to verify your
-                          dump.
+                    {autoDetected ? (
+                      <>
+                        <Button
+                          className="w-full"
+                          size="lg"
+                          onClick={onStartDump}
+                          disabled={validation && !validation.valid}
+                        >
+                          Start Dump{dumpSizeLabel && ` (${dumpSizeLabel})`}
+                        </Button>
+                        {suggestLoadDat && (
+                          <p className="text-center text-[11px] text-muted-foreground">
+                            Load a No-Intro DAT in the sidebar to verify your
+                            dump.
+                          </p>
+                        )}
+                      </>
+                    ) : (
+                      <div className="flex flex-col items-center gap-2">
+                        <p className="text-center text-xs text-muted-foreground">
+                          {hotSwap
+                            ? "Insert a cartridge and click Scan."
+                            : "Insert a cartridge, then click Disconnect and reconnect."}
                         </p>
-                      )}
+                        {compatibilityNote && (
+                          <p className="text-center text-[11px] text-muted-foreground/70">
+                            {compatibilityNote}
+                          </p>
+                        )}
+                      </div>
+                    )}
                   </div>
                 </>
               )}
@@ -236,6 +268,7 @@ export function ConfigureStep({
           )}
         </CardContent>
       </Card>
+      )}
     </div>
   );
 }

--- a/src/hooks/use-connection.ts
+++ b/src/hooks/use-connection.ts
@@ -324,6 +324,8 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
         ),
       );
       if (!ps3Device) return;
+      // Another auto-reconnect probe (serial/HID) may have already won.
+      if (driverRef.current) return;
 
       log("Reconnecting to USB device...");
       try {

--- a/src/hooks/use-connection.ts
+++ b/src/hooks/use-connection.ts
@@ -3,11 +3,14 @@ import { MockDriver } from "@/lib/core/mock-driver";
 import { DEVICES, type DeviceDef } from "@/lib/core/devices";
 import { SerialTransport } from "@/lib/transport/serial-transport";
 import { HidTransport } from "@/lib/transport/hid-transport";
+import { UsbTransport } from "@/lib/transport/usb-transport";
 import { GBxCartDriver } from "@/lib/drivers/gbxcart/gbxcart-driver";
 import { PowerSaveDriver } from "@/lib/drivers/powersave/powersave-driver";
 import { DEVICE_FILTERS as POWERSAVE_FILTERS } from "@/lib/drivers/powersave/powersave-commands";
 import { InfinityDriver } from "@/lib/drivers/infinity/infinity-driver";
 import { DEVICE_FILTERS as INFINITY_FILTERS } from "@/lib/drivers/infinity/infinity-commands";
+import { Ps3McaDriver } from "@/lib/drivers/ps3-mca/ps3-mca-driver";
+import { DEVICE_FILTERS as PS3_MCA_FILTERS } from "@/lib/drivers/ps3-mca/ps3-mca-commands";
 import type { DeviceDriver, DeviceInfo, Transport } from "@/lib/types";
 
 // ─── Device probing ──────────────────────────────────────────────────────
@@ -202,6 +205,9 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
   const finishConnect = useCallback(
     (drv: DeviceDriver, info: DeviceInfo, deviceId?: string) => {
       if (deviceId) lastDeviceIdRef.current = deviceId;
+      // Set the ref synchronously so reprobe() can't race us into a duplicate
+      // connection before React commits the driver state update.
+      driverRef.current = drv;
       setDriver(drv);
       setDeviceInfo(info);
       setConnected(true);
@@ -309,6 +315,37 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
         }
       }
     });
+
+    // Try WebUSB (PS3 Memory Card Adaptor)
+    navigator.usb?.getDevices().then(async (devices) => {
+      const ps3Device = devices.find((d) =>
+        PS3_MCA_FILTERS.some(
+          (f) => f.vendorId === d.vendorId && f.productId === d.productId,
+        ),
+      );
+      if (!ps3Device) return;
+
+      log("Reconnecting to USB device...");
+      try {
+        const transport = new UsbTransport(PS3_MCA_FILTERS);
+        const identity = await transport.connectWithDevice(ps3Device);
+        log(`USB device opened: ${identity.name}`);
+
+        transport.on("onDisconnect", () => {
+          log("Device disconnected", "warn");
+          handleDisconnect();
+        });
+
+        const ps3Driver = new Ps3McaDriver(transport);
+        ps3Driver.on("onLog", (msg, level) => log(msg, level));
+
+        const info = await ps3Driver.initialize();
+        log(`Connected: ${info.deviceName}`);
+        finishConnect(ps3Driver, info, "PS3_MCA");
+      } catch (e) {
+        log(`Auto-reconnect failed: ${(e as Error).message}`, "warn");
+      }
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -411,6 +448,30 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
             const info = await infDriver.initialize();
             log(`Connected: ${info.deviceName} (fw: ${info.firmwareVersion})`);
             finishConnect(infDriver, info, deviceId);
+            break;
+          }
+
+          case "PS3_MCA": {
+            const transport = new UsbTransport(PS3_MCA_FILTERS);
+            if (authorized) {
+              log("Connecting...");
+              await transport.connectWithDevice(authorized as USBDevice);
+            } else {
+              log("Requesting USB device...");
+              await transport.connect();
+            }
+
+            transport.on("onDisconnect", () => {
+              log("Device disconnected", "warn");
+              handleDisconnect();
+            });
+
+            const ps3Driver = new Ps3McaDriver(transport);
+            ps3Driver.on("onLog", (msg, level) => log(msg, level));
+
+            const info = await ps3Driver.initialize();
+            log(`Connected: ${info.deviceName}`);
+            finishConnect(ps3Driver, info, deviceId);
             break;
           }
         }

--- a/src/lib/core/devices.ts
+++ b/src/lib/core/devices.ts
@@ -48,4 +48,23 @@ export const DEVICES: Record<string, DeviceDef> = {
       "Logic3/PDP Wii/Wii U/PS3/PS4/PC base (INF-8032386). " +
       "Protocol reference: dolphin-emu (GPL-2.0-or-later).",
   },
+  // The adapter performs an SIO-level identification challenge before
+  // reporting a card type. First-party PS1 cards reply with the expected
+  // ID bytes (0x5A 0x5D) on the first request; multi-page clone cards
+  // often fail to detect on the first try. The driver polls verify-card
+  // a handful of times to give clones a chance to come up
+  // (see Ps3McaDriver.getCardType).
+  PS3_MCA: {
+    id: "PS3_MCA",
+    name: "PS3 Memory Card Adaptor",
+    vendorId: 0x054c,
+    productId: 0x02ea,
+    transport: "webusb",
+    systems: [{ id: "ps1", name: "PS1 Memory Card" }],
+    notes:
+      "PS1 cards only; PS2 reads require encryption keys that cannot be " +
+      "redistributed. First-party cards detect instantly; clone cards " +
+      "may need a few retries. " +
+      "Protocol reference: github.com/paolo-caroni/ps3mca-ps1 (GPL-3.0).",
+  },
 };

--- a/src/lib/core/mock-driver.ts
+++ b/src/lib/core/mock-driver.ts
@@ -38,6 +38,7 @@ export class MockDriver implements DeviceDriver {
       firmwareVersion: "mock-1.0",
       deviceName: "Mock Device",
       capabilities: this.capabilities,
+      hotSwap: true,
     };
   }
 

--- a/src/lib/drivers/gbxcart/gbxcart-driver.ts
+++ b/src/lib/drivers/gbxcart/gbxcart-driver.ts
@@ -133,6 +133,13 @@ export class GBxCartDriver implements DeviceDriver {
       hardwareRevision: `PCB v${pcbVersion}`,
       deviceName,
       capabilities: this.capabilities,
+      // TODO: enable hot-swap when we capture cart_power_ctrl and implement
+      // CART_PWR_OFF → prompt → CART_PWR_ON. Per FlashGBX hw_GBxCartRW.py:
+      //   fw_ver >= 12 → honour cart_power_ctrl byte
+      //   else         → pcb_ver in (5, 6)
+      // Driver currently discards those bytes at the "cart_power_ctrl and
+      // bootloader_reset" line above; hot-swap stays false until the follow-up.
+      hotSwap: false,
     };
   }
 

--- a/src/lib/drivers/infinity/infinity-driver.ts
+++ b/src/lib/drivers/infinity/infinity-driver.ts
@@ -101,6 +101,8 @@ export class InfinityDriver implements DeviceDriver {
       firmwareVersion: version,
       deviceName: this.name,
       capabilities: this.capabilities,
+      // Portal emits async tag events; figures come and go freely.
+      hotSwap: true,
     };
   }
 

--- a/src/lib/drivers/powersave/powersave-driver.ts
+++ b/src/lib/drivers/powersave/powersave-driver.ts
@@ -50,6 +50,8 @@ export class PowerSaveDriver implements DeviceDriver {
       firmwareVersion: "",
       deviceName: this.name,
       capabilities: this.capabilities,
+      // Scanner UI polls continuously — tags come and go freely.
+      hotSwap: true,
     };
   }
 

--- a/src/lib/drivers/ps3-mca/ps3-mca-commands.ts
+++ b/src/lib/drivers/ps3-mca/ps3-mca-commands.ts
@@ -1,0 +1,86 @@
+// ─── PS3 Memory Card Adaptor protocol notes ────────────────────────────────
+//
+// Command framing (EP2 OUT bulk):
+//   Short form: [AA op]                          (2 bytes total)
+//   Long form:  [AA 42 <len_lo> <len_hi> <payload…>]   (4 + len bytes)
+//     `len` is the payload length, little-endian. Total packet = 4 + len.
+//
+// Response framing (EP1 IN bulk):
+//   Short form reply:   [55 <byte>]
+//   Long form success:  [55 5A <len_lo> <len_hi> <payload…>]
+//   Long form auth-fail: [55 AF]
+//
+// PS1 frame read (long form, payload length 140):
+//   Payload: [81 52 00 00 <frame_msb> <frame_lsb> 00*134]
+//     81  = memory card access (SIO)
+//     52  = read ('R')
+//     frame is big-endian on the SIO wire (0x0000..0x03FF)
+//     The 134 trailing zeros are dummy bytes that clock out the card reply.
+//
+// PS1 read response (144 bytes total):
+//   [0..3]    55 5A <len_lo> <len_hi>       PS3mca success header
+//   [4..9]    SIO echo of command header (unchecked)
+//   [10..11]  5C 5D                         command acknowledge
+//   [12..13]  <msb> <lsb>                   confirmed frame address
+//   [14..141] 128 data bytes                ← the frame
+//   [142]     checksum (MSB XOR LSB XOR all 128 data bytes)
+//   [143]     memory end byte (47h = good, 4Eh = bad checksum, FFh = bad frame)
+//
+// Reference: github.com/paolo-caroni/ps3mca-ps1 (GPL-3.0)
+// ────────────────────────────────────────────────────────────────────────────
+
+export const DEVICE_FILTERS = [{ vendorId: 0x054c, productId: 0x02ea }];
+
+export const REQ_MARKER = 0xaa;
+export const RES_MARKER = 0x55;
+export const LONG_FORM_OP = 0x42;
+export const LONG_FORM_SUCCESS = 0x5a;
+export const PERMISSION_FAIL = 0xaf;
+
+/** Short-form opcode: report the kind of card currently inserted. */
+export const OP_VERIFY_CARD = 0x40;
+
+export const CARD_TYPE_NONE = 0x00;
+export const CARD_TYPE_PS1 = 0x01;
+export const CARD_TYPE_PS2 = 0x02;
+
+// PS1 SIO memory-card opcodes (used inside long-form payloads).
+export const SIO_CARD_ACCESS = 0x81;
+export const SIO_READ = 0x52;
+
+export const PS1_FRAME_SIZE = 128;
+export const PS1_FRAMES = 1024;
+export const PS1_CARD_SIZE = PS1_FRAMES * PS1_FRAME_SIZE; // 131072
+
+/** Total size of the response to a PS1 frame read. */
+export const PS1_READ_RESPONSE_SIZE = 144;
+
+/** Card-reply byte indicating a successful read ("Good" memory end byte). */
+export const MEB_GOOD = 0x47;
+
+export const COMMAND_TIMEOUT_MS = 5000;
+
+/** Short-form probe for the inserted card (reply: [55, 00|01|02]). */
+export function buildVerifyCardCommand(): Uint8Array {
+  return new Uint8Array([REQ_MARKER, OP_VERIFY_CARD]);
+}
+
+/**
+ * Long-form PS1 read command for a single 128-byte frame.
+ * Frame is 0..1023; encoded big-endian on the SIO wire.
+ */
+export function buildPs1ReadCommand(frame: number): Uint8Array {
+  const payloadLen = 140;
+  const cmd = new Uint8Array(4 + payloadLen);
+  cmd[0] = REQ_MARKER;
+  cmd[1] = LONG_FORM_OP;
+  cmd[2] = payloadLen & 0xff;
+  cmd[3] = (payloadLen >> 8) & 0xff;
+  cmd[4] = SIO_CARD_ACCESS;
+  cmd[5] = SIO_READ;
+  // cmd[6..7] = 00 00 (filler, card ID request slots)
+  cmd[8] = (frame >> 8) & 0xff; // frame MSB (big-endian)
+  cmd[9] = frame & 0xff; // frame LSB
+  // cmd[10..143] remain 0x00 (4 SIO ack slots + 130 clock-out bytes)
+  return cmd;
+}

--- a/src/lib/drivers/ps3-mca/ps3-mca-driver.ts
+++ b/src/lib/drivers/ps3-mca/ps3-mca-driver.ts
@@ -1,0 +1,244 @@
+import type {
+  DeviceDriver,
+  DeviceDriverEvents,
+  DeviceCapability,
+  DeviceInfo,
+  CartridgeInfo,
+  ReadConfig,
+  DumpProgress,
+  SystemId,
+  DetectSystemResult,
+} from "@/lib/types";
+import type { UsbTransport } from "@/lib/transport/usb-transport";
+import {
+  buildPs1ReadCommand,
+  buildVerifyCardCommand,
+  CARD_TYPE_NONE,
+  CARD_TYPE_PS1,
+  CARD_TYPE_PS2,
+  COMMAND_TIMEOUT_MS,
+  LONG_FORM_SUCCESS,
+  MEB_GOOD,
+  PERMISSION_FAIL,
+  PS1_CARD_SIZE,
+  PS1_FRAME_SIZE,
+  PS1_FRAMES,
+  PS1_READ_RESPONSE_SIZE,
+  RES_MARKER,
+} from "./ps3-mca-commands";
+
+const PS2_NOT_SUPPORTED = "PS2 memory cards are not supported.";
+
+export class Ps3McaDriver implements DeviceDriver {
+  readonly id = "PS3_MCA";
+  readonly name = "PS3 Memory Card Adaptor";
+  readonly capabilities: DeviceCapability[] = [
+    // The dump output is save data (a memory-card image), not a ROM — even
+    // though we call readROM() under the hood. Declaring this as dump_save
+    // keeps ROM-oriented UI (e.g. No-Intro DAT hints) suppressed.
+    { systemId: "ps1", operations: ["dump_save"], autoDetect: true },
+  ];
+
+  transport: UsbTransport;
+  private events: Partial<DeviceDriverEvents> = {};
+
+  constructor(transport: UsbTransport) {
+    this.transport = transport;
+  }
+
+  async initialize(): Promise<DeviceInfo> {
+    // The adapter has no activate/wake sequence — it's ready as soon as the
+    // USB interface is claimed. No firmware version is exposed.
+    return {
+      firmwareVersion: "",
+      deviceName: this.name,
+      capabilities: this.capabilities,
+      // Memory cards are hot-pluggable by spec; no cart-power concerns.
+      hotSwap: true,
+      compatibilityNote:
+        "Some third-party clone cards may not be detected. Click Scan a " +
+        "few times if a card isn't recognized.",
+    };
+  }
+
+  async detectSystem(): Promise<DetectSystemResult | null> {
+    const type = await this.getCardType();
+    switch (type) {
+      case CARD_TYPE_PS1:
+        return {
+          systemId: "ps1",
+          cartInfo: { title: "PS1 Memory Card", saveSize: PS1_CARD_SIZE },
+        };
+      case CARD_TYPE_PS2:
+        // Report PS2 detection but flag it unsupported so the UI can render
+        // an explanation without offering a dump. readROM still guards against
+        // being called on PS2 as defense-in-depth.
+        return {
+          systemId: "ps2",
+          cartInfo: { title: "PS2 Memory Card" },
+          unsupported: { reason: PS2_NOT_SUPPORTED },
+        };
+      case CARD_TYPE_NONE:
+        return null;
+      default:
+        throw new Error(`Unknown card type ${hex(type)}`);
+    }
+  }
+
+  async detectCartridge(_systemId: SystemId): Promise<CartridgeInfo | null> {
+    const result = await this.detectSystem();
+    return result?.cartInfo ?? null;
+  }
+
+  async readROM(_config: ReadConfig, signal?: AbortSignal): Promise<Uint8Array> {
+    const type = await this.getCardType();
+    if (type === CARD_TYPE_NONE) {
+      throw new Error("No memory card detected in the PS1 slot.");
+    }
+    if (type === CARD_TYPE_PS2) {
+      throw new Error(PS2_NOT_SUPPORTED);
+    }
+    if (type !== CARD_TYPE_PS1) {
+      throw new Error(`Unknown card type ${hex(type)}`);
+    }
+
+    this.log("Reading PS1 memory card (128 KB)...");
+    const out = new Uint8Array(PS1_CARD_SIZE);
+
+    // The adapter firmware doesn't tolerate pipelined long-form commands —
+    // queueing a second send + recv while the first response is in flight
+    // produces a malformed (short) response on frame N+1. Stick to strict
+    // request-response.
+    for (let frame = 0; frame < PS1_FRAMES; frame++) {
+      if (signal?.aborted) throw new Error("Aborted");
+      await this.transport.send(buildPs1ReadCommand(frame));
+      const resp = await this.transport.receive(PS1_READ_RESPONSE_SIZE, {
+        timeout: COMMAND_TIMEOUT_MS,
+      });
+      const data = this.parseFrameResponse(resp, frame);
+      out.set(data, frame * PS1_FRAME_SIZE);
+      this.emitProgress("rom", (frame + 1) * PS1_FRAME_SIZE, PS1_CARD_SIZE);
+    }
+
+    return out;
+  }
+
+  async readSave(_config: ReadConfig, _signal?: AbortSignal): Promise<Uint8Array> {
+    throw new Error("PS1 memory cards do not have separate save data");
+  }
+
+  async writeSave(
+    _data: Uint8Array,
+    _config: ReadConfig,
+    _signal?: AbortSignal,
+  ): Promise<void> {
+    throw new Error("PS1 memory card writing is not yet implemented");
+  }
+
+  on<K extends keyof DeviceDriverEvents>(
+    event: K,
+    handler: DeviceDriverEvents[K],
+  ): void {
+    this.events[event] = handler;
+  }
+
+  // ─── Protocol helpers ──────────────────────────────────────────────────
+
+  private async getCardType(): Promise<number> {
+    // First-party cards reply on the first verify-card request. Clone
+    // cards often miss the first ID challenge and report NONE; polling a
+    // handful of times sometimes brings them up. A real empty slot still
+    // resolves to NONE quickly — the worst case is ~1s of wasted polling
+    // on Scan.
+    const MAX_ATTEMPTS = 6;
+    const RETRY_DELAY_MS = 150;
+    let lastType = CARD_TYPE_NONE;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      await this.transport.send(buildVerifyCardCommand());
+      const resp = await this.transport.receive(2, {
+        timeout: COMMAND_TIMEOUT_MS,
+      });
+      if (resp.length < 2) {
+        throw new Error("Short response from adapter on verify-card");
+      }
+      if (resp[0] !== RES_MARKER) {
+        throw new Error(`Unexpected verify-card marker ${hex(resp[0])}`);
+      }
+      lastType = resp[1];
+      if (lastType !== CARD_TYPE_NONE) {
+        if (attempt > 1) {
+          this.log(`Card detected after ${attempt} attempts`);
+        }
+        return lastType;
+      }
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, RETRY_DELAY_MS));
+      }
+    }
+    return lastType;
+  }
+
+  private parseFrameResponse(resp: Uint8Array, frame: number): Uint8Array {
+    if (resp.length < PS1_READ_RESPONSE_SIZE) {
+      throw new Error(
+        `Short read on frame ${frame}: got ${resp.length} bytes, expected ${PS1_READ_RESPONSE_SIZE}`,
+      );
+    }
+    if (resp[0] !== RES_MARKER || resp[1] !== LONG_FORM_SUCCESS) {
+      if (resp[0] === RES_MARKER && resp[1] === PERMISSION_FAIL) {
+        throw new Error(
+          `Authentication failure on frame ${frame} (likely a PS2 card)`,
+        );
+      }
+      throw new Error(
+        `Bad response header on frame ${frame}: ${hex(resp[0])} ${hex(resp[1])}`,
+      );
+    }
+
+    const expectedMsb = (frame >> 8) & 0xff;
+    const expectedLsb = frame & 0xff;
+    if (resp[12] !== expectedMsb || resp[13] !== expectedLsb) {
+      throw new Error(
+        `Frame address mismatch on frame ${frame}: got ${hex(resp[12])} ${hex(resp[13])}`,
+      );
+    }
+
+    // Card-reported checksum is XOR of MSB, LSB, and the 128 data bytes.
+    let checksum = 0;
+    for (let i = 12; i < 12 + 2 + PS1_FRAME_SIZE; i++) checksum ^= resp[i];
+    if (resp[142] !== checksum) {
+      throw new Error(
+        `Checksum mismatch on frame ${frame}: got ${hex(resp[142])}, computed ${hex(checksum)}`,
+      );
+    }
+
+    if (resp[143] !== MEB_GOOD) {
+      throw new Error(
+        `Bad memory-end byte on frame ${frame}: ${hex(resp[143])}`,
+      );
+    }
+
+    return resp.slice(14, 14 + PS1_FRAME_SIZE);
+  }
+
+  private emitProgress(
+    phase: DumpProgress["phase"],
+    bytesRead: number,
+    totalBytes: number,
+  ): void {
+    this.events.onProgress?.({
+      phase,
+      bytesRead,
+      totalBytes,
+      fraction: bytesRead / totalBytes,
+    });
+  }
+
+  private log(message: string, level: "info" | "warn" | "error" = "info"): void {
+    this.events.onLog?.(message, level);
+  }
+}
+
+function hex(b: number): string {
+  return `0x${b.toString(16).padStart(2, "0")}`;
+}

--- a/src/lib/systems/ps1/ps1-system-handler.ts
+++ b/src/lib/systems/ps1/ps1-system-handler.ts
@@ -1,0 +1,332 @@
+import type {
+  SystemHandler,
+  ConfigValues,
+  CartridgeInfo,
+  ResolvedConfigField,
+  ValidationResult,
+  ReadConfig,
+  OutputFile,
+  VerificationHashes,
+  VerificationDB,
+  VerificationResult,
+  DumpSummary,
+  DumpSummaryCell,
+} from "@/lib/types";
+import { crc32, sha1Hex, sha256Hex } from "@/lib/core/hashing";
+
+// Spec constants — duplicated from `ps3-mca-commands.ts` to keep the system
+// handler decoupled from a specific driver module.
+const PS1_CARD_SIZE = 131072;
+const PS1_BLOCK_SIZE = 8192;
+const PS1_FRAME_SIZE = 128;
+// Block 0 holds the BIOS-managed metadata (header + 15 directory entries +
+// broken-sector list + test-write frame) — every frame here has its XOR
+// checksum enforced. Save data blocks (1-15) are written by games directly
+// and do not maintain a per-frame XOR, so we don't check them.
+const PS1_BLOCK0_FRAMES = 64;
+const ICON_SCALE = 3;
+
+// Directory-entry block-allocation states (psx-spx).
+//   0x51 = used, head of a save
+//   0x52 / 0x53 = used, middle / last continuation block
+//   0xA0 = free / formatted
+//   0xA1 = deleted, head of a save (filename + chain preserved for undelete)
+//   0xA2 / 0xA3 = deleted continuation
+// We surface only head entries (0x51 / 0xA1) — continuations have zero-filled
+// filenames and contain no SC-magic title frame of their own.
+const STATUS_HEAD_USED = 0x51;
+const STATUS_HEAD_DELETED = 0xa1;
+
+export class Ps1SystemHandler implements SystemHandler {
+  readonly systemId = "ps1";
+  readonly displayName = "PS1 Memory Card";
+  readonly fileExtension = ".mcr";
+
+  getConfigFields(
+    _currentValues: ConfigValues,
+    _autoDetected?: CartridgeInfo,
+  ): ResolvedConfigField[] {
+    return [];
+  }
+
+  estimateDumpSize(_values: ConfigValues): number {
+    return PS1_CARD_SIZE;
+  }
+
+  validate(_values: ConfigValues): ValidationResult {
+    return { valid: true };
+  }
+
+  buildReadConfig(_values: ConfigValues): ReadConfig {
+    return { systemId: "ps1", params: {} };
+  }
+
+  buildOutputFile(rawData: Uint8Array, _config: ReadConfig): OutputFile {
+    const now = new Date();
+    const stamp =
+      now.getFullYear().toString() +
+      (now.getMonth() + 1).toString().padStart(2, "0") +
+      now.getDate().toString().padStart(2, "0");
+    return {
+      data: rawData,
+      filename: `ps1_memcard_${stamp}.mcr`,
+      mimeType: "application/octet-stream",
+      meta: { Format: "Raw PS1 memory card", Size: `${rawData.length} bytes` },
+      // .mcr (ePSXe / PCSX-Reloaded / DuckStation) and .mcd (PCSX) are
+      // byte-identical raw 128 KiB images; offer both in the save dialog.
+      acceptExtensions: [".mcr", ".mcd"],
+      actionLabel: "Save Memory Card",
+    };
+  }
+
+  async computeHashes(rawData: Uint8Array): Promise<VerificationHashes> {
+    const [sha1, sha256] = await Promise.all([
+      sha1Hex(rawData),
+      sha256Hex(rawData),
+    ]);
+    return { crc32: crc32(rawData), sha1, sha256, size: rawData.length };
+  }
+
+  verify(
+    _hashes: VerificationHashes,
+    _db: VerificationDB | null,
+  ): VerificationResult {
+    // No verification DB for user-written memory-card contents.
+    return { matched: false, confidence: "none" };
+  }
+
+  summarizeDump(rawData: Uint8Array): DumpSummary | null {
+    if (rawData.length !== PS1_CARD_SIZE) return null;
+    if (rawData[0] !== 0x4d || rawData[1] !== 0x43) return null; // "MC"
+
+    const ascii = new TextDecoder("ascii");
+    const sjis = new TextDecoder("shift-jis", { fatal: false });
+
+    const rows: DumpSummaryCell[][] = [];
+    let used = 0;
+    let deleted = 0;
+    let blocksUsed = 0;
+
+    // TODO: each used slot could expose a per-save export action that
+    // writes just that save in single-save formats (.mcs / .psx / .psv)
+    // for transferring an individual save to another card. Would need a
+    // richer DumpSummary shape (per-row actions) and a header/wrapper
+    // builder for each format.
+    for (let slot = 1; slot <= 15; slot++) {
+      const entryOffset = slot * PS1_FRAME_SIZE;
+      const status = rawData[entryOffset];
+
+      if (status !== STATUS_HEAD_USED && status !== STATUS_HEAD_DELETED)
+        continue;
+
+      const isDeleted = status === STATUS_HEAD_DELETED;
+      const filename = ascii
+        .decode(rawData.subarray(entryOffset + 10, entryOffset + 30))
+        .replace(/\0+$/, "");
+
+      // Count blocks by walking the next-block-pointer chain at offset
+      // 0x08-0x09 (little-endian). 0xFFFF terminates the chain; otherwise
+      // the value is `block_index - 1`. Cap at 15 hops as a corruption
+      // guard against a self-referencing or out-of-range pointer.
+      let blocks = 1;
+      let cur = slot;
+      for (let hop = 0; hop < 15; hop++) {
+        const ptrOffset = cur * PS1_FRAME_SIZE + 8;
+        const ptr = rawData[ptrOffset] | (rawData[ptrOffset + 1] << 8);
+        if (ptr === 0xffff) break;
+        const next = ptr + 1;
+        if (next < 1 || next > 15) break;
+        cur = next;
+        blocks++;
+      }
+
+      let title = "";
+      let icon: DumpSummaryCell = "";
+      const blockOffset = slot * PS1_BLOCK_SIZE;
+      const hasTitleFrame =
+        rawData[blockOffset] === 0x53 && rawData[blockOffset + 1] === 0x43;
+      if (hasTitleFrame) {
+        // PS1 games typically write Latin titles as fullwidth ASCII
+        // (U+FF01–U+FF5E) and pad with U+3000 (IDEOGRAPHIC SPACE) plus,
+        // in some games, embedded NULs. Normalize fullwidth → halfwidth
+        // for readability, truncate at the first NUL, and trim trailing
+        // whitespace.
+        title = normalizeFullwidth(
+          sjis.decode(rawData.subarray(blockOffset + 4, blockOffset + 68)),
+        )
+          .split("\0", 1)[0]
+          .trimEnd();
+
+        icon = decodeIcon(rawData, blockOffset, title);
+      }
+
+      if (isDeleted) deleted++;
+      else used++;
+      blocksUsed += blocks;
+
+      // A directory entry marked used/deleted but missing the "SC" magic at
+      // the start of its data block has lost its title frame — common when
+      // the save block has been overwritten or partially corrupted.
+      const statusLabel = !hasTitleFrame
+        ? "Corrupt"
+        : isDeleted
+          ? "Deleted"
+          : "Used";
+
+      const productCode = extractProductCode(filename);
+      rows.push([
+        icon,
+        String(slot),
+        statusLabel,
+        productCode,
+        String(blocks),
+        title,
+      ]);
+    }
+
+    const integrity = checkFrameXor(rawData);
+    const baseFooter = `${used} used · ${deleted} deleted (${blocksUsed} / 15 blocks)`;
+    const footer = integrity.ok
+      ? baseFooter
+      : `${baseFooter} · ${integrity.message}`;
+
+    return {
+      title: "Memory card contents",
+      columns: ["Icon", "Slot", "Status", "Code", "Blocks", "Title"],
+      monoColumns: [1, 3, 4],
+      mutedColumns: [1],
+      rows,
+      footer,
+      integrity,
+    };
+  }
+}
+
+/**
+ * XOR-check every frame in block 0. Each frame's last byte is the XOR of
+ * bytes 0..126; the BIOS enforces this for the header, directory entries,
+ * broken-sector list, and test-write frame. (Save data blocks are written
+ * by games directly and don't maintain a per-frame XOR.)
+ */
+function checkFrameXor(rawData: Uint8Array): {
+  ok: boolean;
+  message?: string;
+} {
+  let corrupt = 0;
+  for (let f = 0; f < PS1_BLOCK0_FRAMES; f++) {
+    const start = f * PS1_FRAME_SIZE;
+    let xor = 0;
+    for (let i = 0; i < PS1_FRAME_SIZE - 1; i++) xor ^= rawData[start + i];
+    if (xor !== rawData[start + PS1_FRAME_SIZE - 1]) corrupt++;
+  }
+  if (corrupt === 0) return { ok: true };
+  const noun = corrupt === 1 ? "frame" : "frames";
+  return {
+    ok: false,
+    message: `${corrupt} corrupt directory ${noun}`,
+  };
+}
+
+/**
+ * Decode a save's icon frames to RGBA. Title-frame layout (psx-spx):
+ * palette at +0x60 (16 × BGR555), icon frames at +0x80 / +0x100 / +0x180
+ * (16×16, 4-bpp, low nibble first). The display flag at +0x02 selects 1-3
+ * frames (0x11/0x12/0x13); animation rates are 16 / 11 PAL frames per icon
+ * frame for 2 / 3 frame icons respectively.
+ */
+function decodeIcon(
+  rawData: Uint8Array,
+  blockOffset: number,
+  alt: string,
+): Extract<DumpSummaryCell, { kind: "icon" }> {
+  const paletteOffset = blockOffset + 0x60;
+
+  const palette = new Uint32Array(16);
+  for (let i = 0; i < 16; i++) {
+    const lo = rawData[paletteOffset + i * 2];
+    const hi = rawData[paletteOffset + i * 2 + 1];
+    const word = lo | (hi << 8);
+    const r5 = word & 0x1f;
+    const g5 = (word >> 5) & 0x1f;
+    const b5 = (word >> 10) & 0x1f;
+    palette[i] =
+      ((r5 << 3) | (r5 >> 2)) |
+      (((g5 << 3) | (g5 >> 2)) << 8) |
+      (((b5 << 3) | (b5 >> 2)) << 16) |
+      (0xff << 24);
+  }
+
+  // Byte 0x02 is the format's sole animation flag (0x11/0x12/0x13 = 1/2/3
+  // frames); MemcardRex and the PS1 BIOS bootmenu both animate strictly
+  // based on this. There's no "valid frames" byte to sanity-check against.
+  const flag = rawData[blockOffset + 2];
+  const claimedFrames = flag >= 0x11 && flag <= 0x13 ? flag - 0x10 : 1;
+
+  // UX hedge over the literal BIOS behaviour: a handful of titles set the
+  // flag to 0x13 but only fill the first icon slot — the other 256 bytes
+  // hold save-data leakage. The real BIOS would flicker through that
+  // garbage; we skip any subsequent frame whose non-zero nibble count is
+  // far below frame 0's.
+  const nibbleCount = (off: number) => {
+    let n = 0;
+    for (let i = 0; i < 128; i++) {
+      const b = rawData[off + i];
+      if (b & 0x0f) n++;
+      if (b & 0xf0) n++;
+    }
+    return n;
+  };
+  const frame0Count = nibbleCount(blockOffset + 0x80);
+  const threshold = frame0Count / 4;
+  let frameCount = 1;
+  for (let f = 1; f < claimedFrames; f++) {
+    if (nibbleCount(blockOffset + 0x80 + f * 128) < threshold) break;
+    frameCount = f + 1;
+  }
+
+  const frames: Uint8ClampedArray<ArrayBuffer>[] = [];
+  for (let f = 0; f < frameCount; f++) {
+    const iconOffset = blockOffset + 0x80 + f * 128;
+    const rgba = new Uint8ClampedArray(new ArrayBuffer(16 * 16 * 4));
+    const view = new DataView(rgba.buffer);
+    for (let y = 0; y < 16; y++) {
+      for (let x = 0; x < 16; x++) {
+        const byte = rawData[iconOffset + y * 8 + (x >> 1)];
+        const idx = (x & 1) === 0 ? byte & 0x0f : (byte >> 4) & 0x0f;
+        view.setUint32((y * 16 + x) * 4, palette[idx], true);
+      }
+    }
+    frames.push(rgba);
+  }
+
+  // Per psx-spx: 2-frame icons cycle every 16 PAL frames, 3-frame every 11.
+  // PAL = 50Hz, so 16 frames = 320ms, 11 frames = 220ms.
+  const frameDurationMs = frameCount === 3 ? 220 : 320;
+
+  return {
+    kind: "icon",
+    frames,
+    width: 16,
+    height: 16,
+    displayScale: ICON_SCALE,
+    frameDurationMs,
+    alt,
+  };
+}
+
+function extractProductCode(filename: string): string {
+  // Filenames are typically "B" + region letter + region prefix + dash +
+  // 5-digit serial + optional trailer. A small number of titles use a
+  // single letter or no separator instead of the dash. Strip the leading
+  // "B" + region letter, capture the 4-letter region prefix and 5-digit
+  // serial; allow any single non-digit separator between them (or none).
+  const m = filename.match(/^B[A-Z]([A-Z]{4})[^0-9]?(\d{5})/);
+  return m ? `${m[1]}-${m[2]}` : "";
+}
+
+function normalizeFullwidth(s: string): string {
+  return s.replace(/[\uFF01-\uFF5E\u3000]/g, (ch) => {
+    const code = ch.codePointAt(0)!;
+    return code === 0x3000 ? " " : String.fromCharCode(code - 0xfee0);
+  });
+}

--- a/src/lib/systems/ps1/ps1-system-handler.ts
+++ b/src/lib/systems/ps1/ps1-system-handler.ts
@@ -229,10 +229,11 @@ function checkFrameXor(rawData: Uint8Array): {
 
 /**
  * Decode a save's icon frames to RGBA. Title-frame layout (psx-spx):
- * palette at +0x60 (16 × BGR555), icon frames at +0x80 / +0x100 / +0x180
- * (16×16, 4-bpp, low nibble first). The display flag at +0x02 selects 1-3
- * frames (0x11/0x12/0x13); animation rates are 16 / 11 PAL frames per icon
- * frame for 2 / 3 frame icons respectively.
+ * palette at +0x60 (16 × 16-bit colour: bits 0-4 R, 5-9 G, 10-14 B, bit 15
+ * = mask), icon frames at +0x80 / +0x100 / +0x180 (16×16, 4-bpp, low nibble
+ * first). The display flag at +0x02 selects 1-3 frames (0x11/0x12/0x13);
+ * animation rates are 16 / 11 PAL frames per icon frame for 2 / 3 frame
+ * icons respectively.
  */
 function decodeIcon(
   rawData: Uint8Array,

--- a/src/lib/transport/usb-transport.ts
+++ b/src/lib/transport/usb-transport.ts
@@ -44,7 +44,12 @@ export class UsbTransport implements Transport {
 
   /** Prompt the user to select a USB device. */
   async connect(_options?: TransportConnectOptions): Promise<DeviceIdentity> {
-    const device = await navigator.usb!.requestDevice({
+    if (!navigator.usb) {
+      throw new Error(
+        "WebUSB is not available. Use Chrome 89+ over HTTPS or localhost.",
+      );
+    }
+    const device = await navigator.usb.requestDevice({
       filters: this.filters,
     });
     return this.openDevice(device);
@@ -107,21 +112,29 @@ export class UsbTransport implements Transport {
 
     const ep = options?.endpointIn ?? this.endpointIn;
     const timeout = options?.timeout ?? 5000;
-    const result = await Promise.race([
-      this.device.transferIn(ep, length),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("USB receive timeout")), timeout),
-      ),
-    ]);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const result = await Promise.race([
+        this.device.transferIn(ep, length),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error("USB receive timeout")),
+            timeout,
+          );
+        }),
+      ]);
 
-    if (result.data) {
-      return new Uint8Array(
-        result.data.buffer,
-        result.data.byteOffset,
-        result.data.byteLength,
-      );
+      if (result.data) {
+        return new Uint8Array(
+          result.data.buffer,
+          result.data.byteOffset,
+          result.data.byteLength,
+        );
+      }
+      return new Uint8Array(0);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
     }
-    return new Uint8Array(0);
   }
 
   on<K extends keyof TransportEvents>(
@@ -133,6 +146,7 @@ export class UsbTransport implements Transport {
 
   private onDisconnect = (event: USBConnectionEvent) => {
     if (event.device === this.device) {
+      navigator.usb!.removeEventListener("disconnect", this.onDisconnect);
       this.device = null;
       this.events.onDisconnect?.();
     }

--- a/src/lib/transport/usb-transport.ts
+++ b/src/lib/transport/usb-transport.ts
@@ -1,0 +1,140 @@
+/**
+ * WebUSB transport for vendor-specific USB devices.
+ *
+ * Wraps the WebUSB API for devices that expose a vendor-specific interface
+ * with bulk endpoints. Supports configurable endpoint numbers and
+ * per-transfer endpoint overrides for devices with multiple IN endpoints.
+ */
+
+import type {
+  Transport,
+  TransportEvents,
+  TransportConnectOptions,
+  TransferOptions,
+  DeviceIdentity,
+} from "@/lib/types";
+
+interface UsbDeviceFilter {
+  vendorId: number;
+  productId?: number;
+}
+
+export class UsbTransport implements Transport {
+  readonly type = "webusb" as const;
+
+  private device: USBDevice | null = null;
+  private events: Partial<TransportEvents> = {};
+  private endpointIn = 1;
+  private endpointOut = 2;
+  private readonly filters: UsbDeviceFilter[];
+
+  constructor(
+    filters: UsbDeviceFilter[],
+    endpointIn?: number,
+    endpointOut?: number,
+  ) {
+    this.filters = filters;
+    if (endpointIn !== undefined) this.endpointIn = endpointIn;
+    if (endpointOut !== undefined) this.endpointOut = endpointOut;
+  }
+
+  get connected(): boolean {
+    return this.device?.opened ?? false;
+  }
+
+  /** Prompt the user to select a USB device. */
+  async connect(_options?: TransportConnectOptions): Promise<DeviceIdentity> {
+    const device = await navigator.usb!.requestDevice({
+      filters: this.filters,
+    });
+    return this.openDevice(device);
+  }
+
+  /** Reconnect to a previously authorized device (no user gesture needed). */
+  async connectWithDevice(device: USBDevice): Promise<DeviceIdentity> {
+    return this.openDevice(device);
+  }
+
+  private async openDevice(device: USBDevice): Promise<DeviceIdentity> {
+    await device.open();
+    await device.selectConfiguration(1);
+    await device.claimInterface(0);
+
+    this.device = device;
+
+    navigator.usb!.addEventListener("disconnect", this.onDisconnect);
+
+    return {
+      vendorId: device.vendorId,
+      productId: device.productId,
+      name: device.productName ?? "USB Device",
+      serial: device.serialNumber,
+      transport: "webusb",
+      raw: device,
+    };
+  }
+
+  async disconnect(): Promise<void> {
+    navigator.usb!.removeEventListener("disconnect", this.onDisconnect);
+    if (this.device?.opened) {
+      try {
+        await this.device.releaseInterface(0);
+      } catch {
+        // Best-effort
+      }
+      try {
+        await this.device.close();
+      } catch {
+        // Best-effort
+      }
+    }
+    this.device = null;
+  }
+
+  async send(data: Uint8Array, _options?: TransferOptions): Promise<void> {
+    if (!this.device) throw new Error("USB device not connected");
+    await this.device.transferOut(
+      this.endpointOut,
+      data as unknown as BufferSource,
+    );
+  }
+
+  async receive(
+    length: number,
+    options?: TransferOptions & { endpointIn?: number },
+  ): Promise<Uint8Array> {
+    if (!this.device) throw new Error("USB device not connected");
+
+    const ep = options?.endpointIn ?? this.endpointIn;
+    const timeout = options?.timeout ?? 5000;
+    const result = await Promise.race([
+      this.device.transferIn(ep, length),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("USB receive timeout")), timeout),
+      ),
+    ]);
+
+    if (result.data) {
+      return new Uint8Array(
+        result.data.buffer,
+        result.data.byteOffset,
+        result.data.byteLength,
+      );
+    }
+    return new Uint8Array(0);
+  }
+
+  on<K extends keyof TransportEvents>(
+    event: K,
+    handler: TransportEvents[K],
+  ): void {
+    this.events[event] = handler;
+  }
+
+  private onDisconnect = (event: USBConnectionEvent) => {
+    if (event.device === this.device) {
+      this.device = null;
+      this.events.onDisconnect?.();
+    }
+  };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,12 @@ export interface DeviceDriverEvents {
 export interface DetectSystemResult {
   systemId: SystemId;
   cartInfo: CartridgeInfo;
+  /**
+   * Set when a cartridge is detected but the driver cannot dump it
+   * (e.g. media that requires non-redistributable encryption keys).
+   * The wizard renders `reason` as an explanation instead of the dump UI.
+   */
+  unsupported?: { reason: string };
 }
 
 export interface DeviceDriver {
@@ -104,6 +110,20 @@ export interface DeviceInfo {
   hardwareRevision?: string;
   deviceName: string;
   capabilities: DeviceCapability[];
+  /**
+   * If true, the device can re-detect a freshly-inserted cartridge without
+   * a full USB disconnect/reconnect cycle. Defaults to false (conservative).
+   * Drivers opt in when they know the hardware supports it safely —
+   * e.g. natively hot-pluggable memory-card adapters, or GBxCart PCBs
+   * with programmatic cart-power control.
+   */
+  hotSwap?: boolean;
+  /**
+   * Optional one-line note about cartridge compatibility — surfaced under
+   * the "Insert a cartridge…" prompt to set user expectations before they
+   * try and fail.
+   */
+  compatibilityNote?: string;
 }
 
 export interface ReadConfig {
@@ -154,6 +174,45 @@ export interface SystemHandler {
     hashes: VerificationHashes,
     db: VerificationDB | null,
   ): VerificationResult;
+  /** Optional: extract a human-readable summary of a completed dump's contents. */
+  summarizeDump?(rawData: Uint8Array): DumpSummary | null;
+}
+
+/** A single cell in a {@link DumpSummary} row — text or a small bitmap (e.g. PS1 save icon). */
+export type DumpSummaryCell =
+  | string
+  | {
+      kind: "icon";
+      /** One or more RGBA frames at native resolution. Multiple frames animate. */
+      frames: Uint8ClampedArray<ArrayBuffer>[];
+      width: number;
+      height: number;
+      /** CSS upscale factor; the canvas itself is rendered at native size with `image-rendering: pixelated`. */
+      displayScale: number;
+      /** Per-frame duration in milliseconds when animating. */
+      frameDurationMs?: number;
+      alt?: string;
+    };
+
+export interface DumpSummary {
+  /** Heading shown above the table. */
+  title: string;
+  /** Column headers, in order. */
+  columns: string[];
+  /** Column indices to render in a monospace font (e.g., codes, IDs). */
+  monoColumns?: number[];
+  /** Column indices to render with muted/secondary text color (e.g., row IDs). */
+  mutedColumns?: number[];
+  /** Rows of cells; each row's length should equal `columns.length`. */
+  rows: DumpSummaryCell[][];
+  /** Optional summary line below the table (e.g., counts). */
+  footer?: string;
+  /**
+   * Optional integrity check (e.g. per-frame checksum). When `ok` is false,
+   * the dump is flagged as unverified in the UI even for save-only systems
+   * with no verification database.
+   */
+  integrity?: { ok: boolean; message?: string };
 }
 
 // ─── Config Fields ──────────────────────────────────────────────────────────
@@ -201,6 +260,19 @@ export interface OutputFile {
   filename: string;
   mimeType: string;
   meta?: Record<string, string>;
+  /**
+   * Optional list of equivalent file extensions to offer in the save dialog.
+   * Useful when the same byte content is conventionally given different
+   * names by different tools (e.g. PS1 memory cards: .mcr / .mcd).
+   * Defaults to the extension parsed from `filename`.
+   */
+  acceptExtensions?: string[];
+  /**
+   * Optional override for the action button label shown in CompleteStep
+   * (e.g. "Save Memory Card"). When unset, the UI picks a sensible default
+   * based on whether the dump is save-only or a ROM.
+   */
+  actionLabel?: string;
 }
 
 export interface VerificationHashes {


### PR DESCRIPTION
## Summary
- WebUSB driver for the PS3 Memory Card Adaptor (054c:02ea); reads PS1 memory cards as 128 KiB raw `.mcr` / `.mcd` images. PS2 cards are detected but flagged unsupported (require non-redistributable encryption keys).
- PS1 system handler decodes directory entries, animated 16×16 icons (BGR555 palette, 1–3 frames at psx-spx PAL timing), and verifies block 0's per-frame XOR integrity. Renders a contents table in the wizard.
- Pipeline support for save-only and hot-swap devices: capability-driven readSave skipping, opt-in `hotSwap` flag, typed `unsupported` detection result, `DumpSummary` for system-specific tables, `OutputFile.acceptExtensions` / `actionLabel`.

Driver protocol — short/long-form framing, opcodes, and PS1 frame read/response layout — ported from [paolo-caroni/ps3mca-ps1](https://github.com/paolo-caroni/ps3mca-ps1) (GPL-3.0); full attribution in `THIRD-PARTY-LICENSES`. PS1 memory card format follows the psx-spx specification.

## Test plan
- [x] Adapter authorized via WebUSB; auto-reconnects on subsequent visits
- [x] Empty slot reports "No cartridge detected"
- [x] First-party PS1 card detected on the first attempt; dump produces a valid 128 KiB image
- [x] Clone card detected after a few retries (or eventually times out gracefully)
- [x] PS2 card flagged unsupported; UI renders the explanation rather than the dump button
- [x] DumpSummary table renders with directory rows + animated icons
- [x] Card with corrupted block 0 XOR shows Unverified status; download still offered
- [x] Save dialog offers both `.mcr` and `.mcd` extensions
- [x] Scan button re-detects after a physical card swap (no USB re-plug)
- [x] Disconnect releases the device cleanly
- [ ] Cross-platform check: macOS Chrome, Windows Chrome