### PR TITLE
Centralize useConnection driver dispatch in a registry

### DIFF
--- a/src/hooks/use-connection.ts
+++ b/src/hooks/use-connection.ts
@@ -1,16 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { MockDriver } from "@/lib/core/mock-driver";
 import { DEVICES, type DeviceDef } from "@/lib/core/devices";
-import { SerialTransport } from "@/lib/transport/serial-transport";
-import { HidTransport } from "@/lib/transport/hid-transport";
-import { UsbTransport } from "@/lib/transport/usb-transport";
-import { GBxCartDriver } from "@/lib/drivers/gbxcart/gbxcart-driver";
-import { PowerSaveDriver } from "@/lib/drivers/powersave/powersave-driver";
-import { DEVICE_FILTERS as POWERSAVE_FILTERS } from "@/lib/drivers/powersave/powersave-commands";
-import { InfinityDriver } from "@/lib/drivers/infinity/infinity-driver";
-import { DEVICE_FILTERS as INFINITY_FILTERS } from "@/lib/drivers/infinity/infinity-commands";
-import { Ps3McaDriver } from "@/lib/drivers/ps3-mca/ps3-mca-driver";
-import { DEVICE_FILTERS as PS3_MCA_FILTERS } from "@/lib/drivers/ps3-mca/ps3-mca-commands";
+import { CONNECTION_ENTRIES } from "@/lib/core/connection-registry";
 import type { DeviceDriver, DeviceInfo, Transport } from "@/lib/types";
 
 // ─── Device probing ──────────────────────────────────────────────────────
@@ -109,6 +100,12 @@ async function findAuthorized(
       return null;
   }
 }
+
+const TRANSPORT_LABEL: Record<string, string> = {
+  serial: "serial port",
+  webhid: "HID device",
+  webusb: "USB device",
+};
 
 type LogFn = (msg: string, level?: "info" | "warn" | "error") => void;
 
@@ -216,6 +213,66 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
     [onReady],
   );
 
+  /**
+   * Connect to a registered device.
+   *
+   * Three race-guard checkpoints (pre-I/O, post-findAuthorized, post-open)
+   * make it safe to call concurrently from auto-reconnect probes and the
+   * manual handleConnect path: whichever call publishes a driver first wins,
+   * and any later caller observes driverRef.current and bails — closing its
+   * transport on the rare 3-way tie so we don't leak a port.
+   *
+   * `auto: true` requires a previously-authorized device and never prompts
+   * the user (page-load reconnect has no user gesture to spend).
+   *
+   * Returns true if this call published a driver, false otherwise.
+   */
+  const connectDevice = useCallback(
+    async (deviceId: string, opts: { auto: boolean }): Promise<boolean> => {
+      if (driverRef.current) return false;
+
+      const entry = CONNECTION_ENTRIES[deviceId];
+      const dev = DEVICES[deviceId];
+      if (!entry || !dev) return false;
+
+      const authorized = await findAuthorized(dev);
+      if (opts.auto && !authorized) return false;
+      if (driverRef.current) return false;
+
+      const transport = entry.createTransport();
+      const transportLabel = TRANSPORT_LABEL[dev.transport] ?? dev.transport;
+      log(
+        opts.auto || authorized
+          ? "Connecting..."
+          : `Requesting ${transportLabel}...`,
+      );
+      const identity = await entry.connect(transport, { authorized });
+
+      if (driverRef.current) {
+        await transport.disconnect().catch(() => {});
+        return false;
+      }
+
+      log(`Opened ${transportLabel}: ${identity.name}`);
+
+      transport.on("onDisconnect", () => {
+        log("Device disconnected", "warn");
+        handleDisconnect();
+      });
+
+      const drv = entry.createDriver(transport);
+      drv.on("onLog", (msg, level) => log(msg, level));
+
+      log(entry.preInitLog ?? "Initializing device...");
+      const info = await drv.initialize();
+      log(entry.postInitLog?.(info) ?? `Connected: ${info.deviceName}`);
+
+      finishConnect(drv, info, deviceId);
+      return true;
+    },
+    [log, handleDisconnect, finishConnect],
+  );
+
   // ─── Auto-reconnect on page load ──────────────────────────────────────
 
   const autoConnectAttempted = useRef(false);
