### PR TITLE
Add per-device info dialog and Linux udev rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,24 @@ keeper of knowledge. Seemed fitting for a preservation tool.
 | Device | Connection | Systems |
 | --- | --- | --- |
 | [GBxCart RW](https://www.gbxcart.com/) v1.4 Pro | Web Serial | Game Boy, Game Boy Color, Game Boy Advance |
-| [PowerSaves for Amiibo](https://www.yourpowersaves.com/) | WebHID | Amiibo (NTAG215) |
+| PowerSaves for Amiibo | WebHID | Amiibo (NTAG215) |
 
 This is still early. More hardware and more systems are in the works.
+
+## Linux setup
+
+Linux blocks browser access to USB devices by default — they won't appear in
+Chrome's device picker until a udev rule grants the desktop user access. Each
+device's info button on the connect screen shows the rule it needs, or you can
+drop in [`linux/99-nabu.rules`](linux/99-nabu.rules) which covers every
+supported device:
+
+```sh
+sudo cp linux/99-nabu.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules && sudo udevadm trigger
+```
+
+Then unplug and replug the device. macOS and Windows don't need this.
 
 ## What It Does
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ keeper of knowledge. Seemed fitting for a preservation tool.
 | --- | --- | --- |
 | [GBxCart RW](https://www.gbxcart.com/) v1.4 Pro | Web Serial | Game Boy, Game Boy Color, Game Boy Advance |
 | PowerSaves for Amiibo | WebHID | Amiibo (NTAG215) |
+| Disney Infinity Base | WebHID | Disney Infinity Figures |
+| PS3 Memory Card Adaptor | WebUSB | PS1 Memory Card |
 
 This is still early. More hardware and more systems are in the works.
 

--- a/linux/99-nabu.rules
+++ b/linux/99-nabu.rules
@@ -1,0 +1,17 @@
+# nabu — udev rules for cartridge dumper devices
+# Install:
+#   sudo cp 99-nabu.rules /etc/udev/rules.d/
+#   sudo udevadm control --reload-rules && sudo udevadm trigger
+#   (then unplug and replug the device)
+#
+# TAG+="uaccess" grants the active desktop user an ACL via systemd-logind.
+# MODE="0660" keeps everyone else out as a floor.
+
+# GBXCART — GBxCart RW
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", TAG+="uaccess", MODE="0660"
+# POWERSAVE — PowerSaves for Amiibo
+KERNEL=="hidraw*", ATTRS{idVendor}=="1c1a", ATTRS{idProduct}=="03d9", TAG+="uaccess", MODE="0660"
+# DISNEY_INFINITY — Disney Infinity Base
+KERNEL=="hidraw*", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="0129", TAG+="uaccess", MODE="0660"
+# PS3_MCA — PS3 Memory Card Adaptor
+SUBSYSTEM=="usb", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="02ea", TAG+="uaccess", MODE="0660"

--- a/src/components/wizard/connect-step.tsx
+++ b/src/components/wizard/connect-step.tsx
@@ -2,8 +2,19 @@ import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { DEVICES } from "@/lib/core/devices";
+import { DEVICES, type DeviceDef } from "@/lib/core/devices";
 import { DeviceInfoDialog } from "@/components/wizard/device-info-dialog";
+
+const MOCK_DEVICE: DeviceDef = {
+  id: "MOCK",
+  name: "Mock Device",
+  vendorId: null,
+  productId: null,
+  transport: "webusb",
+  systems: [{ id: "mock", name: "Mock System" }],
+  description:
+    "Simulated device for browser testing. Available via the ?mock query parameter; useful for UI development without hardware attached.",
+};
 
 interface ConnectStepProps {
   onConnect: (deviceId: string) => void;
@@ -111,9 +122,12 @@ export function ConnectStep({
                     Simulated device for testing
                   </div>
                 </div>
-                <Button size="sm" onClick={onMockConnect}>
-                  Connect
-                </Button>
+                <div className="flex items-center gap-1">
+                  <DeviceInfoDialog device={MOCK_DEVICE} />
+                  <Button size="sm" onClick={onMockConnect}>
+                    Connect
+                  </Button>
+                </div>
               </div>
             )}
           </div>

--- a/src/components/wizard/connect-step.tsx
+++ b/src/components/wizard/connect-step.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { DEVICES } from "@/lib/core/devices";
+import { DeviceInfoDialog } from "@/components/wizard/device-info-dialog";
 
 interface ConnectStepProps {
   onConnect: (deviceId: string) => void;
@@ -87,13 +88,16 @@ export function ConnectStep({
                       {dev.systems.map((s) => s.name).join(", ")}
                     </div>
                   </div>
-                  <Button
-                    size="sm"
-                    onClick={() => onConnect(dev.id)}
-                    disabled={!transportAvailable[dev.transport]}
-                  >
-                    Connect
-                  </Button>
+                  <div className="flex items-center gap-1">
+                    <DeviceInfoDialog device={dev} />
+                    <Button
+                      size="sm"
+                      onClick={() => onConnect(dev.id)}
+                      disabled={!transportAvailable[dev.transport]}
+                    >
+                      Connect
+                    </Button>
+                  </div>
                 </div>
               );
             })}

--- a/src/components/wizard/device-info-dialog.tsx
+++ b/src/components/wizard/device-info-dialog.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import { Check, Copy, ExternalLink, Info } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { DeviceDef } from "@/lib/core/devices";
+import { buildUdevRule, formatUsbId, isLinuxLike } from "@/lib/core/udev";
+
+const TRANSPORT_LABEL: Record<DeviceDef["transport"], string> = {
+  serial: "Web Serial",
+  webhid: "WebHID",
+  webusb: "WebUSB",
+  nfc: "Web NFC",
+  http: "HTTP",
+};
+
+const RULES_FILE_URL =
+  "https://github.com/pathawks/nabu.tools/blob/main/linux/99-nabu.rules";
+
+const RELOAD_COMMANDS = `sudo udevadm control --reload-rules && sudo udevadm trigger`;
+
+interface DeviceInfoDialogProps {
+  device: DeviceDef;
+}
+
+export function DeviceInfoDialog({ device }: DeviceInfoDialogProps) {
+  const usbId = formatUsbId(device);
+  const rule = buildUdevRule(device);
+
+  return (
+    <Dialog>
+      <DialogTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`About ${device.name}`}
+          />
+        }
+      >
+        <Info />
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{device.name}</DialogTitle>
+          {device.models && device.models.length > 0 && (
+            <DialogDescription className="font-mono text-xs">
+              {device.models.join(" · ")}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        <div className="flex flex-col gap-3 text-sm">
+          <p className="text-card-foreground">{device.description}</p>
+
+          <DetailRow label="Systems">
+            {device.systems.map((s) => s.name).join(", ")}
+          </DetailRow>
+
+          {usbId && (
+            <DetailRow label="USB ID">
+              <span className="font-mono">{usbId}</span>
+              <span className="ml-2 text-muted-foreground">
+                ({TRANSPORT_LABEL[device.transport]})
+              </span>
+            </DetailRow>
+          )}
+
+          {device.homepage && (
+            <DetailRow label="Homepage">
+              <a
+                href={device.homepage}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1 underline underline-offset-3 hover:text-foreground"
+              >
+                {new URL(device.homepage).host}
+                <ExternalLink className="size-3" />
+              </a>
+            </DetailRow>
+          )}
+
+          {rule && (
+            <details
+              className="mt-2 rounded-md border border-border bg-muted/30 px-3 py-2"
+              open={isLinuxLike()}
+            >
+              <summary className="cursor-pointer select-none text-[10px] font-medium uppercase tracking-widest text-muted-foreground">
+                Linux setup
+              </summary>
+              <div className="mt-3 flex flex-col gap-3 text-xs">
+                <p className="text-card-foreground">
+                  Linux blocks browser access to USB devices by default. Add a
+                  udev rule to grant your desktop user access:
+                </p>
+                <CodeBlock
+                  label="Append to /etc/udev/rules.d/99-nabu.rules"
+                  value={rule}
+                />
+                <CodeBlock label="Reload and replug" value={RELOAD_COMMANDS} />
+                <p className="text-muted-foreground">
+                  Or download{" "}
+                  <a
+                    href={RULES_FILE_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 underline underline-offset-3 hover:text-foreground"
+                  >
+                    99-nabu.rules
+                    <ExternalLink className="size-3" />
+                  </a>{" "}
+                  with rules for every supported device.
+                </p>
+              </div>
+            </details>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function DetailRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-[10px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </span>
+      <span className="text-card-foreground">{children}</span>
+    </div>
+  );
+}
+
+function CodeBlock({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Best-effort; clipboard API unavailable in some contexts.
+    }
+  };
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] uppercase tracking-widest text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex items-start gap-2 rounded-md border border-border bg-background p-2">
+        <pre className="flex-1 overflow-x-auto whitespace-pre-wrap break-all font-mono text-[11px] leading-snug">
+          {value}
+        </pre>
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          onClick={onCopy}
+          aria-label={copied ? "Copied" : "Copy to clipboard"}
+        >
+          {copied ? <Check /> : <Copy />}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/core/devices.ts
+++ b/src/lib/core/devices.ts
@@ -40,9 +40,7 @@ export const DEVICES: Record<string, DeviceDef> = {
     productId: 0x03d9,
     transport: "webhid",
     systems: [{ id: "amiibo", name: "Amiibo (NTAG215)" }],
-    description:
-      "Datel NFC portal for reading and writing Amiibo (NTAG215) tags. " +
-      "Also recognizes MaxLander and NaMiio clones.",
+    description: "Datel NFC portal for reading Amiibo (NTAG215) tags.",
   },
   DISNEY_INFINITY: {
     id: "DISNEY_INFINITY",

--- a/src/lib/core/devices.ts
+++ b/src/lib/core/devices.ts
@@ -7,13 +7,18 @@ export interface DeviceDef {
   productId: number | null;
   transport: TransportType;
   systems: { id: string; name: string }[];
-  notes: string;
+  /** Known model identifiers, e.g. ["CECHZM1", "SCPH-98042"]. */
+  models?: string[];
+  /** Official homepage / product page, when one still exists. */
+  homepage?: string;
+  /** User-facing prose: 1–2 sentences. What is it, what does it do. */
+  description: string;
 }
 
 export const DEVICES: Record<string, DeviceDef> = {
   GBXCART: {
     id: "GBXCART",
-    name: "GBxCart RW v1.4 Pro",
+    name: "GBxCart RW",
     vendorId: 0x1a86,
     productId: 0x7523,
     transport: "serial",
@@ -22,9 +27,11 @@ export const DEVICES: Record<string, DeviceDef> = {
       { id: "gbc", name: "Game Boy Color" },
       { id: "gba", name: "Game Boy Advance" },
     ],
-    notes:
-      "Open-source by insideGadgets. Uses CH340 serial. " +
-      "Protocol: github.com/lesserkuma/FlashGBX",
+    models: ["v1.4 Pro"],
+    homepage: "https://www.gbxcart.com/",
+    description:
+      "Open-source Game Boy / Game Boy Color / Game Boy Advance cartridge " +
+      "reader by insideGadgets. Uses a CH340 USB-serial chip.",
   },
   POWERSAVE: {
     id: "POWERSAVE",
@@ -33,9 +40,9 @@ export const DEVICES: Record<string, DeviceDef> = {
     productId: 0x03d9,
     transport: "webhid",
     systems: [{ id: "amiibo", name: "Amiibo (NTAG215)" }],
-    notes:
-      "Datel NFC portal. Also supports MaxLander/NaMiio clones. " +
-      "Protocol: github.com/malc0mn/amiigo",
+    description:
+      "Datel NFC portal for reading and writing Amiibo (NTAG215) tags. " +
+      "Also recognizes MaxLander and NaMiio clones.",
   },
   DISNEY_INFINITY: {
     id: "DISNEY_INFINITY",
@@ -44,9 +51,10 @@ export const DEVICES: Record<string, DeviceDef> = {
     productId: 0x0129,
     transport: "webhid",
     systems: [{ id: "disney-infinity", name: "Disney Infinity Figures" }],
-    notes:
-      "Logic3/PDP Wii/Wii U/PS3/PS4/PC base (INF-8032386). " +
-      "Protocol reference: dolphin-emu (GPL-2.0-or-later).",
+    models: ["INF-8032386"],
+    description:
+      "Logic3 / PDP Disney Infinity Base. Reads Disney Infinity figures " +
+      "(Wii / Wii U / PS3 / PS4 / PC variant).",
   },
   // The adapter performs an SIO-level identification challenge before
   // reporting a card type. First-party PS1 cards reply with the expected
@@ -61,10 +69,10 @@ export const DEVICES: Record<string, DeviceDef> = {
     productId: 0x02ea,
     transport: "webusb",
     systems: [{ id: "ps1", name: "PS1 Memory Card" }],
-    notes:
-      "PS1 cards only; PS2 reads require encryption keys that cannot be " +
-      "redistributed. First-party cards detect instantly; clone cards " +
-      "may need a few retries. " +
-      "Protocol reference: github.com/paolo-caroni/ps3mca-ps1 (GPL-3.0).",
+    models: ["CECHZM1", "SCPH-98042"],
+    description:
+      "Sony's PlayStation 3 adapter for PlayStation 1 and 2 memory cards. " +
+      "Only PS1 cards are dumpable in the browser (PS2 reads require " +
+      "MagicGate authentication keys that cannot be redistributed).",
   },
 };

--- a/src/lib/core/udev.ts
+++ b/src/lib/core/udev.ts
@@ -34,10 +34,10 @@ export function formatUsbId(dev: DeviceDef): string {
   return `${v}:${p}`;
 }
 
-/** Detect a Linux-like platform (covers ChromeOS via the legacy fallback). */
+/** True on Linux, including ChromeOS (whose userAgentData reports "Chrome OS" but whose navigator.platform contains "Linux"). */
 export function isLinuxLike(): boolean {
   const ua = (
     navigator as Navigator & { userAgentData?: { platform: string } }
   ).userAgentData?.platform;
-  return /linux/i.test(ua ?? navigator.platform ?? "");
+  return /linux/i.test(`${ua ?? ""} ${navigator.platform ?? ""}`);
 }

--- a/src/lib/core/udev.ts
+++ b/src/lib/core/udev.ts
@@ -1,0 +1,43 @@
+import type { DeviceDef } from "@/lib/core/devices";
+
+/**
+ * Build a single-line udev rule for a device. The subsystem match depends on
+ * how Chrome accesses the device on Linux:
+ *   - WebUSB    → SUBSYSTEM=="usb"        (raw USB via /dev/bus/usb/...)
+ *   - WebHID    → KERNEL=="hidraw*"       (hidraw subsystem; ATTRS{} walks
+ *                                          up the parent chain for VID/PID)
+ *   - Web Serial → SUBSYSTEM=="tty"       (covers ttyUSB* and ttyACM*)
+ *
+ * `TAG+="uaccess"` asks systemd-logind to grant an ACL to the active console
+ * user, which is what we actually want — the desktop user running Chrome.
+ * The `+=` operator is cooperative with anything else udev might tag.
+ * `MODE="0660"` keeps non-logged-in users out as a floor.
+ */
+export function buildUdevRule(dev: DeviceDef): string {
+  if (dev.vendorId == null || dev.productId == null) return "";
+  const v = dev.vendorId.toString(16).padStart(4, "0");
+  const p = dev.productId.toString(16).padStart(4, "0");
+  const subsystem =
+    dev.transport === "webhid"
+      ? 'KERNEL=="hidraw*"'
+      : dev.transport === "serial"
+        ? 'SUBSYSTEM=="tty"'
+        : 'SUBSYSTEM=="usb"';
+  return `${subsystem}, ATTRS{idVendor}=="${v}", ATTRS{idProduct}=="${p}", TAG+="uaccess", MODE="0660"`;
+}
+
+/** Format `vid:pid` as the conventional 4+4 lowercase hex pair. */
+export function formatUsbId(dev: DeviceDef): string {
+  if (dev.vendorId == null || dev.productId == null) return "";
+  const v = dev.vendorId.toString(16).padStart(4, "0");
+  const p = dev.productId.toString(16).padStart(4, "0");
+  return `${v}:${p}`;
+}
+
+/** Detect a Linux-like platform (covers ChromeOS via the legacy fallback). */
+export function isLinuxLike(): boolean {
+  const ua = (
+    navigator as Navigator & { userAgentData?: { platform: string } }
+  ).userAgentData?.platform;
+  return /linux/i.test(ua ?? navigator.platform ?? "");
+}

--- a/src/lib/drivers/powersave/powersave-commands.ts
+++ b/src/lib/drivers/powersave/powersave-commands.ts
@@ -84,5 +84,4 @@ export const COMMAND_TIMEOUT_MS = 2000;
 
 export const DEVICE_FILTERS: HIDDeviceFilter[] = [
   { vendorId: 0x1c1a, productId: 0x03d9 }, // Datel PowerSaves for Amiibo
-  { vendorId: 0x5c60, productId: 0xdead }, // MaxLander / NaMiio
 ];


### PR DESCRIPTION
## Summary
- New Info button on each Connect-screen row opens a dialog showing the device's name, model identifiers, description, supported systems, USB VID:PID, transport, and homepage link.
- Dialog includes a Linux setup section (auto-expanded on Linux via `navigator.userAgentData.platform`) with the udev rule for that device and copy buttons for the rule line plus the reload commands.
- Bundle `linux/99-nabu.rules` covering every supported device for one-shot install. Rules use `TAG+="uaccess"` + `MODE="0660"` so systemd-logind grants ACL access to the active desktop user — no group-membership fiddling.
- New helper module `src/lib/core/udev.ts` with `buildUdevRule()` (transport-aware: `tty` / `hidraw*` / `usb`), `formatUsbId()`, and `isLinuxLike()`.
- Drop the unused `DeviceDef.notes` field; replace with structured `models?`, `homepage?`, and `description`. Existing protocol references that were buried in `notes` already exist as code comments next to each driver.
- README gains a Linux setup section between Supported Hardware and What It Does.

## Test plan
- [x] Info button visible on every Connect-screen row
- [x] Dialog renders name, models, description, systems, VID:PID, transport, and homepage link
- [x] Homepage link omitted gracefully for devices without one
- [x] Linux setup section auto-expanded on Linux, collapsed on other platforms
- [x] Copy buttons copy the udev rule line and reload commands to the clipboard
- [x] Per-device udev rule line has the right `SUBSYSTEM` for each transport (`tty` for serial, `hidraw` for WebHID, `usb` for WebUSB)
- [x] `linux/99-nabu.rules` covers every device in `DEVICES` and reloads cleanly with `udevadm control --reload-rules && udevadm trigger`
- [x] After installing the bundled rules, each device opens in the wizard without `sudo` / group membership