### PR TITLE
Throttle dump-progress updates to one per animation frame

### DIFF
--- a/src/hooks/use-dump-job.ts
+++ b/src/hooks/use-dump-job.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import type {
   DeviceDriver,
   SystemHandler,
@@ -10,15 +10,45 @@ import type {
 } from "@/lib/types";
 import { DumpJobImpl } from "@/lib/core/dump-job";
 
-export function useDumpJob(log: (msg: string, level?: "info" | "warn" | "error") => void) {
+export function useDumpJob(
+  log: (msg: string, level?: "info" | "warn" | "error") => void,
+) {
   const [state, setState] = useState<DumpJobState>("idle");
   const [progress, setProgress] = useState<DumpProgress | null>(null);
   const [result, setResult] = useState<DumpResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+  const pendingProgressRef = useRef<DumpProgress | null>(null);
+  const rafIdRef = useRef<number | null>(null);
+
+  // Coalesce rapid progress events to one render per animation frame. PS1
+  // dumps fire ~1024 events in well under a second; without throttling the
+  // concurrent renderer keeps interrupting itself and the bar appears stuck.
+  const setProgressThrottled = useCallback((p: DumpProgress) => {
+    pendingProgressRef.current = p;
+    if (rafIdRef.current !== null) return;
+    rafIdRef.current = requestAnimationFrame(() => {
+      rafIdRef.current = null;
+      const latest = pendingProgressRef.current;
+      pendingProgressRef.current = null;
+      if (latest) setProgress(latest);
+    });
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current);
+    },
+    [],
+  );
 
   const run = useCallback(
-    async (driver: DeviceDriver, system: SystemHandler, values: ConfigValues, verificationDb?: VerificationDB | null) => {
+    async (
+      driver: DeviceDriver,
+      system: SystemHandler,
+      values: ConfigValues,
+      verificationDb?: VerificationDB | null,
+    ) => {
       const job = new DumpJobImpl(driver, system, verificationDb ?? null);
       const abort = new AbortController();
       abortRef.current = abort;
@@ -26,9 +56,10 @@ export function useDumpJob(log: (msg: string, level?: "info" | "warn" | "error")
       setResult(null);
       setError(null);
       setProgress(null);
+      pendingProgressRef.current = null;
 
       job.on("onStateChange", setState);
-      job.on("onProgress", setProgress);
+      job.on("onProgress", setProgressThrottled);
       job.on("onLog", (msg, level) => log(msg, level));
       job.on("onComplete", setResult);
 
@@ -44,7 +75,7 @@ export function useDumpJob(log: (msg: string, level?: "info" | "warn" | "error")
         abortRef.current = null;
       }
     },
-    [log],
+    [log, setProgressThrottled],
   );
 
   const abort = useCallback(() => {

--- a/src/hooks/use-dump-job.ts
+++ b/src/hooks/use-dump-job.ts
@@ -35,12 +35,15 @@ export function useDumpJob(
     });
   }, []);
 
-  useEffect(
-    () => () => {
-      if (rafIdRef.current !== null) cancelAnimationFrame(rafIdRef.current);
-    },
-    [],
-  );
+  const cancelPendingProgress = useCallback(() => {
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current);
+      rafIdRef.current = null;
+    }
+    pendingProgressRef.current = null;
+  }, []);
+
+  useEffect(() => () => cancelPendingProgress(), [cancelPendingProgress]);
 
   const run = useCallback(
     async (
@@ -53,10 +56,10 @@ export function useDumpJob(
       const abort = new AbortController();
       abortRef.current = abort;
 
+      cancelPendingProgress();
       setResult(null);
       setError(null);
       setProgress(null);
-      pendingProgressRef.current = null;
 
       job.on("onStateChange", setState);
       job.on("onProgress", setProgressThrottled);
@@ -75,7 +78,7 @@ export function useDumpJob(
         abortRef.current = null;
       }
     },
-    [log, setProgressThrottled],
+    [log, setProgressThrottled, cancelPendingProgress],
   );
 
   const abort = useCallback(() => {
@@ -85,11 +88,12 @@ export function useDumpJob(
   }, [log]);
 
   const reset = useCallback(() => {
+    cancelPendingProgress();
     setState("idle");
     setProgress(null);
     setResult(null);
     setError(null);
-  }, []);
+  }, [cancelPendingProgress]);
 
   return { state, progress, result, error, run, abort, reset };
 }


### PR DESCRIPTION
## Summary

- The PS1 driver fires a progress event after each of its 1024 frames; a PS3 MCA dump completes in well under a second, so React's concurrent renderer keeps interrupting itself trying to keep up. The progress bar visibly sticks around 1/8 even after the dump finishes.
- Coalesce progress events at the React boundary in `useDumpJob` using `requestAnimationFrame`. The latest pending value always wins, so no progress is dropped.
- Universal change but only PS1 is visibly affected — other drivers emit progress per chunk and already arrive >16ms apart, so the rAF gate passes through immediately.

## Test plan

- [x] Dump a PS1 memory card; confirm the progress bar fills smoothly to 100% and matches the byte counter.
- [x] Dump a GB/GBC/GBA cart via GBxCart; confirm progress behavior is unchanged.
- [x] Dump an amiibo via PowerSaves; confirm progress behavior is unchanged.
- [x] Abort a dump mid-stream; confirm clean teardown.