@@ -223,131 +280,15 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
     if (autoConnectAttempted.current) return;
     autoConnectAttempted.current = true;
 
-    // Try serial (GBxCart)
-    navigator.serial?.getPorts().then(async (ports) => {
-      if (ports.length !== 1) return;
-
-      log("Reconnecting to serial port...");
-      try {
-        const transport = new SerialTransport();
-        const identity = await transport.connectWithPort(ports[0], {
-          baudRate: 1_000_000,
-        });
-        log(
-          `Serial port opened: ${identity.vendorId?.toString(16)}:${identity.productId?.toString(16)}`,
-        );
-
-        transport.on("onDisconnect", () => {
-          log("Device disconnected", "warn");
-          handleDisconnect();
-        });
-
-        const gbxDriver = new GBxCartDriver(transport);
-        gbxDriver.on("onLog", (msg, level) => log(msg, level));
-
-        log("Initializing device...");
-        const info = await gbxDriver.initialize();
-        log(
-          `Connected: ${info.deviceName} (fw: ${info.firmwareVersion}, ${info.hardwareRevision})`,
-        );
-        finishConnect(gbxDriver, info, "GBXCART");
-      } catch (e) {
-        log(`Auto-reconnect failed: ${(e as Error).message}`, "warn");
-      }
-    });
-
-    // Try HID (PowerSaves Portal or Disney Infinity Base)
-    navigator.hid?.getDevices().then(async (devices) => {
-      const psDevice = devices.find((d) =>
-        POWERSAVE_FILTERS.some(
-          (f) => f.vendorId === d.vendorId && f.productId === d.productId,
-        ),
-      );
-      if (psDevice) {
-        log("Reconnecting to HID device...");
+    (async () => {
+      for (const id of Object.keys(CONNECTION_ENTRIES)) {
         try {
-          const transport = new HidTransport(POWERSAVE_FILTERS);
-          const identity = await transport.connectWithDevice(psDevice);
-          log(`HID device opened: ${identity.name}`);
-
-          transport.on("onDisconnect", () => {
-            log("Device disconnected", "warn");
-            handleDisconnect();
-          });
-
-          const psDriver = new PowerSaveDriver(transport);
-          psDriver.on("onLog", (msg, level) => log(msg, level));
-
-          const info = await psDriver.initialize();
-          log(`Connected: ${info.deviceName}`);
-          finishConnect(psDriver, info, "POWERSAVE");
-        } catch (e) {
-          log(`Auto-reconnect failed: ${(e as Error).message}`, "warn");
-        }
-        return;
-      }
-
-      const infDevice = devices.find((d) =>
-        INFINITY_FILTERS.some(
-          (f) => f.vendorId === d.vendorId && f.productId === d.productId,
-        ),
-      );
-      if (infDevice) {
-        log("Reconnecting to HID device...");
-        try {
-          const transport = new HidTransport(INFINITY_FILTERS);
-          const identity = await transport.connectWithDevice(infDevice);
-          log(`HID device opened: ${identity.name}`);
-
-          transport.on("onDisconnect", () => {
-            log("Device disconnected", "warn");
-            handleDisconnect();
-          });
-
-          const infDriver = new InfinityDriver(transport);
-          infDriver.on("onLog", (msg, level) => log(msg, level));
-
-          const info = await infDriver.initialize();
-          log(`Connected: ${info.deviceName} (fw: ${info.firmwareVersion})`);
-          finishConnect(infDriver, info, "DISNEY_INFINITY");
+          if (await connectDevice(id, { auto: true })) return;
         } catch (e) {
           log(`Auto-reconnect failed: ${(e as Error).message}`, "warn");
         }
       }
-    });
-
-    // Try WebUSB (PS3 Memory Card Adaptor)
-    navigator.usb?.getDevices().then(async (devices) => {
-      const ps3Device = devices.find((d) =>
-        PS3_MCA_FILTERS.some(
-          (f) => f.vendorId === d.vendorId && f.productId === d.productId,
-        ),
-      );
-      if (!ps3Device) return;
-      // Another auto-reconnect probe (serial/HID) may have already won.
-      if (driverRef.current) return;
-
-      log("Reconnecting to USB device...");
-      try {
-        const transport = new UsbTransport(PS3_MCA_FILTERS);
-        const identity = await transport.connectWithDevice(ps3Device);
-        log(`USB device opened: ${identity.name}`);
-
-        transport.on("onDisconnect", () => {
-          log("Device disconnected", "warn");
-          handleDisconnect();
-        });
-
-        const ps3Driver = new Ps3McaDriver(transport);
-        ps3Driver.on("onLog", (msg, level) => log(msg, level));
-
-        const info = await ps3Driver.initialize();
-        log(`Connected: ${info.deviceName}`);
-        finishConnect(ps3Driver, info, "PS3_MCA");
-      } catch (e) {
-        log(`Auto-reconnect failed: ${(e as Error).message}`, "warn");
-      }
-    });
+    })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -372,111 +313,7 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
       }
 
       try {
-        const authorized = await findAuthorized(dev);
-
-        switch (deviceId) {
-          case "GBXCART": {
-            const transport = new SerialTransport();
-            if (authorized) {
-              log("Connecting...");
-              await transport.connectWithPort(authorized as SerialPort, {
-                baudRate: 1_000_000,
-              });
-            } else {
-              log("Requesting serial port...");
-              await transport.connect({ baudRate: 1_000_000 });
-            }
-
-            transport.on("onDisconnect", () => {
-              log("Device disconnected", "warn");
-              handleDisconnect();
-            });
-
-            const gbxDriver = new GBxCartDriver(transport);
-            gbxDriver.on("onLog", (msg, level) => log(msg, level));
-
-            log("Initializing device...");
-            const info = await gbxDriver.initialize();
-            log(
-              `Connected: ${info.deviceName} (fw: ${info.firmwareVersion}, ${info.hardwareRevision})`,
-            );
-            finishConnect(gbxDriver, info, deviceId);
-            break;
-          }
-
-          case "POWERSAVE": {
-            const transport = new HidTransport(POWERSAVE_FILTERS);
-            if (authorized) {
-              log("Connecting...");
-              await transport.connectWithDevice(authorized as HIDDevice);
-            } else {
-              log("Requesting HID device...");
-              await transport.connect();
-            }
-
-            transport.on("onDisconnect", () => {
-              log("Device disconnected", "warn");
-              handleDisconnect();
-            });
-
-            const psDriver = new PowerSaveDriver(transport);
-            psDriver.on("onLog", (msg, level) => log(msg, level));
-
-            const info = await psDriver.initialize();
-            log(`Connected: ${info.deviceName}`);
-            finishConnect(psDriver, info, deviceId);
-            break;
-          }
-
-          case "DISNEY_INFINITY": {
-            const transport = new HidTransport(INFINITY_FILTERS);
-            if (authorized) {
-              log("Connecting...");
-              await transport.connectWithDevice(authorized as HIDDevice);
-            } else {
-              log("Requesting HID device...");
-              await transport.connect();
-            }
-
-            transport.on("onDisconnect", () => {
-              log("Device disconnected", "warn");
-              handleDisconnect();
-            });
-
-            const infDriver = new InfinityDriver(transport);
-            infDriver.on("onLog", (msg, level) => log(msg, level));
-
-            log("Activating base...");
-            const info = await infDriver.initialize();
-            log(`Connected: ${info.deviceName} (fw: ${info.firmwareVersion})`);
-            finishConnect(infDriver, info, deviceId);
-            break;
-          }
-
-          case "PS3_MCA": {
-            const transport = new UsbTransport(PS3_MCA_FILTERS);
-            if (authorized) {
-              log("Connecting...");
-              await transport.connectWithDevice(authorized as USBDevice);
-            } else {
-              log("Requesting USB device...");
-              await transport.connect();
-            }
-
-            transport.on("onDisconnect", () => {
-              log("Device disconnected", "warn");
-              handleDisconnect();
-            });
-
-            const ps3Driver = new Ps3McaDriver(transport);
-            ps3Driver.on("onLog", (msg, level) => log(msg, level));
-
-            const info = await ps3Driver.initialize();
-            log(`Connected: ${info.deviceName}`);
-            finishConnect(ps3Driver, info, deviceId);
-            break;
-          }
-        }
+        await connectDevice(deviceId, { auto: false });
       } catch (e) {
         const msg = (e as Error).message;
         if (
@@ -490,7 +327,7 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
         }
       }
     },
-    [log, handleDisconnect, finishConnect],
+    [log, connectDevice],
   );
 
   // Keep ref in sync so the probe effect can trigger reconnection

--- a/src/hooks/use-connection.ts
+++ b/src/hooks/use-connection.ts
@@ -246,29 +246,45 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
           ? "Connecting..."
           : `Requesting ${transportLabel}...`,
       );
-      const identity = await entry.connect(transport, { authorized });
 
-      if (driverRef.current) {
+      try {
+        const identity = await entry.connect(transport, { authorized });
+
+        if (driverRef.current) {
+          await transport.disconnect().catch(() => {});
+          return false;
+        }
+
+        log(`Opened ${transportLabel}: ${identity.name}`);
+
+        transport.on("onDisconnect", () => {
+          log("Device disconnected", "warn");
+          handleDisconnect();
+        });
+
+        const drv = entry.createDriver(transport);
+        drv.on("onLog", (msg, level) => log(msg, level));
+
+        log(entry.preInitLog ?? "Initializing device...");
+        const info = await drv.initialize();
+
+        // Final race check — another path may have published its driver
+        // while we were awaiting initialize().
+        if (driverRef.current) {
+          await transport.disconnect().catch(() => {});
+          return false;
+        }
+
+        log(entry.postInitLog?.(info) ?? `Connected: ${info.deviceName}`);
+        finishConnect(drv, info, deviceId);
+        return true;
+      } catch (e) {
+        // entry.connect or drv.initialize threw — close the transport so we
+        // don't leak an open serial port / claimed USB interface / opened
+        // HID device, then propagate.
         await transport.disconnect().catch(() => {});
-        return false;
+        throw e;
       }
-
-      log(`Opened ${transportLabel}: ${identity.name}`);
-
-      transport.on("onDisconnect", () => {
-        log("Device disconnected", "warn");
-        handleDisconnect();
-      });
-
-      const drv = entry.createDriver(transport);
-      drv.on("onLog", (msg, level) => log(msg, level));
-
-      log(entry.preInitLog ?? "Initializing device...");
-      const info = await drv.initialize();
-      log(entry.postInitLog?.(info) ?? `Connected: ${info.deviceName}`);
-
-      finishConnect(drv, info, deviceId);
-      return true;
     },
     [log, handleDisconnect, finishConnect],
   );

--- a/src/lib/core/connection-registry.ts
+++ b/src/lib/core/connection-registry.ts
@@ -1,0 +1,76 @@
+import { SerialTransport } from "@/lib/transport/serial-transport";
+import { HidTransport } from "@/lib/transport/hid-transport";
+import { UsbTransport } from "@/lib/transport/usb-transport";
+import { GBxCartDriver } from "@/lib/drivers/gbxcart/gbxcart-driver";
+import { PowerSaveDriver } from "@/lib/drivers/powersave/powersave-driver";
+import { DEVICE_FILTERS as POWERSAVE_FILTERS } from "@/lib/drivers/powersave/powersave-commands";
+import { InfinityDriver } from "@/lib/drivers/infinity/infinity-driver";
+import { DEVICE_FILTERS as INFINITY_FILTERS } from "@/lib/drivers/infinity/infinity-commands";
+import { Ps3McaDriver } from "@/lib/drivers/ps3-mca/ps3-mca-driver";
+import { DEVICE_FILTERS as PS3_MCA_FILTERS } from "@/lib/drivers/ps3-mca/ps3-mca-commands";
+import type {
+  DeviceDriver,
+  DeviceIdentity,
+  DeviceInfo,
+  Transport,
+} from "@/lib/types";
+
+export type AuthorizedDevice = SerialPort | USBDevice | HIDDevice;
+
+export interface ConnectionEntry {
+  createTransport(): Transport;
+  connect(
+    transport: Transport,
+    ctx: { authorized: AuthorizedDevice | null },
+  ): Promise<DeviceIdentity>;
+  createDriver(transport: Transport): DeviceDriver;
+  /** Pre-initialize log line. Default: "Initializing device..." */
+  preInitLog?: string;
+  /** Post-initialize log line. Default: `Connected: ${info.deviceName}` */
+  postInitLog?: (info: DeviceInfo) => string;
+}
+
+export const CONNECTION_ENTRIES: Record<string, ConnectionEntry> = {
+  GBXCART: {
+    createTransport: () => new SerialTransport(),
+    connect: (t, { authorized }) =>
+      authorized
+        ? (t as SerialTransport).connectWithPort(authorized as SerialPort, {
+            baudRate: 1_000_000,
+          })
+        : (t as SerialTransport).connect({ baudRate: 1_000_000 }),
+    createDriver: (t) => new GBxCartDriver(t as SerialTransport),
+    postInitLog: (info) =>
+      `Connected: ${info.deviceName} (fw: ${info.firmwareVersion}, ${info.hardwareRevision})`,
+  },
+
+  POWERSAVE: {
+    createTransport: () => new HidTransport(POWERSAVE_FILTERS),
+    connect: (t, { authorized }) =>
+      authorized
+        ? (t as HidTransport).connectWithDevice(authorized as HIDDevice)
+        : (t as HidTransport).connect(),
+    createDriver: (t) => new PowerSaveDriver(t as HidTransport),
+  },
+
+  DISNEY_INFINITY: {
+    createTransport: () => new HidTransport(INFINITY_FILTERS),
+    connect: (t, { authorized }) =>
+      authorized
+        ? (t as HidTransport).connectWithDevice(authorized as HIDDevice)
+        : (t as HidTransport).connect(),
+    createDriver: (t) => new InfinityDriver(t as HidTransport),
+    preInitLog: "Activating base...",
+    postInitLog: (info) =>
+      `Connected: ${info.deviceName} (fw: ${info.firmwareVersion})`,
+  },
+
+  PS3_MCA: {
+    createTransport: () => new UsbTransport(PS3_MCA_FILTERS),
+    connect: (t, { authorized }) =>
+      authorized
+        ? (t as UsbTransport).connectWithDevice(authorized as USBDevice)
+        : (t as UsbTransport).connect(),
+    createDriver: (t) => new Ps3McaDriver(t as UsbTransport),
+  },
+};

--- a/src/lib/transport/serial-transport.ts
+++ b/src/lib/transport/serial-transport.ts
@@ -58,10 +58,16 @@ export class SerialTransport implements Transport {
     });
 
     const info = port.getInfo();
+    // Web Serial doesn't expose productName; the vendor:product pair is the
+    // most identifying string available.
+    const name =
+      info.usbVendorId !== undefined && info.usbProductId !== undefined
+        ? `${info.usbVendorId.toString(16)}:${info.usbProductId.toString(16)}`
+        : "Serial Device";
     return {
       vendorId: info.usbVendorId,
       productId: info.usbProductId,
-      name: "Serial Device",
+      name,
       transport: "serial",
       raw: port,
     };

--- a/src/lib/transport/usb-transport.ts
+++ b/src/lib/transport/usb-transport.ts
@@ -61,9 +61,18 @@ export class UsbTransport implements Transport {
   }
 
   private async openDevice(device: USBDevice): Promise<DeviceIdentity> {
-    await device.open();
-    await device.selectConfiguration(1);
-    await device.claimInterface(0);
+    // Device may already be open + claimed after Vite HMR or StrictMode
+    // double-mount (no full page unload). Re-claiming throws "Unable to
+    // claim interface", so check before each step.
+    if (!device.opened) {
+      await device.open();
+    }
+    if (device.configuration?.configurationValue !== 1) {
+      await device.selectConfiguration(1);
+    }
+    if (!device.configuration?.interfaces[0]?.claimed) {
+      await device.claimInterface(0);
+    }
 
     this.device = device;
 

--- a/src/lib/transport/usb-transport.ts
+++ b/src/lib/transport/usb-transport.ts
@@ -70,7 +70,12 @@ export class UsbTransport implements Transport {
     if (device.configuration?.configurationValue !== 1) {
       await device.selectConfiguration(1);
     }
-    if (!device.configuration?.interfaces[0]?.claimed) {
+    // configuration.interfaces[] is not guaranteed to be ordered by
+    // interfaceNumber, so look up by number rather than array index.
+    const iface = device.configuration?.interfaces.find(
+      (i) => i.interfaceNumber === 0,
+    );
+    if (!iface?.claimed) {
       await device.claimInterface(0);
     }
 


### PR DESCRIPTION
## Summary

Closes #7. Collapses the four near-identical case blocks in `handleConnect` and the three parallel auto-reconnect probes in `useConnection` into a single registry-driven path.

- New `src/lib/core/connection-registry.ts` holds one entry per device (transport factory, connect fn, driver factory, optional log overrides). Adding a fifth driver is now a one-entry edit instead of a six-place edit.
- `connectDevice(deviceId, { auto })` is the only path that opens a transport. Three `driverRef` checkpoints (pre-I/O, post-`findAuthorized`, post-open) make the manual and auto paths safe to coexist; the post-open check disconnects on the rare 3-way tie so we don't leak a port.
- Auto-reconnect is a sequential loop over registered devices — win-once-by-construction, so the serial/HID parallel-probe race is structurally impossible, not just guarded.
- Drive-by: `UsbTransport.openDevice` is now idempotent (skips `open` / `selectConfiguration` / `claimInterface` when their post-condition already holds), matching `SerialTransport`. This fixes a pre-existing "Unable to claim interface" error under Vite HMR / React StrictMode that surfaced while testing this branch.

Net: ~-157 LOC across `useConnection`, with the parallel-probe race converted from a guarded condition into a structural impossibility.

## Test plan

- [x] `npm run build` — type-check + production build pass
- [x] `npx eslint src/` — no warnings
- [ ] Single-device auto-reconnect: with each of GBxCart / PowerSaves / Infinity / PS3 MCA already authorized + plugged in, reload → that device auto-reconnects
- [ ] Race scenario: authorize two devices in browser permissions, plug both in, reload → exactly one connects, no orphan transports in DevTools' WebUSB/HID/Serial inspector
- [ ] Manual connect path: disconnect, click each card on the connect screen → connects, status updates, picker still works for unauthorized devices
- [ ] Disconnect: unplug while connected → "Device disconnected" log, status returns to picker
- [ ] HMR sanity: edit a source file with the dev server running and a USB device connected → no "Unable to claim interface" error in the console