### PR TITLE
Add Neoflash SMS4 driver — DS cartridge save backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ keeper of knowledge. Seemed fitting for a preservation tool.
 | PowerSaves for 3DS | WebHID | DS cartridge saves |
 | Disney Infinity Base | WebHID | Disney Infinity Figures |
 | PS3 Memory Card Adaptor | WebUSB | PS1 Memory Card |
+| Neoflash SMS4 | WebUSB | DS cartridge saves |
 
 This is still early. More hardware and more systems are in the works.
 
@@ -84,3 +85,9 @@ derived from [FlashGBX](https://github.com/lesserkuma/FlashGBX),
 
 PowerSaves and Datel are trademarks of Datel Ltd. nabu is not affiliated
 with or endorsed by Datel.
+
+SMS4 and Neoflash are trademarks of their respective owners. nabu is not
+affiliated with or endorsed by Neoflash.
+
+Nintendo, Nintendo DS, and DS are trademarks of Nintendo Co., Ltd. nabu
+is not affiliated with or endorsed by Nintendo.

--- a/linux/99-nabu.rules
+++ b/linux/99-nabu.rules
@@ -17,3 +17,5 @@ KERNEL=="hidraw*", ATTRS{idVendor}=="1c1a", ATTRS{idProduct}=="03d5", TAG+="uacc
 KERNEL=="hidraw*", ATTRS{idVendor}=="0e6f", ATTRS{idProduct}=="0129", TAG+="uaccess", MODE="0660"
 # PS3_MCA — PS3 Memory Card Adaptor
 SUBSYSTEM=="usb", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="02ea", TAG+="uaccess", MODE="0660"
+# SMS4 — Neoflash SMS4
+SUBSYSTEM=="usb", ATTRS{idVendor}=="ffab", ATTRS{idProduct}=="dd03", TAG+="uaccess", MODE="0660"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -445,9 +445,12 @@ function App() {
                     <span className="text-muted-foreground">
                       {connection.deviceInfo.deviceName}
                       {connection.deviceInfo.firmwareVersion && (
-                        <span className="ml-2 text-muted-foreground/50">
-                          fw {connection.deviceInfo.firmwareVersion}
-                        </span>
+                        <>
+                          {" "}
+                          <span className="ml-1 text-muted-foreground/50">
+                            {connection.deviceInfo.firmwareVersion}
+                          </span>
+                        </>
                       )}
                     </span>
                   )}

--- a/src/components/wizard/nds-scanner.tsx
+++ b/src/components/wizard/nds-scanner.tsx
@@ -80,14 +80,24 @@ export function NDSScanner({
         </Alert>
       )}
 
-      {/* Polling state */}
-      {(phase === "polling" || phase === "idle") && (
+      {/* Detecting state — brief, while the one-shot detect is in flight. */}
+      {(phase === "detecting" || phase === "idle") && (
         <Card>
           <CardContent className="flex items-center gap-3 py-8">
             <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
             <span className="text-sm text-muted-foreground">
-              Insert a DS cartridge...
+              Detecting cartridge...
             </span>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* No-cart terminal state — detect ran and found nothing. */}
+      {phase === "no-cart" && (
+        <Card>
+          <CardContent className="py-8 text-sm text-muted-foreground">
+            No DS cartridge detected. Disconnect the adapter from USB, insert
+            a cart, and reconnect.
           </CardContent>
         </Card>
       )}

--- a/src/components/wizard/nds-scanner.tsx
+++ b/src/components/wizard/nds-scanner.tsx
@@ -53,9 +53,12 @@ export function NDSScanner({
           <span className="text-muted-foreground">
             {deviceInfo.deviceName}
             {deviceInfo.firmwareVersion && (
-              <span className="ml-2 text-muted-foreground/50">
-                fw {deviceInfo.firmwareVersion}
-              </span>
+              <>
+                {" "}
+                <span className="ml-1 text-muted-foreground/50">
+                  {deviceInfo.firmwareVersion}
+                </span>
+              </>
             )}
           </span>
         )}

--- a/src/hooks/use-nds-scanner.ts
+++ b/src/hooks/use-nds-scanner.ts
@@ -12,7 +12,13 @@ import {
 } from "@/lib/systems/nds/nds-header";
 import { NDSSaveSystemHandler } from "@/lib/systems/nds/nds-save-system-handler";
 
-export type NDSScannerPhase = "idle" | "polling" | "reading" | "done" | "error";
+export type NDSScannerPhase =
+  | "idle"
+  | "detecting"
+  | "no-cart"
+  | "reading"
+  | "done"
+  | "error";
 
 export interface NDSScannerResult {
   data: Uint8Array;
@@ -28,7 +34,7 @@ export function useNDSScanner(
   log: (msg: string, level?: "info" | "warn" | "error") => void,
   nointroDb: VerificationDB | null = null,
 ) {
-  // Read the latest DB through a ref so the polling effect below doesn't
+  // Read the latest DB through a ref so the detect effect below doesn't
   // need to re-run (and interrupt an in-flight dump) when the user loads a
   // DAT mid-session.
   const nointroRef = useRef(nointroDb);
@@ -52,7 +58,7 @@ export function useNDSScanner(
   const [prevDriver, setPrevDriver] = useState(driver);
   if (driver !== prevDriver) {
     setPrevDriver(driver);
-    setPhase(driver ? "polling" : "idle");
+    setPhase(driver ? "detecting" : "idle");
     setResult(null);
     setError(null);
     setErrorRecoverable(true);
@@ -64,7 +70,6 @@ export function useNDSScanner(
 
     const abort = new AbortController();
     const { signal } = abort;
-    let timer: ReturnType<typeof setTimeout>;
 
     driver.on("onLog", (msg, level) => log(msg, level));
 
@@ -79,24 +84,13 @@ export function useNDSScanner(
 
     driver.on("onProgress", (p: DumpProgress) => {
       setProgress(p);
-      // The driver learns save type/size during readROM()'s SPI probe — after
+      // The driver learns save type/size during readSave()'s SPI probe — after
       // detectCartridge already set our cartInfo. Pick the enriched info back
       // up on progress so the UI can show it alongside the progress bar.
       if (driver.cartInfo) setCartInfo(enrichWithNoIntro(driver.cartInfo));
     });
 
-    const schedule = (fn: () => Promise<void>, ms: number) => {
-      timer = setTimeout(() => {
-        fn().catch((e) => {
-          if (!signal.aborted) {
-            console.error("[nds-scanner]", e);
-            schedule(pollForCart, 1000);
-          }
-        });
-      }, ms);
-    };
-
-    const pollForCart = async () => {
+    const detectCart = async () => {
       if (signal.aborted) return;
 
       const info = await driver.detectCartridge("nds_save");
@@ -110,7 +104,15 @@ export function useNDSScanner(
         setProgress(null);
         await readSave(enriched);
       } else {
-        schedule(pollForCart, 500);
+        // One-shot detect: no cart, terminal state. Polling was removed
+        // because the supported devices (PowerSaves 3DS, SMS4) require
+        // disconnect-and-reconnect between cartridges anyway — their
+        // firmware can't recover cleanly from aborted mid-operation state.
+        log(
+          "No cartridge detected. Disconnect the adapter, insert a DS " +
+            "cart, and reconnect.",
+        );
+        setPhase("no-cart");
       }
     };
 
@@ -121,10 +123,10 @@ export function useNDSScanner(
           saveSizeBytes: initialInfo.saveSize,
         });
 
-        const saveData = await driver.readROM(config, signal);
+        const saveData = await driver.readSave(config, signal);
         if (signal.aborted) return;
 
-        // After readROM, the driver has full cart info (save size, save type).
+        // After readSave, the driver has full cart info (save size, save type).
         // Re-apply No-Intro enrichment: the driver's cartInfo getter doesn't
         // know about No-Intro, so its title would otherwise overwrite the
         // nicer one we surfaced during reading.
@@ -158,9 +160,6 @@ export function useNDSScanner(
         });
         setPhase("done");
 
-        // Deliberately do NOT resume polling here. Require the user to
-        // reconnect the device between cartridges; the scanner is
-        // rebuilt with a fresh driver instance on reconnect.
         log(
           "Dump complete. Disconnect the adapter from USB to dump another cartridge.",
         );
@@ -171,17 +170,21 @@ export function useNDSScanner(
         setError(msg);
         setErrorRecoverable(!(e instanceof UnsupportedCartError));
         setPhase("error");
-        // Do not auto-retry — require the user to reconnect the device.
       }
     };
 
-    schedule(() => {
-      log("Waiting for cartridge...");
-      return pollForCart();
-    }, 0);
+    log("Detecting cartridge...");
+    detectCart().catch((e) => {
+      if (signal.aborted) return;
+      const msg = (e as Error).message;
+      console.error("[nds-scanner]", e);
+      log(`Detect error: ${msg}`, "error");
+      setError(msg);
+      setErrorRecoverable(true);
+      setPhase("error");
+    });
 
     return () => {
-      clearTimeout(timer);
       abort.abort();
     };
   }, [driver, system, log]);

--- a/src/lib/core/connection-registry.ts
+++ b/src/lib/core/connection-registry.ts
@@ -10,6 +10,8 @@ import { InfinityDriver } from "@/lib/drivers/infinity/infinity-driver";
 import { DEVICE_FILTERS as INFINITY_FILTERS } from "@/lib/drivers/infinity/infinity-commands";
 import { Ps3McaDriver } from "@/lib/drivers/ps3-mca/ps3-mca-driver";
 import { DEVICE_FILTERS as PS3_MCA_FILTERS } from "@/lib/drivers/ps3-mca/ps3-mca-commands";
+import { SMS4Driver } from "@/lib/drivers/sms4/sms4-driver";
+import { DEVICE_FILTERS as SMS4_FILTERS } from "@/lib/drivers/sms4/sms4-commands";
 import type {
   DeviceDriver,
   DeviceIdentity,
@@ -83,5 +85,14 @@ export const CONNECTION_ENTRIES: Record<string, ConnectionEntry> = {
         ? (t as UsbTransport).connectWithDevice(authorized as USBDevice)
         : (t as UsbTransport).connect(),
     createDriver: (t) => new Ps3McaDriver(t as UsbTransport),
+  },
+
+  SMS4: {
+    createTransport: () => new UsbTransport(SMS4_FILTERS),
+    connect: (t, { authorized }) =>
+      authorized
+        ? (t as UsbTransport).connectWithDevice(authorized as USBDevice)
+        : (t as UsbTransport).connect(),
+    createDriver: (t) => new SMS4Driver(t as UsbTransport),
   },
 };

--- a/src/lib/core/devices.ts
+++ b/src/lib/core/devices.ts
@@ -84,4 +84,16 @@ export const DEVICES: Record<string, DeviceDef> = {
       "Only PS1 cards are dumpable in the browser (PS2 reads require " +
       "MagicGate authentication keys that cannot be redistributed).",
   },
+  SMS4: {
+    id: "SMS4",
+    name: "Neoflash SMS4",
+    vendorId: 0xffab,
+    productId: 0xdd03,
+    transport: "webusb",
+    systems: [{ id: "nds_save", name: "DS (Saves Only)" }],
+    models: ["NEO NDS SMS4 V6G"],
+    description:
+      "Discontinued Neoflash NDS slot-1 cartridge adapter. Backs up DS " +
+      "cartridge save data via the cart's SPI passthrough.",
+  },
 };

--- a/src/lib/drivers/powersave-3ds/powersave-3ds-driver.ts
+++ b/src/lib/drivers/powersave-3ds/powersave-3ds-driver.ts
@@ -247,12 +247,20 @@ export class PowerSave3DSDriver implements NDSDeviceDriver {
     return this.buildCartInfo();
   }
 
+  async readROM(): Promise<Uint8Array> {
+    throw new Error(
+      "PowerSaves 3DS: ROM dump is not supported — this device backs up " +
+        "DS cartridge saves only.",
+    );
+  }
+
   /**
    * Read cart header (NTR) + identify save chip (SPI) + dump save data.
-   * The save data is returned as the primary output: this is a save-only
-   * device, so readROM surfaces the save bytes directly.
    */
-  async readROM(config: ReadConfig, signal?: AbortSignal): Promise<Uint8Array> {
+  async readSave(
+    config: ReadConfig,
+    signal?: AbortSignal,
+  ): Promise<Uint8Array> {
     void config;
     this.currentSignal = signal ?? null;
     try {
@@ -260,8 +268,9 @@ export class PowerSave3DSDriver implements NDSDeviceDriver {
       // detect. No-op on first dump (nothing cached yet).
       await this.verifyCartUnchanged();
 
-      // Header is normally read by detectCartridge() during polling. If the
-      // user jumped past polling (mock flows, re-entry), run a detect first.
+      // Header is normally read by detectCartridge() during the scanner's
+      // initial detect. If the user jumped past detect (mock flows,
+      // re-entry), run a detect first.
       if (!this.header) {
         const info = await this.detectCartridge("nds_save");
         if (!info) {
@@ -330,13 +339,6 @@ export class PowerSave3DSDriver implements NDSDeviceDriver {
     } finally {
       this.currentSignal = null;
     }
-  }
-
-  async readSave(
-    config: ReadConfig,
-    signal?: AbortSignal,
-  ): Promise<Uint8Array> {
-    return this.readROM(config, signal);
   }
 
   async writeSave(

--- a/src/lib/drivers/powersave-3ds/powersave-3ds-driver.ts
+++ b/src/lib/drivers/powersave-3ds/powersave-3ds-driver.ts
@@ -247,7 +247,10 @@ export class PowerSave3DSDriver implements NDSDeviceDriver {
     return this.buildCartInfo();
   }
 
-  async readROM(): Promise<Uint8Array> {
+  async readROM(
+    _config: ReadConfig,
+    _signal?: AbortSignal,
+  ): Promise<Uint8Array> {
     throw new Error(
       "PowerSaves 3DS: ROM dump is not supported — this device backs up " +
         "DS cartridge saves only.",

--- a/src/lib/drivers/sms4/sms4-chip-database.test.ts
+++ b/src/lib/drivers/sms4/sms4-chip-database.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import {
+  decodeSpiCapacityByte,
+  identifyByJedec,
+  parseProbeResponse,
+  SAVE_CHIPS,
+} from "./sms4-chip-database";
+
+describe("decodeSpiCapacityByte", () => {
+  it("decodes the documented Numonyx capacity ladder", () => {
+    expect(decodeSpiCapacityByte(0x11)).toBe(128 * 1024);
+    expect(decodeSpiCapacityByte(0x12)).toBe(256 * 1024);
+    expect(decodeSpiCapacityByte(0x13)).toBe(512 * 1024);
+    expect(decodeSpiCapacityByte(0x14)).toBe(1024 * 1024);
+    expect(decodeSpiCapacityByte(0x15)).toBe(2 * 1024 * 1024);
+    expect(decodeSpiCapacityByte(0x16)).toBe(4 * 1024 * 1024);
+    expect(decodeSpiCapacityByte(0x17)).toBe(8 * 1024 * 1024);
+    expect(decodeSpiCapacityByte(0x18)).toBe(16 * 1024 * 1024);
+  });
+
+  it("returns 0 below 0x11 — there's no NDS save chip that small", () => {
+    expect(decodeSpiCapacityByte(0x00)).toBe(0);
+    expect(decodeSpiCapacityByte(0x10)).toBe(0);
+  });
+
+  it("returns 0 above 0x18 — beyond that range 1<<n overflows JS's 32-bit shift", () => {
+    expect(decodeSpiCapacityByte(0x19)).toBe(0);
+    expect(decodeSpiCapacityByte(0xff)).toBe(0);
+  });
+});
+
+describe("identifyByJedec — exact match", () => {
+  it("identifies M25P80 by full JEDEC ID", () => {
+    const result = identifyByJedec([0x20, 0x20, 0x14], 0x03);
+    expect(result.source).toBe("exact");
+    expect(result.name).toBe("M25P80");
+    expect(result.kind).toBe("FLASH");
+    expect(result.sizeBytes).toBe(1024 * 1024);
+  });
+
+  it("identifies a M45PE family chip by exact JEDEC ID", () => {
+    const result = identifyByJedec([0x20, 0x40, 0x13], 0x03);
+    expect(result.source).toBe("exact");
+    expect(result.name).toBe("M45PE40");
+    expect(result.sizeBytes).toBe(512 * 1024);
+  });
+
+  it("identifies an LE25FW chip by exact JEDEC ID", () => {
+    const result = identifyByJedec([0x62, 0x11, 0x00], 0x03);
+    expect(result.source).toBe("exact");
+    expect(result.name).toBe("LE25FW403");
+    expect(result.flag).toBe(0x0f);
+  });
+});
+
+describe("identifyByJedec — family fallback", () => {
+  it("falls back to generic Numonyx for an undocumented device-type 0x50", () => {
+    // 0x20 0x50 0x12 isn't in SAVE_CHIPS, but manufacturer 0x20 + a
+    // capacity-decodable byte 2 should match the generic Numonyx family.
+    const result = identifyByJedec([0x20, 0x50, 0x12], 0x03);
+    expect(result.source).toBe("family");
+    expect(result.kind).toBe("FLASH");
+    expect(result.sizeBytes).toBe(256 * 1024);
+    expect(result.flag).toBe(0x07);
+  });
+});
+
+describe("identifyByJedec — EEPROM family from family-code byte", () => {
+  it("classifies family-code 0x01 as a tiny M95 EEPROM (size pending wrap-probe)", () => {
+    const result = identifyByJedec([0xff, 0xff, 0xff], 0x01);
+    expect(result.source).toBe("eeprom-family");
+    expect(result.kind).toBe("EEPROM");
+    expect(result.sizeBytes).toBe(0);
+  });
+
+  it("classifies family-code 0x02 as a medium M95 EEPROM (size pending wrap-probe)", () => {
+    const result = identifyByJedec([0xff, 0xff, 0xff], 0x02);
+    expect(result.source).toBe("eeprom-family");
+    expect(result.kind).toBe("EEPROM");
+    expect(result.sizeBytes).toBe(0);
+  });
+});
+
+describe("identifyByJedec — unknown fallback", () => {
+  it("returns 'unknown' when neither JEDEC nor family code matches anything", () => {
+    const result = identifyByJedec([0xff, 0xff, 0xff], 0x00);
+    expect(result.source).toBe("unknown");
+    expect(result.kind).toBe("FLASH");
+    expect(result.sizeBytes).toBe(0);
+  });
+});
+
+describe("parseProbeResponse", () => {
+  it("extracts JEDEC + familyCode and reports consistency when the two reads agree", () => {
+    // 9-byte response: bytes 0..2 JEDEC, 3..4 padding, 5..7 JEDEC repeat, 8 family.
+    const raw = new Uint8Array([0x20, 0x50, 0x12, 0x00, 0x00, 0x20, 0x50, 0x12, 0x03]);
+    const parsed = parseProbeResponse(raw);
+    expect(parsed.jedec).toEqual([0x20, 0x50, 0x12]);
+    expect(parsed.familyCode).toBe(0x03);
+    expect(parsed.jedecConsistent).toBe(true);
+  });
+
+  it("flags inconsistency when the two firmware JEDEC reads disagree", () => {
+    const raw = new Uint8Array([0x20, 0x50, 0x12, 0x00, 0x00, 0x20, 0x50, 0x13, 0x03]);
+    const parsed = parseProbeResponse(raw);
+    expect(parsed.jedecConsistent).toBe(false);
+  });
+
+  it("doesn't crash on a short response — missing bytes read as 0", () => {
+    const parsed = parseProbeResponse(new Uint8Array([0x20, 0x50, 0x12]));
+    expect(parsed.jedec).toEqual([0x20, 0x50, 0x12]);
+    expect(parsed.familyCode).toBe(0);
+    expect(parsed.jedecConsistent).toBe(false);
+  });
+});
+
+describe("SAVE_CHIPS table sanity", () => {
+  it("every entry has a 14-byte cmdTable", () => {
+    for (const c of SAVE_CHIPS) {
+      expect(c.cmdTable.length).toBe(14);
+    }
+  });
+
+  it("every FLASH entry has a 3-byte JEDEC ID; M95 EEPROMs do not", () => {
+    for (const c of SAVE_CHIPS) {
+      if (c.name.startsWith("M95")) {
+        expect(c.jedecId).toBeUndefined();
+      } else {
+        expect(c.jedecId?.length).toBe(3);
+      }
+    }
+  });
+});

--- a/src/lib/drivers/sms4/sms4-chip-database.ts
+++ b/src/lib/drivers/sms4/sms4-chip-database.ts
@@ -346,11 +346,19 @@ export interface ParsedProbeResponse {
   jedecConsistent: boolean;
 }
 
+/** Minimum bytes needed to make the `jedecConsistent` check meaningful
+ *  (covers raw[0..7]; familyCode at raw[8] is allowed to be missing —
+ *  defaults to 0 below). Matches PROBE_JEDEC_RESPONSE_LEN on full reads. */
+const PROBE_CONSISTENT_MIN_LEN = 8;
+
 export function parseProbeResponse(raw: Uint8Array): ParsedProbeResponse {
   return {
     jedec: [raw[0] ?? 0, raw[1] ?? 0, raw[2] ?? 0],
     familyCode: raw[8] ?? 0,
     jedecConsistent:
-      raw[0] === raw[5] && raw[1] === raw[6] && raw[2] === raw[7],
+      raw.length >= PROBE_CONSISTENT_MIN_LEN &&
+      raw[0] === raw[5] &&
+      raw[1] === raw[6] &&
+      raw[2] === raw[7],
   };
 }

--- a/src/lib/drivers/sms4/sms4-chip-database.ts
+++ b/src/lib/drivers/sms4/sms4-chip-database.ts
@@ -15,9 +15,9 @@
  * not recognized by the device's built-in chip-detection logic.
  *
  * The specific-chip table below is retained for:
- *   - The UI override dropdown (so the user can pick a specific chip)
  *   - Future write support (per-chip page-program + erase opcodes differ)
  *   - Cross-validation when family inference is uncertain
+ *   - Future per-chip override UI (not yet wired)
  */
 
 export interface SaveChipFamily {
@@ -85,8 +85,8 @@ export const SAVE_CHIP_FAMILIES: readonly SaveChipFamily[] = [
   // with device-type 0x50 land here when that doesn't match the more-
   // specific families above. Uses M25P-class read opcodes (0x03), which
   // work universally on Numonyx-derived SPI flashes regardless of
-  // device-type sub-family. Page-program / erase opcodes are best-
-  // effort and may need overriding via the UI dropdown for writes.
+  // device-type sub-family. Page-program / erase opcodes are best-effort
+  // for any future write support.
   {
     name: "Generic Numonyx SPI flash",
     manufacturer: 0x20,
@@ -122,8 +122,8 @@ export function decodeSpiCapacityByte(b: number): number {
  *   - Authoritative size info that contradicts the generic decoder
  *     (e.g. Sanyo LE25FW chips encode size differently)
  *   - Exact-match override before family fallback
- *   - UI dropdown options
  *   - Future write support (specific chip's exact opcodes)
+ *   - Future per-chip override UI (not yet wired)
  */
 export interface SaveChipDef {
   name: string;
@@ -177,9 +177,11 @@ export const SAVE_CHIPS: readonly SaveChipDef[] = [
  *   - "eeprom-family" — chip didn't answer JEDEC RDID (M95-family
  *     EEPROMs don't), but the SMS4 firmware classified it via its
  *     family-code byte (0x01 = small EEPROM, 0x02 = medium EEPROM).
- *     EXACT SIZE is undetermined without a wrap-probe — `sizeBytes`
- *     is 0 and the UI should require the user to pick from the M95
- *     options in the dropdown before dumping.
+ *     `sizeBytes` is 0 at this point; the driver runs a wrap-probe
+ *     after `identifyByJedec` returns to refine size, promoting
+ *     `source` to `wrap-probed` on success.
+ *   - "wrap-probed" — size determined by reading at candidate sz-1
+ *     offsets and observing address-bus aliasing back to offset 0.
  *   - "unknown" — neither JEDEC nor family code matched anything.
  */
 export interface ChipIdentification {
@@ -212,10 +214,9 @@ export interface ChipIdentification {
  *      be 0xFF 0xFF 0xFF since M95s ignore SPI 0x9F)
  *   4. Unknown
  *
- * For the `eeprom-family` path we return `sizeBytes: 0` because exact
- * size needs a wrap-probe (write markers, read back, observe aliasing)
- * which we haven't implemented yet — the UI should force the user to
- * pick from the M95 options in the override dropdown.
+ * For the `eeprom-family` path we return `sizeBytes: 0` — the caller
+ * (the driver) runs a wrap-probe to refine size by observing address-
+ * bus aliasing at standard candidate offsets.
  */
 export function identifyByJedec(
   jedec: readonly [number, number, number],
@@ -293,7 +294,7 @@ export function identifyByJedec(
   if (familyCode === 0x02) {
     // Medium EEPROMs: M95080 / M95128 / M95256 / M95512 / M95M01. Pick
     // M95512 (64 KB) as the default — it's the most common medium-size
-    // DS save chip; user can override via the dropdown.
+    // DS save chip. The driver's wrap-probe refines size after this call.
     const medium = SAVE_CHIPS.find((c) => c.name.startsWith("M95512"));
     return {
       source: "eeprom-family",
@@ -311,8 +312,8 @@ export function identifyByJedec(
   }
 
   // No identification at all. Default to FLASH for the read path since
-  // the SPI READ DATA opcode (0x03) works on FLASH and the user can
-  // adjust size via the dropdown.
+  // the SPI READ DATA opcode (0x03) works on FLASH. Size stays at 0;
+  // readSave will throw rather than dump garbage.
   return {
     source: "unknown",
     jedec,

--- a/src/lib/drivers/sms4/sms4-chip-database.ts
+++ b/src/lib/drivers/sms4/sms4-chip-database.ts
@@ -1,0 +1,355 @@
+/**
+ * SMS4 save-chip identification.
+ *
+ * The chip identifier is a 3-byte JEDEC RDID response: manufacturer +
+ * device-type + capacity. We extract two pieces of information from it:
+ *
+ *   1. **Family** — `(manufacturer, device-type)` → protocol family that
+ *      shares a single 14-byte command-table template. Most NDS save chips
+ *      fall into one of ~4 families (M25P / M25PE / M45PE / LE25FW).
+ *   2. **Size** — `capacity` byte → bytes via the standard JEDEC encoding
+ *      (`1 << (cap - 0x11) * 128 KB` for Numonyx-class chips).
+ *
+ * That decoder handles every chip the SMS4 hardware supports AND any
+ * future chip in a known family, even one whose specific JEDEC ID is
+ * not recognized by the device's built-in chip-detection logic.
+ *
+ * The specific-chip table below is retained for:
+ *   - The UI override dropdown (so the user can pick a specific chip)
+ *   - Future write support (per-chip page-program + erase opcodes differ)
+ *   - Cross-validation when family inference is uncertain
+ */
+
+export interface SaveChipFamily {
+  /** Human-readable family name shown in the UI. */
+  name: string;
+  /** Expected JEDEC manufacturer byte (byte 0). */
+  manufacturer: number;
+  /**
+   * Predicate on the JEDEC device-type byte (byte 1). Most families
+   * pin it to a single value; some span a range.
+   */
+  matchesDeviceType: (deviceType: number) => boolean;
+  /**
+   * 14-byte SPI command-table template that the SMS4 firmware uses to
+   * drive the chip's SPI lines. Byte 0 is the flag/family selector
+   * (`0x07` for standard SPI, `0x0F` for Sanyo-style). The rest is
+   * chip-specific opcodes (READ, WREN, RDSR, page-program, etc.).
+   * For READ-ONLY operations, the relevant byte is `[1]` (READ DATA
+   * opcode = `0x03` on every supported family).
+   */
+  cmdTable: readonly number[];
+  /** Default flag bit assumed when no chip-specific override exists. */
+  defaultFlag: 0x07 | 0x0f;
+}
+
+/**
+ * SPI-flash family templates. Order matters for matching: more-specific
+ * predicates come before more-permissive ones.
+ */
+export const SAVE_CHIP_FAMILIES: readonly SaveChipFamily[] = [
+  // Numonyx M25PE-class (page-erasable, smaller pages, write opcode 0x0A)
+  // Device type 0x80.
+  {
+    name: "M25PE-class",
+    manufacturer: 0x20,
+    matchesDeviceType: (b) => b === 0x80,
+    cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7],
+    defaultFlag: 0x07,
+  },
+  // Numonyx M45PE-class (similar to M25PE but device type 0x40).
+  {
+    name: "M45PE-class",
+    manufacturer: 0x20,
+    matchesDeviceType: (b) => b === 0x40,
+    cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7],
+    defaultFlag: 0x07,
+  },
+  // Numonyx M25P-class (standard SPI flash, write opcode 0x02, device type 0x20).
+  {
+    name: "M25P-class",
+    manufacturer: 0x20,
+    matchesDeviceType: (b) => b === 0x20,
+    cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7],
+    defaultFlag: 0x07,
+  },
+  // Sanyo LE25FW-class (manufacturer 0x62, distinct protocol byte 0x0F).
+  {
+    name: "LE25FW-class",
+    manufacturer: 0x62,
+    matchesDeviceType: () => true,
+    cmdTable: [0x0f, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x00, 0x03, 0x05, 0x06, 0x00, 0x0a, 0xd8],
+    defaultFlag: 0x0f,
+  },
+  // Fallback Numonyx (any device type). Test carts seen in the wild
+  // with device-type 0x50 land here when that doesn't match the more-
+  // specific families above. Uses M25P-class read opcodes (0x03), which
+  // work universally on Numonyx-derived SPI flashes regardless of
+  // device-type sub-family. Page-program / erase opcodes are best-
+  // effort and may need overriding via the UI dropdown for writes.
+  {
+    name: "Generic Numonyx SPI flash",
+    manufacturer: 0x20,
+    matchesDeviceType: () => true,
+    cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7],
+    defaultFlag: 0x07,
+  },
+];
+
+/**
+ * Decode the JEDEC capacity byte (byte 2) into bytes. Returns 0 for
+ * unrecognized capacity codes.
+ *
+ * Encoding for Numonyx-class chips:
+ *   0x11 → 128 KB (1 Mbit)
+ *   0x12 → 256 KB (2 Mbit)
+ *   0x13 → 512 KB (4 Mbit)
+ *   0x14 → 1 MB  (8 Mbit)
+ *   0x15 → 2 MB  (16 Mbit)
+ *   0x16 → 4 MB  (32 Mbit)
+ *   0x17 → 8 MB  (64 Mbit)
+ *
+ * Sanyo LE25FW uses a different scheme; see SAVE_CHIPS table for
+ * specific entries.
+ */
+export function decodeSpiCapacityByte(b: number): number {
+  if (b < 0x11 || b > 0x18) return 0;
+  return 128 * 1024 * (1 << (b - 0x11));
+}
+
+/**
+ * Specific chips, indexed by exact 3-byte JEDEC ID. Used for:
+ *   - Authoritative size info that contradicts the generic decoder
+ *     (e.g. Sanyo LE25FW chips encode size differently)
+ *   - Exact-match override before family fallback
+ *   - UI dropdown options
+ *   - Future write support (specific chip's exact opcodes)
+ */
+export interface SaveChipDef {
+  name: string;
+  sizeBytes: number;
+  pageSize: number;
+  cmdTable: readonly number[];
+  /** 3-byte JEDEC RDID response, or undefined for M95-class EEPROMs
+   *  (which need wrap-probe identification rather than JEDEC). */
+  jedecId?: readonly [number, number, number];
+}
+
+export const SAVE_CHIPS: readonly SaveChipDef[] = [
+  // ─── Numonyx M25P (standard SPI flash) ─────────────────────────────
+  { name: "M25P80",  sizeBytes: 1 * 1024 * 1024, pageSize: 256, jedecId: [0x20, 0x20, 0x14], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7] },
+  { name: "M25P64",  sizeBytes: 8 * 1024 * 1024, pageSize: 256, jedecId: [0x20, 0x20, 0x17], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xd8] },
+  // ─── Numonyx M25PE (pageable, smaller pages) ───────────────────────
+  { name: "M25PE10", sizeBytes:       128 * 1024, pageSize: 256, jedecId: [0x20, 0x80, 0x11], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7] },
+  { name: "M25PE20", sizeBytes:       256 * 1024, pageSize: 256, jedecId: [0x20, 0x80, 0x12], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7] },
+  { name: "M25PE40", sizeBytes:       512 * 1024, pageSize: 256, jedecId: [0x20, 0x80, 0x13], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7] },
+  { name: "M25PE80", sizeBytes: 1 * 1024 * 1024, pageSize: 256, jedecId: [0x20, 0x80, 0x14], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7] },
+  { name: "M25PE16", sizeBytes: 2 * 1024 * 1024, pageSize: 256, jedecId: [0x20, 0x80, 0x15], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7] },
+  // ─── Micron M45PE sibling family ───────────────────────────────────
+  { name: "M45PE10", sizeBytes:       128 * 1024, pageSize: 256, jedecId: [0x20, 0x40, 0x11], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7] },
+  { name: "M45PE20", sizeBytes:       256 * 1024, pageSize: 256, jedecId: [0x20, 0x40, 0x12], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7] },
+  { name: "M45PE40", sizeBytes:       512 * 1024, pageSize: 256, jedecId: [0x20, 0x40, 0x13], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x00, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xd8] },
+  { name: "M45PE80", sizeBytes: 1 * 1024 * 1024, pageSize: 256, jedecId: [0x20, 0x40, 0x14], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xdb] },
+  { name: "M45PE16", sizeBytes: 2 * 1024 * 1024, pageSize: 256, jedecId: [0x20, 0x40, 0x15], cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x0a, 0xc7] },
+  // ─── Sanyo LE25FW (different protocol byte = 0x0F) ─────────────────
+  { name: "LE25FW203", sizeBytes:       256 * 1024, pageSize: 256, jedecId: [0x62, 0x16, 0x00], cmdTable: [0x0f, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x00, 0x03, 0x05, 0x06, 0x00, 0x0a, 0xd8] },
+  { name: "LE25FW206", sizeBytes:       256 * 1024, pageSize: 256, jedecId: [0x62, 0x42, 0x00], cmdTable: [0x0f, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x00, 0x03, 0x05, 0x06, 0x00, 0x0a, 0xd8] },
+  { name: "LE25FW403", sizeBytes:       512 * 1024, pageSize: 256, jedecId: [0x62, 0x11, 0x00], cmdTable: [0x0f, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x00, 0x03, 0x05, 0x06, 0x00, 0x0a, 0xd8] },
+  { name: "LE25FW806", sizeBytes: 1 * 1024 * 1024, pageSize: 256, jedecId: [0x62, 0x26, 0x00], cmdTable: [0x0f, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x00, 0x03, 0x05, 0x06, 0x00, 0x0a, 0xd8] },
+  // ─── M95 EEPROMs (no JEDEC; wrap-probe required) ───────────────────
+  { name: "M95040", sizeBytes: 512,         pageSize: 16,  cmdTable: [0x01, 0x01, 0x0f, 0x00, 0xff, 0xff, 0x00, 0x06, 0x0b, 0x05, 0x06, 0x01, 0x02, 0xc7] },
+  { name: "M95080", sizeBytes: 1024,        pageSize: 32,  cmdTable: [0x01, 0x02, 0x1f, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7] },
+  { name: "M95128", sizeBytes: 16 * 1024,   pageSize: 64,  cmdTable: [0x01, 0x02, 0x3f, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7] },
+  { name: "M95256", sizeBytes: 32 * 1024,   pageSize: 64,  cmdTable: [0x01, 0x02, 0x3f, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7] },
+  { name: "M95512", sizeBytes: 64 * 1024,   pageSize: 128, cmdTable: [0x01, 0x02, 0x7f, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7] },
+  { name: "M95M01", sizeBytes: 128 * 1024,  pageSize: 256, cmdTable: [0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7] },
+];
+
+/**
+ * Result of identifying a save chip from a JEDEC probe response.
+ *
+ * `source` records how we arrived at the identification:
+ *   - "exact" — JEDEC bytes matched a specific chip in our database
+ *     verbatim. Highest confidence; both read and write should work.
+ *   - "family" — JEDEC manufacturer + device-type matched a known SPI
+ *     family template, capacity decoded from byte 2. Reads should work
+ *     via the family's read opcode (0x03 for all supported families).
+ *   - "eeprom-family" — chip didn't answer JEDEC RDID (M95-family
+ *     EEPROMs don't), but the SMS4 firmware classified it via its
+ *     family-code byte (0x01 = small EEPROM, 0x02 = medium EEPROM).
+ *     EXACT SIZE is undetermined without a wrap-probe — `sizeBytes`
+ *     is 0 and the UI should require the user to pick from the M95
+ *     options in the dropdown before dumping.
+ *   - "unknown" — neither JEDEC nor family code matched anything.
+ */
+export interface ChipIdentification {
+  source: "exact" | "family" | "eeprom-family" | "wrap-probed" | "unknown";
+  jedec: readonly [number, number, number];
+  /** SMS4 firmware's family classification byte (probe response byte 8). */
+  familyCode: number;
+  /** Memory kind for the UI. EEPROM = M95-family (familyCode 0x01 / 0x02);
+   *  FLASH = SPI flash with JEDEC RDID (M25P / M25PE / M45PE / LE25FW). */
+  kind: "EEPROM" | "FLASH";
+  /** Display name — specific chip if "exact"; family if "family"; "M95
+   *  EEPROM" for eeprom-family / wrap-probed. */
+  name: string;
+  /** Chip capacity in bytes. 0 if size couldn't be determined from the
+   *  probe alone (eeprom-family case requires wrap-probe). */
+  sizeBytes: number;
+  pageSize: number;
+  cmdTable: readonly number[];
+  /** Flag bit to patch into byte 0 of the command-table region. */
+  flag: 0x07 | 0x0f;
+}
+
+/**
+ * Identify a save chip from the parsed JEDEC + family-code probe result.
+ *
+ * Resolution order (most-specific to least):
+ *   1. Exact match against a chip's specific JEDEC ID
+ *   2. SPI family inference (manufacturer + device-type)
+ *   3. M95 EEPROM family from firmware's family-code byte (JEDEC will
+ *      be 0xFF 0xFF 0xFF since M95s ignore SPI 0x9F)
+ *   4. Unknown
+ *
+ * For the `eeprom-family` path we return `sizeBytes: 0` because exact
+ * size needs a wrap-probe (write markers, read back, observe aliasing)
+ * which we haven't implemented yet — the UI should force the user to
+ * pick from the M95 options in the override dropdown.
+ */
+export function identifyByJedec(
+  jedec: readonly [number, number, number],
+  familyCode: number,
+): ChipIdentification {
+  const jedecLooksReal =
+    jedec[0] !== 0xff && jedec[0] !== 0x00 && jedec[0] !== undefined;
+
+  // Pass 1: exact JEDEC match.
+  if (jedecLooksReal) {
+    for (const c of SAVE_CHIPS) {
+      if (!c.jedecId) continue;
+      if (
+        c.jedecId[0] === jedec[0] &&
+        c.jedecId[1] === jedec[1] &&
+        c.jedecId[2] === jedec[2]
+      ) {
+        return {
+          source: "exact",
+          jedec,
+          familyCode,
+          kind: c.name.startsWith("M95") ? "EEPROM" : "FLASH",
+          name: c.name,
+          sizeBytes: c.sizeBytes,
+          pageSize: c.pageSize,
+          cmdTable: c.cmdTable,
+          flag: c.cmdTable[0] === 0x0f ? 0x0f : 0x07,
+        };
+      }
+    }
+  }
+
+  // Pass 2: SPI family inference from JEDEC.
+  if (jedecLooksReal) {
+    for (const f of SAVE_CHIP_FAMILIES) {
+      if (f.manufacturer !== jedec[0]) continue;
+      if (!f.matchesDeviceType(jedec[1])) continue;
+      const sizeBytes = decodeSpiCapacityByte(jedec[2]);
+      if (sizeBytes === 0) continue;
+      return {
+        source: "family",
+        jedec,
+        familyCode,
+        kind: "FLASH",
+        name: f.name,
+        sizeBytes,
+        pageSize: 256,
+        cmdTable: f.cmdTable,
+        flag: f.defaultFlag,
+      };
+    }
+  }
+
+  // Pass 3: M95 EEPROM family from firmware's family-code byte. Used
+  // when JEDEC is all-FF (chip doesn't respond to 0x9F) but the SMS4
+  // firmware probed something else and classified it.
+  if (familyCode === 0x01) {
+    // Tiny EEPROMs (M95040 + sub-sizes). Use the M95040 cmd table as a
+    // safe default; the wrap-probe later would refine the exact size.
+    const tiny = SAVE_CHIPS.find((c) => c.name.startsWith("M95040"));
+    return {
+      source: "eeprom-family",
+      jedec,
+      familyCode,
+      kind: "EEPROM",
+      name: "M95 EEPROM",
+      sizeBytes: 0,
+      pageSize: tiny?.pageSize ?? 16,
+      cmdTable:
+        tiny?.cmdTable ??
+        [0x01, 0x01, 0x0f, 0x00, 0xff, 0xff, 0x00, 0x06, 0x0b, 0x05, 0x06, 0x01, 0x02, 0xc7],
+      flag: 0x07,
+    };
+  }
+  if (familyCode === 0x02) {
+    // Medium EEPROMs: M95080 / M95128 / M95256 / M95512 / M95M01. Pick
+    // M95512 (64 KB) as the default — it's the most common medium-size
+    // DS save chip; user can override via the dropdown.
+    const medium = SAVE_CHIPS.find((c) => c.name.startsWith("M95512"));
+    return {
+      source: "eeprom-family",
+      jedec,
+      familyCode,
+      kind: "EEPROM",
+      name: "M95 EEPROM",
+      sizeBytes: 0,
+      pageSize: medium?.pageSize ?? 128,
+      cmdTable:
+        medium?.cmdTable ??
+        [0x01, 0x02, 0x7f, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01, 0x02, 0xc7],
+      flag: 0x07,
+    };
+  }
+
+  // No identification at all. Default to FLASH for the read path since
+  // the SPI READ DATA opcode (0x03) works on FLASH and the user can
+  // adjust size via the dropdown.
+  return {
+    source: "unknown",
+    jedec,
+    familyCode,
+    kind: "FLASH",
+    name: "Unknown chip",
+    sizeBytes: 0,
+    pageSize: 256,
+    cmdTable: SAVE_CHIP_FAMILIES[0]!.cmdTable,
+    flag: 0x07,
+  };
+}
+
+/**
+ * Parse a raw 9-byte `60 A0` probe response into structured fields.
+ *
+ * Layout (confirmed empirically with a Numonyx 0x20/0x50 capacity-0x12
+ * test cart returning `20 50 12 00 00 20 50 12 03`):
+ *   bytes 0..2 — JEDEC ID (manufacturer + device-type + capacity)
+ *   bytes 3..4 — padding / extended-ID space (typically 00 00)
+ *   bytes 5..7 — JEDEC ID repeated (firmware-internal verification)
+ *   byte 8     — family code (0x01 / 0x02 / 0x03 / other)
+ */
+export interface ParsedProbeResponse {
+  jedec: readonly [number, number, number];
+  /** Family code byte. 0x03 = SPI flash with JEDEC (most retail carts). */
+  familyCode: number;
+  /** True if bytes 0..2 match bytes 5..7 — sanity check that the
+   *  firmware's two reads agree on the chip ID. */
+  jedecConsistent: boolean;
+}
+
+export function parseProbeResponse(raw: Uint8Array): ParsedProbeResponse {
+  return {
+    jedec: [raw[0] ?? 0, raw[1] ?? 0, raw[2] ?? 0],
+    familyCode: raw[8] ?? 0,
+    jedecConsistent:
+      raw[0] === raw[5] && raw[1] === raw[6] && raw[2] === raw[7],
+  };
+}

--- a/src/lib/drivers/sms4/sms4-commands.test.ts
+++ b/src/lib/drivers/sms4/sms4-commands.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCartPacket,
+  buildSaveReadPacket,
+  ntrGetChipId,
+  ntrReadHeader,
+  NTR_CMD,
+  PACKET_LEN,
+  PACKET_OPCODE,
+  SUBCMD,
+} from "./sms4-commands";
+
+describe("buildCartPacket", () => {
+  it("produces a 32-byte packet", () => {
+    const pkt = buildCartPacket({
+      ntrCmd: ntrReadHeader(),
+      responseLen: 0x200,
+    });
+    expect(pkt.length).toBe(PACKET_LEN);
+    expect(PACKET_LEN).toBe(32);
+  });
+
+  it("leads with opcode 0x60 0xA5", () => {
+    const pkt = buildCartPacket({
+      ntrCmd: ntrReadHeader(),
+      responseLen: 0,
+    });
+    expect(pkt[0]).toBe(PACKET_OPCODE[0]);
+    expect(pkt[1]).toBe(PACKET_OPCODE[1]);
+    expect(pkt[0]).toBe(0x60);
+    expect(pkt[1]).toBe(0xa5);
+  });
+
+  it("encodes responseLen at bytes 6..9 LE", () => {
+    const pkt = buildCartPacket({
+      ntrCmd: ntrReadHeader(),
+      responseLen: 0x12345678,
+    });
+    expect(pkt[6]).toBe(0x78);
+    expect(pkt[7]).toBe(0x56);
+    expect(pkt[8]).toBe(0x34);
+    expect(pkt[9]).toBe(0x12);
+  });
+
+  it("encodes extra (optional offset) at bytes 2..5 LE; defaults to 0", () => {
+    const def = buildCartPacket({
+      ntrCmd: ntrReadHeader(),
+      responseLen: 0,
+    });
+    expect([def[2], def[3], def[4], def[5]]).toEqual([0, 0, 0, 0]);
+
+    const set = buildCartPacket({
+      ntrCmd: ntrReadHeader(),
+      responseLen: 0,
+      extra: 0xdeadbeef,
+    });
+    expect(set[2]).toBe(0xef);
+    expect(set[3]).toBe(0xbe);
+    expect(set[4]).toBe(0xad);
+    expect(set[5]).toBe(0xde);
+  });
+
+  it("places the NTR command at bytes 11..18 (big-endian on-the-wire)", () => {
+    const cmd = new Uint8Array([0x90, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77]);
+    const pkt = buildCartPacket({ ntrCmd: cmd, responseLen: 0 });
+    expect(Array.from(pkt.subarray(11, 19))).toEqual(Array.from(cmd));
+  });
+
+  it("places SUBCMD at byte 19 — defaults to NORMAL, accepts RESET", () => {
+    const def = buildCartPacket({
+      ntrCmd: ntrReadHeader(),
+      responseLen: 0,
+    });
+    expect(def[19]).toBe(SUBCMD.NORMAL);
+    expect(def[19]).toBe(0);
+
+    const reset = buildCartPacket({
+      ntrCmd: new Uint8Array(8),
+      responseLen: 0,
+      subcmd: SUBCMD.RESET,
+    });
+    expect(reset[19]).toBe(SUBCMD.RESET);
+    expect(reset[19]).toBe(0xf0);
+  });
+
+  it("clears the mode-flag byte at index 10 and zero-pads bytes 20..31", () => {
+    const pkt = buildCartPacket({
+      ntrCmd: new Uint8Array(8),
+      responseLen: 0,
+    });
+    expect(pkt[10]).toBe(0);
+    for (let i = 20; i < PACKET_LEN; i++) {
+      expect(pkt[i]).toBe(0);
+    }
+  });
+
+  it("rejects an ntrCmd that isn't exactly 8 bytes", () => {
+    expect(() =>
+      buildCartPacket({ ntrCmd: new Uint8Array(7), responseLen: 0 }),
+    ).toThrow();
+    expect(() =>
+      buildCartPacket({ ntrCmd: new Uint8Array(9), responseLen: 0 }),
+    ).toThrow();
+  });
+});
+
+describe("ntrReadHeader / ntrGetChipId", () => {
+  it("ntrReadHeader returns 8 zero bytes (opcode 0x00 + 7 zeros)", () => {
+    const c = ntrReadHeader();
+    expect(c.length).toBe(8);
+    expect(Array.from(c)).toEqual([0, 0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it("ntrGetChipId places the chip-id opcode (0x90) at byte 0, rest zero", () => {
+    const c = ntrGetChipId();
+    expect(c.length).toBe(8);
+    expect(c[0]).toBe(NTR_CMD.GET_CHIP_ID);
+    expect(c[0]).toBe(0x90);
+    expect(Array.from(c.subarray(1))).toEqual([0, 0, 0, 0, 0, 0, 0]);
+  });
+});
+
+describe("buildSaveReadPacket", () => {
+  const cmdTable: readonly number[] = [
+    0x01, 0x03, 0xff, 0x00, 0xff, 0xff, 0x00, 0x06, 0x03, 0x05, 0x06, 0x01,
+    0x02, 0xc7,
+  ];
+
+  it("produces a 32-byte packet leading with 0x60 0xA2", () => {
+    const pkt = buildSaveReadPacket({
+      cmdTable,
+      flag: 0x07,
+      address: 0,
+      length: 256,
+    });
+    expect(pkt.length).toBe(PACKET_LEN);
+    expect(pkt[0]).toBe(0x60);
+    expect(pkt[1]).toBe(0xa2);
+  });
+
+  it("encodes address at bytes 2..5 LE", () => {
+    const pkt = buildSaveReadPacket({
+      cmdTable,
+      flag: 0x07,
+      address: 0x000123ab,
+      length: 16,
+    });
+    expect(pkt[2]).toBe(0xab);
+    expect(pkt[3]).toBe(0x23);
+    expect(pkt[4]).toBe(0x01);
+    expect(pkt[5]).toBe(0x00);
+  });
+
+  it("encodes length at bytes 6..9 LE", () => {
+    const pkt = buildSaveReadPacket({
+      cmdTable,
+      flag: 0x07,
+      address: 0,
+      length: 0xffff,
+    });
+    expect(pkt[6]).toBe(0xff);
+    expect(pkt[7]).toBe(0xff);
+    expect(pkt[8]).toBe(0x00);
+    expect(pkt[9]).toBe(0x00);
+  });
+
+  it("places the flag byte at index 10", () => {
+    const a = buildSaveReadPacket({
+      cmdTable,
+      flag: 0x07,
+      address: 0,
+      length: 16,
+    });
+    expect(a[10]).toBe(0x07);
+
+    const b = buildSaveReadPacket({
+      cmdTable,
+      flag: 0x0f,
+      address: 0,
+      length: 16,
+    });
+    expect(b[10]).toBe(0x0f);
+  });
+
+  it("copies cmdTable[1..13] to packet bytes 11..23", () => {
+    const pkt = buildSaveReadPacket({
+      cmdTable,
+      flag: 0x07,
+      address: 0,
+      length: 16,
+    });
+    for (let i = 1; i < 14; i++) {
+      expect(pkt[10 + i]).toBe(cmdTable[i]);
+    }
+  });
+
+  it("zero-pads bytes 24..31", () => {
+    const pkt = buildSaveReadPacket({
+      cmdTable,
+      flag: 0x07,
+      address: 0,
+      length: 16,
+    });
+    for (let i = 24; i < PACKET_LEN; i++) {
+      expect(pkt[i]).toBe(0);
+    }
+  });
+
+  it("rejects a cmdTable that isn't exactly 14 bytes", () => {
+    expect(() =>
+      buildSaveReadPacket({
+        cmdTable: cmdTable.slice(0, 13),
+        flag: 0x07,
+        address: 0,
+        length: 16,
+      }),
+    ).toThrow();
+    expect(() =>
+      buildSaveReadPacket({
+        cmdTable: [...cmdTable, 0x00],
+        flag: 0x07,
+        address: 0,
+        length: 16,
+      }),
+    ).toThrow();
+  });
+});

--- a/src/lib/drivers/sms4/sms4-commands.ts
+++ b/src/lib/drivers/sms4/sms4-commands.ts
@@ -1,0 +1,219 @@
+/**
+ * Neoflash SMS4 — protocol constants and packet builders.
+ *
+ * Wire model: vendor-specific USB device with bulk IN + bulk OUT plus a
+ * vendor control-transfer channel. Each cart-bus operation is a three-step
+ * sequence:
+ *   1. Control OUT 0xAA — set transfer length + direction
+ *   2. Control OUT 0xA0 (read) or 0xA1 (write) — init bulk channel
+ *   3. Bulk IN on EP 0x81 / bulk OUT on EP 0x02
+ *
+ * Cart-bus commands are 32-byte packets framed with opcode 0x60 0xA5
+ * sent over the bulk-OUT channel; the device executes the embedded
+ * 8-byte NDS slot-1 command and returns N bytes (specified in the
+ * packet header) on the next bulk-IN.
+ */
+
+export const SMS4_VID = 0xffab;
+export const SMS4_PID = 0xdd03;
+
+export const DEVICE_FILTERS = [{ vendorId: SMS4_VID, productId: SMS4_PID }];
+
+/**
+ * Bulk endpoint *numbers* (1-15) as WebUSB expects them on transferIn /
+ * transferOut. Direction is implicit in the WebUSB API: transferIn always
+ * targets an IN endpoint, transferOut always OUT. On the wire these
+ * correspond to USB descriptor addresses 0x81 (EP1 IN) and 0x02 (EP2 OUT).
+ */
+export const ENDPOINT = {
+  IN: 1,
+  OUT: 2,
+} as const;
+
+/**
+ * Vendor control-transfer opcodes (bRequest). All use bmRequestType
+ * 0x40 (vendor OUT) or 0xC0 (vendor IN).
+ */
+export const VENDOR_CTRL = {
+  /**
+   * "Open session" handshake (bmReqType=0xC0, wValue=0x0001, wLength=0,
+   * no data stage). Issued once per session. Without it the device
+   * firmware accepts cart packets but never produces responses — bulk
+   * INs hang waiting indefinitely.
+   */
+  OPEN_SESSION: 0xa3,
+  /**
+   * Query bulk status (bmReqType=0xC0, wValue=0x0001, returns 8 bytes).
+   * Used as a liveness check + firmware-version probe at init time, and
+   * polled after errors to wait for status byte 0 bit 3 ("ready") before
+   * retrying.
+   */
+  QUERY_STATUS: 0xa2,
+} as const;
+
+/**
+ * Cart-bus command packet — 32 bytes.
+ *
+ * The device wraps every cart-bus operation in this 32-byte envelope.
+ * The leading `0x60 0xA5` opcode tells the firmware "this is a slot-1
+ * cart-bus passthrough"; bytes 11..18 carry the 8-byte NDS NTR command
+ * verbatim (big-endian on the wire); bytes 6..9 advertise how many
+ * bytes the cart will reply with on the next bulk-IN.
+ *
+ * Field map:
+ *   [ 0..1 ] = 0x60 0xA5  — cart-bus passthrough opcode
+ *   [ 2..5 ] = extra/addr (LE; often 0; some commands use it as an offset)
+ *   [ 6..9 ] = response length (LE; how many bytes to bulk-IN after)
+ *   [10    ] = mode flag (0 = standard cart cmd; firmware-specific other values exist)
+ *   [11..18] = 8-byte NDS NTR command (BE — cmd[0] is highest byte)
+ *   [19    ] = subcommand (0 = normal; 0xF0 = cart reset)
+ *   [20..31] = zero padding
+ */
+export const PACKET_LEN = 32;
+
+/** Lead bytes of every cart-bus passthrough packet. */
+export const PACKET_OPCODE = [0x60, 0xa5] as const;
+
+/** Save-chip JEDEC RDID probe lead bytes (0x60 0xA0). Response is 9 bytes:
+ *  family code + 3-byte JEDEC ID + flag bit + padding. Byte layout
+ *  established empirically against the SMS4 firmware. */
+export const PROBE_JEDEC_OPCODE = [0x60, 0xa0] as const;
+export const PROBE_JEDEC_RESPONSE_LEN = 9;
+
+/** Byte-19 subcommand selector. */
+export const SUBCMD = {
+  NORMAL: 0x00,
+  RESET: 0xf0,
+} as const;
+
+/**
+ * NDS NTR (slot-1) command bytes we exercise during header detection
+ * and chip-ID readout. Reference:
+ * https://problemkaputt.de/gbatek.htm#dscartridgeprotocol
+ */
+export const NTR_CMD = {
+  /** Read header bytes (post-reset). 8 bytes of zero. */
+  READ_HEADER: 0x00,
+  /** Get cart Chip ID, post-reset. 4 bytes returned. */
+  GET_CHIP_ID: 0x90,
+  /** Dummy / wake-up command. */
+  DUMMY: 0x9f,
+} as const;
+
+/** Status response from QUERY_STATUS — 8 bytes returned. */
+export const STATUS_RESPONSE_LEN = 8;
+
+/** NDS header is 0x200 bytes; smallest read that includes the CRC fields. */
+export const HEADER_LEN = 0x200;
+
+/** Chip ID response — 4 bytes from NTR 0x90. */
+export const CHIP_ID_LEN = 4;
+
+/**
+ * Build a 32-byte cart-bus packet.
+ *
+ *   ntrCmd:        the 8-byte NDS command to forward to the cart (LSB-first
+ *                  array; we BE-encode it into the packet).
+ *   responseLen:   number of bytes the cart will return on the next bulk-IN.
+ *   subcmd:        SUBCMD.NORMAL or SUBCMD.RESET.
+ *   extra:         optional 4-byte field at offset 2 (some commands use it
+ *                  as an offset; defaults to 0).
+ */
+export function buildCartPacket(opts: {
+  ntrCmd: Uint8Array;
+  responseLen: number;
+  subcmd?: number;
+  extra?: number;
+}): Uint8Array {
+  if (opts.ntrCmd.length !== 8) {
+    throw new Error(`ntrCmd must be 8 bytes, got ${opts.ntrCmd.length}`);
+  }
+  const pkt = new Uint8Array(PACKET_LEN);
+  pkt[0] = PACKET_OPCODE[0];
+  pkt[1] = PACKET_OPCODE[1];
+
+  const extra = opts.extra ?? 0;
+  pkt[2] = extra & 0xff;
+  pkt[3] = (extra >> 8) & 0xff;
+  pkt[4] = (extra >> 16) & 0xff;
+  pkt[5] = (extra >> 24) & 0xff;
+
+  pkt[6] = opts.responseLen & 0xff;
+  pkt[7] = (opts.responseLen >> 8) & 0xff;
+  pkt[8] = (opts.responseLen >> 16) & 0xff;
+  pkt[9] = (opts.responseLen >> 24) & 0xff;
+
+  pkt[10] = 0;
+
+  // NTR command is sent BIG-ENDIAN on the slot-1 bus, so cmd[0] (the
+  // opcode byte like 0x90) goes to the highest position.
+  pkt[11] = opts.ntrCmd[0];
+  pkt[12] = opts.ntrCmd[1];
+  pkt[13] = opts.ntrCmd[2];
+  pkt[14] = opts.ntrCmd[3];
+  pkt[15] = opts.ntrCmd[4];
+  pkt[16] = opts.ntrCmd[5];
+  pkt[17] = opts.ntrCmd[6];
+  pkt[18] = opts.ntrCmd[7];
+
+  pkt[19] = opts.subcmd ?? SUBCMD.NORMAL;
+  // bytes [20..31] remain zero from the Uint8Array initializer.
+
+  return pkt;
+}
+
+/** Build an 8-byte all-zero NTR header-read command. */
+export function ntrReadHeader(): Uint8Array {
+  return new Uint8Array(8);
+}
+
+/**
+ * Build a 32-byte `60 A2` save-read packet. The SMS4 firmware uses the
+ * 14-byte `cmdTable` to drive the cart's save-chip SPI lines (cmdTable[1]
+ * is typically the SPI READ DATA opcode, byte 0 is the flag/family
+ * selector that we patch at runtime).
+ *
+ * Packet layout:
+ *   bytes 0..1   60 A2          save-read opcode
+ *   bytes 2..5   address LE     where to start reading on the chip
+ *   bytes 6..9   length  LE     how many bytes to return
+ *   byte 10      flag (0x07 / 0x0F)   patched from cmdTable[0]
+ *   bytes 11..23 cmdTable[1..13]      rest of the SPI command sequence
+ *   bytes 24..31 zero padding
+ */
+export function buildSaveReadPacket(opts: {
+  cmdTable: readonly number[];
+  flag: 0x07 | 0x0f;
+  address: number;
+  length: number;
+}): Uint8Array {
+  if (opts.cmdTable.length !== 14) {
+    throw new Error(
+      `cmdTable must be 14 bytes, got ${opts.cmdTable.length}`,
+    );
+  }
+  const pkt = new Uint8Array(PACKET_LEN);
+  pkt[0] = 0x60;
+  pkt[1] = 0xa2;
+  pkt[2] = opts.address & 0xff;
+  pkt[3] = (opts.address >> 8) & 0xff;
+  pkt[4] = (opts.address >> 16) & 0xff;
+  pkt[5] = (opts.address >> 24) & 0xff;
+  pkt[6] = opts.length & 0xff;
+  pkt[7] = (opts.length >> 8) & 0xff;
+  pkt[8] = (opts.length >> 16) & 0xff;
+  pkt[9] = (opts.length >> 24) & 0xff;
+  pkt[10] = opts.flag;
+  // cmdTable[1..13] → packet bytes 11..23
+  for (let i = 1; i < 14; i++) {
+    pkt[10 + i] = opts.cmdTable[i]!;
+  }
+  return pkt;
+}
+
+/** Build an 8-byte NTR Get-Chip-ID command (opcode 0x90 + 7 zeros). */
+export function ntrGetChipId(): Uint8Array {
+  const c = new Uint8Array(8);
+  c[0] = NTR_CMD.GET_CHIP_ID;
+  return c;
+}

--- a/src/lib/drivers/sms4/sms4-commands.ts
+++ b/src/lib/drivers/sms4/sms4-commands.ts
@@ -1,17 +1,6 @@
 /**
- * Neoflash SMS4 — protocol constants and packet builders.
- *
- * Wire model: vendor-specific USB device with bulk IN + bulk OUT plus a
- * vendor control-transfer channel. Each cart-bus operation is a three-step
- * sequence:
- *   1. Control OUT 0xAA — set transfer length + direction
- *   2. Control OUT 0xA0 (read) or 0xA1 (write) — init bulk channel
- *   3. Bulk IN on EP 0x81 / bulk OUT on EP 0x02
- *
- * Cart-bus commands are 32-byte packets framed with opcode 0x60 0xA5
- * sent over the bulk-OUT channel; the device executes the embedded
- * 8-byte NDS slot-1 command and returns N bytes (specified in the
- * packet header) on the next bulk-IN.
+ * Neoflash SMS4 — protocol constants and packet builders. See
+ * `sms4-driver.ts` for the wire-level protocol description.
  */
 
 export const SMS4_VID = 0xffab;

--- a/src/lib/drivers/sms4/sms4-driver.ts
+++ b/src/lib/drivers/sms4/sms4-driver.ts
@@ -111,11 +111,7 @@ export class SMS4Driver implements NDSDeviceDriver {
   readonly id = "SMS4";
   readonly name = "Neoflash SMS4";
   readonly capabilities: DeviceCapability[] = [
-    {
-      systemId: "nds_save",
-      operations: [],
-      autoDetect: true,
-    },
+    { systemId: "nds_save", operations: ["dump_save"], autoDetect: true },
   ];
 
   readonly transport: UsbTransport;
@@ -266,8 +262,8 @@ export class SMS4Driver implements NDSDeviceDriver {
       this.cachedHeader = await this.readAndValidateHeader(headerReadLen);
       // Probe save chip JEDEC after header read. Best-effort: if the probe
       // fails or returns an unrecognized response, we still report the
-      // cart info; the UI lets the user pick a chip manually via the
-      // dropdown.
+      // cart info — readSave will throw rather than dump garbage if the
+      // chip stayed unknown.
       try {
         const probe = await this.probeJedec();
         const parsed = parseProbeResponse(probe);
@@ -312,15 +308,16 @@ export class SMS4Driver implements NDSDeviceDriver {
             this.log(
               `Wrap-probe didn't detect aliasing at any standard NDS ` +
                 `EEPROM size (512 B / 8 KB / 64 KB). Chip is larger or ` +
-                `non-standard — use the override dropdown.`,
+                `non-standard — this cart isn't currently dumpable with ` +
+                `the SMS4.`,
               "warn",
             );
           }
         } else {
           this.log(
             `Save-chip JEDEC probe: ${jedecStr}, family 0x${familyHex} — ` +
-              `chip not recognized by any family template. ` +
-              `Use the override dropdown to pick a similar chip.`,
+              `chip not recognized by any family template; this cart ` +
+              `isn't currently dumpable with the SMS4.`,
             "warn",
           );
         }
@@ -385,44 +382,38 @@ export class SMS4Driver implements NDSDeviceDriver {
    * lines accordingly and returns the page on bulk-IN; no chip-side state
    * machine is touched, so this is non-destructive.
    *
-   * `config.params` may carry an override `{ saveSize, cmdTable, flag }`
-   * (the scanner sends one when the user picks a chip in the dropdown);
-   * otherwise we fall back to whatever `cachedSaveChip` settled on during
-   * `detectCartridge`. If neither path supplies a usable cmd table, throw
-   * before issuing any USB transfers — better than reading 64 KB of 0xFF
-   * and writing it to disk.
+   * `config.params.saveSizeBytes` (if supplied by the caller) overrides
+   * the size auto-detected during `detectCartridge`; otherwise we fall
+   * back to `cachedSaveChip.sizeBytes`. If neither path yields a usable
+   * size or cmd table, throw before issuing any USB transfers — better
+   * than reading 64 KB of 0xFF and writing it to disk.
    */
   async readSave(
     config: ReadConfig,
     signal?: AbortSignal,
   ): Promise<Uint8Array> {
-    const override = config?.params as
-      | {
-          saveSize?: number;
-          cmdTable?: readonly number[];
-          flag?: 0x07 | 0x0f;
-        }
-      | undefined;
+    const overrideSize = config?.params?.saveSizeBytes as number | undefined;
 
-    const cmdTable = override?.cmdTable ?? this.cachedSaveChip?.cmdTable;
-    const flag = override?.flag ?? this.cachedSaveChip?.flag;
+    const cmdTable = this.cachedSaveChip?.cmdTable;
+    const flag = this.cachedSaveChip?.flag;
     const sizeBytes =
-      override?.saveSize ??
+      overrideSize ??
       (this.cachedSaveChip && this.cachedSaveChip.sizeBytes > 0
         ? this.cachedSaveChip.sizeBytes
         : 0);
 
     if (!cmdTable || cmdTable.length !== 14 || !flag) {
       throw new Error(
-        "Cannot read save: no save-chip identified. Insert a cart, wait for " +
-          "detection, then pick a chip from the override dropdown if " +
-          "auto-detect failed.",
+        "Cannot read save: no save-chip identified. Auto-detect didn't " +
+          "find a recognized chip — this cart isn't currently dumpable " +
+          "with the SMS4.",
       );
     }
     if (sizeBytes <= 0) {
       throw new Error(
-        "Cannot read save: save-chip size is unknown. Pick a specific chip " +
-          "in the override dropdown so we know how many bytes to read.",
+        "Cannot read save: save-chip size is unknown. Auto-detect couldn't " +
+          "determine the size — this cart isn't currently dumpable with " +
+          "the SMS4.",
       );
     }
 

--- a/src/lib/drivers/sms4/sms4-driver.ts
+++ b/src/lib/drivers/sms4/sms4-driver.ts
@@ -197,6 +197,7 @@ export class SMS4Driver implements NDSDeviceDriver {
         this.cartInited = false;
         this.cachedHeader = null;
         this.cachedChipId = "";
+        this.cachedSaveChip = null;
         // Best-effort cart reset so the next attempt isn't fighting a
         // half-initialized cart.
         try {
@@ -235,6 +236,22 @@ export class SMS4Driver implements NDSDeviceDriver {
     const chipIdHex = Array.from(chipId, hex).join(" ");
     this.log(`Chip ID: ${chipIdHex || "(empty)"}`);
 
+    // Short read = the device returned fewer bytes than the 4-byte chip-ID
+    // response should be. Treat it as a comm error (force a full reset next
+    // attempt) — pretending a partial response is a valid chip ID would
+    // mis-route downstream gating on chipId[3].
+    if (chipId.length !== 0 && chipId.length !== CHIP_ID_LEN) {
+      this.log(
+        `Chip ID short read: got ${chipId.length} bytes, expected ${CHIP_ID_LEN}.`,
+        "warn",
+      );
+      this.cartInited = false;
+      this.cachedHeader = null;
+      this.cachedChipId = "";
+      this.cachedSaveChip = null;
+      return null;
+    }
+
     if (isNoCart(chipId)) {
       const why =
         chipId.length === 0
@@ -245,6 +262,7 @@ export class SMS4Driver implements NDSDeviceDriver {
       this.log(why);
       this.cachedHeader = null;
       this.cachedChipId = "";
+      this.cachedSaveChip = null;
       // Force a full reset on the next attempt — if the cart was
       // hot-swapped, the new cart needs its own wake-up cycle.
       this.cartInited = false;
@@ -373,7 +391,10 @@ export class SMS4Driver implements NDSDeviceDriver {
     return this.buildCartInfo();
   }
 
-  async readROM(): Promise<Uint8Array> {
+  async readROM(
+    _config: ReadConfig,
+    _signal?: AbortSignal,
+  ): Promise<Uint8Array> {
     throw new Error(
       "SMS4: ROM dump is not implemented in this build (save preservation only).",
     );
@@ -449,7 +470,11 @@ export class SMS4Driver implements NDSDeviceDriver {
     return result;
   }
 
-  async writeSave(): Promise<void> {
+  async writeSave(
+    _data: Uint8Array,
+    _config: ReadConfig,
+    _signal?: AbortSignal,
+  ): Promise<void> {
     throw new Error("SMS4: save write is not implemented (read-only build).");
   }
 

--- a/src/lib/drivers/sms4/sms4-driver.ts
+++ b/src/lib/drivers/sms4/sms4-driver.ts
@@ -90,14 +90,15 @@ const RESET_SETTLE_MS = 1000;
 const HEADER_READ_RETRIES = 3;
 
 /**
- * Bytes per `0x60 0xA2` save-read packet. The firmware happily handles any
- * length the 32-bit field in the packet can describe, but smaller chunks
- * give smoother progress updates and bound the worst-case "save half-read,
- * then USB error" window. 256 B is one SPI flash page and a multiple of
- * every M95 EEPROM page (16 / 32 / 64 / 128), so chunks always align with
- * the chip's natural addressing.
+ * Bytes per `0x60 0xA2` save-read packet. The firmware handles any length
+ * the 32-bit field in the packet can describe; chunk size trades USB-
+ * roundtrip overhead (each chunk is bulk-OUT packet + ZLP + bulk-IN = 3
+ * transfers, each ~1 ms of WebUSB overhead) against progress-bar
+ * granularity and the worst-case "save half-read, then USB error" window.
+ * 16 KB is 64 SPI-flash pages and 128 M95 EEPROM pages (page size 128 B),
+ * still a multiple of every M95 page size (16 / 32 / 64 / 128).
  */
-const SAVE_READ_CHUNK = 256;
+const SAVE_READ_CHUNK = 16 * 1024;
 
 /**
  * NDS chip ID byte-3 bit 0x40 (= bit 30 of the LE u32) flags a DSi-

--- a/src/lib/drivers/sms4/sms4-driver.ts
+++ b/src/lib/drivers/sms4/sms4-driver.ts
@@ -154,16 +154,22 @@ export class SMS4Driver implements NDSDeviceDriver {
     this.log("Session opened (vendor request 0xA3).");
 
     // Liveness probe: 8-byte status response. If the device doesn't
-    // reply here, there's no point trying any cart op.
+    // reply here, there's no point trying any cart op. Status bytes
+    // don't carry a firmware-version field — log them as diagnostic,
+    // not as a version.
     const status = await this.queryStatus();
-    const fwHex = Array.from(status, hex).join(" ");
-    this.log(`Status: ${fwHex}`);
+    this.log(`Status: ${Array.from(status, hex).join(" ")}`);
+
+    // The real device-version marker is the USB descriptor's bcdDevice.
+    // The original Neoflash host software branches behaviour on the
+    // threshold `bcdDevice >= 0x1008`, dubbing the two eras "SP2" and
+    // "pre-SP2". We surface that classification as the firmwareVersion.
+    const bcd = this.transport.getBcdDevice();
+    const firmwareVersion =
+      bcd === null ? "" : bcd >= 0x1008 ? "SP2" : "pre-SP2";
 
     return {
-      // Status bytes don't have a canonical "firmware version" field —
-      // surface the raw hex so the user can flag a mismatch if we ever
-      // need a fw-gate.
-      firmwareVersion: fwHex,
+      firmwareVersion,
       deviceName: this.name,
       capabilities: this.capabilities,
     };

--- a/src/lib/drivers/sms4/sms4-driver.ts
+++ b/src/lib/drivers/sms4/sms4-driver.ts
@@ -1,0 +1,744 @@
+/**
+ * Neoflash SMS4 — device driver for Nintendo DS cartridges.
+ *
+ * Hardware
+ * ========
+ * Vendor-specific USB device, VID 0xFFAB PID 0xDD03. Board silkscreen
+ * "NEO NDS SMS4 V6G". Main MCU is chip-on-board (epoxy blob) so silicon
+ * ID is unrecoverable.
+ *
+ * Scope
+ * =====
+ * Save preservation only. detectCartridge reads the cart header (NTR
+ * cmd 0x00) and probes the save chip (JEDEC RDID via the SMS4
+ * firmware's `60 A0` shortcut). readSave drives the save chip via
+ * `60 A2` cart-bus passthrough with the family-appropriate SPI cmd
+ * table. ROM dumping and save writing are not implemented in this
+ * build.
+ *
+ * Wire-level model
+ * ================
+ * Session-open handshake (once, at initialize()):
+ *
+ *   • Control IN  0xC0 / 0xA3 / wValue=0x0001 / wIndex=0 / wLength=0.
+ *     Puts the firmware into "ready for cart commands" state — without
+ *     it, bulk transfers go through but the firmware never produces
+ *     responses.
+ *   • Control IN  0xC0 / 0xA2 / 0x0001 / 0 / wLength=8 — 8-byte
+ *     liveness probe.
+ *   • clearHalt on both bulk pipes (best-effort) to recover from a
+ *     prior aborted run that left an endpoint STALLed.
+ *
+ * Per cart-bus operation:
+ *
+ *   1. Bulk OUT on EP2 — 32-byte 0x60 0xA5 packet (NTR cmd at bytes
+ *      11..18 BE, response length at bytes 6..9 LE).
+ *   2. Bulk OUT on EP2 — Zero-Length Packet. The SMS4 firmware waits
+ *      for a ZLP to signal "end of transfer" before processing the
+ *      command. Without the ZLP the bulk IN hangs indefinitely.
+ *   3. Bulk IN  on EP1 — N bytes of cart response (chunked at 64 KB).
+ */
+
+import type {
+  DeviceCapability,
+  DeviceDriverEvents,
+  DeviceInfo,
+  DetectSystemResult,
+  DumpProgress,
+  ReadConfig,
+  SystemId,
+} from "@/lib/types";
+import type { UsbTransport } from "@/lib/transport/usb-transport";
+import {
+  ENDPOINT,
+  HEADER_LEN,
+  CHIP_ID_LEN,
+  NTR_CMD,
+  PROBE_JEDEC_OPCODE,
+  PROBE_JEDEC_RESPONSE_LEN,
+  STATUS_RESPONSE_LEN,
+  SUBCMD,
+  VENDOR_CTRL,
+  PACKET_LEN,
+  buildCartPacket,
+  buildSaveReadPacket,
+  ntrGetChipId,
+  ntrReadHeader,
+} from "./sms4-commands";
+import {
+  type ChipIdentification,
+  identifyByJedec,
+  parseProbeResponse,
+} from "./sms4-chip-database";
+import { formatBytes } from "@/lib/core/hashing";
+import { MAKER_CODES } from "@/lib/systems/nds/nds-maker-codes";
+import {
+  parseNDSHeader as parseNDSHeaderShared,
+  buildNDSCartInfoFromHeader,
+  type CardHeader,
+  type NDSCartridgeInfo,
+  type NDSDeviceDriver,
+} from "@/lib/systems/nds/nds-header";
+
+const parseNDSHeader = (raw: Uint8Array): CardHeader =>
+  parseNDSHeaderShared(raw, MAKER_CODES);
+
+/** SMS4 firmware needs ~1 s after a cart reset before the cart will respond. */
+const RESET_SETTLE_MS = 1000;
+
+/** Number of attempts to read a CRC-valid header before giving up. */
+const HEADER_READ_RETRIES = 3;
+
+/**
+ * Bytes per `0x60 0xA2` save-read packet. The firmware happily handles any
+ * length the 32-bit field in the packet can describe, but smaller chunks
+ * give smoother progress updates and bound the worst-case "save half-read,
+ * then USB error" window. 256 B is one SPI flash page and a multiple of
+ * every M95 EEPROM page (16 / 32 / 64 / 128), so chunks always align with
+ * the chip's natural addressing.
+ */
+const SAVE_READ_CHUNK = 256;
+
+/**
+ * NDS chip ID byte-3 bit 0x40 (= bit 30 of the LE u32) flags a DSi-
+ * Enhanced cart that needs 0x1000-byte header reads instead of 0x200.
+ */
+const CHIP_ID_DSI_4K_HEADER_BIT = 0x40;
+
+const hex = (b: number) => b.toString(16).padStart(2, "0");
+
+export class SMS4Driver implements NDSDeviceDriver {
+  readonly id = "SMS4";
+  readonly name = "Neoflash SMS4";
+  readonly capabilities: DeviceCapability[] = [
+    {
+      systemId: "nds_save",
+      operations: [],
+      autoDetect: true,
+    },
+  ];
+
+  readonly transport: UsbTransport;
+  private events: Partial<DeviceDriverEvents> = {};
+
+  /** True after a successful cart reset; cleared when the cart goes away. */
+  private cartInited = false;
+  /** Last chip-ID hex string we saw, to detect cart swap between detects. */
+  private cachedChipId = "";
+  /** Cached parsed header for the current chip-ID. */
+  private cachedHeader: CardHeader | null = null;
+  /** Chip identification (exact match, family inference, or unknown). */
+  private cachedSaveChip: ChipIdentification | null = null;
+
+  /**
+   * Promise of the currently-in-flight detectCartridge() call, or null
+   * if no detect is in progress. Used to dedupe concurrent calls — React
+   * Strict Mode double-mounts in dev cause two scanner effects to start
+   * detects in parallel; without dedupe the two calls' USB transfers
+   * interleave on the same pipes and confuse the cart. Both callers
+   * get the same promise and the driver does the work once.
+   */
+  private inFlightDetect: Promise<NDSCartridgeInfo | null> | null = null;
+
+  constructor(transport: UsbTransport) {
+    this.transport = transport;
+  }
+
+  async initialize(): Promise<DeviceInfo> {
+    // Clear any halt left on EP1 IN / EP2 OUT from a previous failed run
+    // — the bulk pipes can be STALLed if the host gave up mid-transfer
+    // and the device didn't auto-recover.
+    await this.tryClearHalt();
+
+    // Vendor control IN 0xA3 puts the firmware into "ready" state.
+    // Without it the device accepts our bulk-OUTs but never produces
+    // responses — every bulk IN hangs until the host gives up.
+    await this.openSession();
+    this.log("Session opened (vendor request 0xA3).");
+
+    // Liveness probe: 8-byte status response. If the device doesn't
+    // reply here, there's no point trying any cart op.
+    const status = await this.queryStatus();
+    const fwHex = Array.from(status, hex).join(" ");
+    this.log(`Status: ${fwHex}`);
+
+    return {
+      // Status bytes don't have a canonical "firmware version" field —
+      // surface the raw hex so the user can flag a mismatch if we ever
+      // need a fw-gate.
+      firmwareVersion: fwHex,
+      deviceName: this.name,
+      capabilities: this.capabilities,
+    };
+  }
+
+  async detectSystem(): Promise<DetectSystemResult | null> {
+    const info = await this.detectCartridge("nds_save");
+    if (!info) return null;
+    return { systemId: "nds_save", cartInfo: info };
+  }
+
+  async detectCartridge(systemId: SystemId): Promise<NDSCartridgeInfo | null> {
+    // Concurrent-call dedupe: if a detect is already running, both
+    // callers share the same promise. The driver does the work once.
+    if (this.inFlightDetect) return this.inFlightDetect;
+
+    const promise = (async () => {
+      try {
+        return await this.detectCartridgeInner();
+      } catch (err) {
+        // Any USB-level failure (timeout, stall, transferOut error)
+        // probably left the cart-bus state machine wedged. Force a full
+        // reset on the next attempt so it re-issues 0xF0 + wake-up
+        // dummy.
+        this.cartInited = false;
+        this.cachedHeader = null;
+        this.cachedChipId = "";
+        // Best-effort cart reset so the next attempt isn't fighting a
+        // half-initialized cart.
+        try {
+          await this.resetCart();
+        } catch {
+          /* a wedged USB stack will rethrow; the outer catch already
+             surfaced the original error. */
+        }
+        throw err;
+      }
+    })();
+
+    this.inFlightDetect = promise.finally(() => {
+      this.inFlightDetect = null;
+    });
+    // detectCartridge is allowed to use systemId in the future; reference
+    // it now so the linter doesn't strip the param.
+    void systemId;
+    return promise;
+  }
+
+  private async detectCartridgeInner(): Promise<NDSCartridgeInfo | null> {
+    // First detect (or after a "no cart" result) — full reset cycle so
+    // the cart-bus state machine wakes cleanly.
+    if (!this.cartInited) {
+      await this.resetCart();
+      this.log("Reset done; waking cart with NTR 0x9F dummy...");
+      // NTR 0x9F is the canonical NDS wake-up dummy. Real retail carts
+      // are documented to need a 0x9F before responding to 0x90.
+      await this.sendNtr(NTR_CMD.DUMMY, 0);
+      this.log("Dummy done; reading chip ID (NTR 0x90)...");
+      this.cartInited = true;
+    }
+
+    const chipId = await this.readChipId();
+    const chipIdHex = Array.from(chipId, hex).join(" ");
+    this.log(`Chip ID: ${chipIdHex || "(empty)"}`);
+
+    if (isNoCart(chipId)) {
+      const why =
+        chipId.length === 0
+          ? "Chip ID response was empty — device firmware did not return any data."
+          : chipId.every((b) => b === 0xff)
+            ? "Chip ID is all 0xFF — no cart inserted, or cart not making contact."
+            : "Chip ID is all zero — device returned empty response.";
+      this.log(why);
+      this.cachedHeader = null;
+      this.cachedChipId = "";
+      // Force a full reset on the next attempt — if the cart was
+      // hot-swapped, the new cart needs its own wake-up cycle.
+      this.cartInited = false;
+      return null;
+    }
+
+    const isDsiEnhanced = (chipId[3] & CHIP_ID_DSI_4K_HEADER_BIT) !== 0;
+    const headerReadLen = isDsiEnhanced ? 0x1000 : 0x200;
+    if (isDsiEnhanced) {
+      this.log(
+        `Chip ID byte 3 bit 0x40 is set — DSi-Enhanced cart, ` +
+          `using ${headerReadLen}-byte header read.`,
+      );
+    }
+
+    if (chipIdHex !== this.cachedChipId) {
+      this.cachedHeader = null;
+      this.cachedChipId = chipIdHex;
+    }
+
+    if (!this.cachedHeader) {
+      this.cachedHeader = await this.readAndValidateHeader(headerReadLen);
+      // Probe save chip JEDEC after header read. Best-effort: if the probe
+      // fails or returns an unrecognized response, we still report the
+      // cart info; the UI lets the user pick a chip manually via the
+      // dropdown.
+      try {
+        const probe = await this.probeJedec();
+        const parsed = parseProbeResponse(probe);
+        const chip = identifyByJedec(parsed.jedec, parsed.familyCode);
+        this.cachedSaveChip = chip;
+        const jedecStr = parsed.jedec.map(hex).join(" ").toUpperCase();
+        const familyHex = hex(parsed.familyCode);
+        if (chip.source === "exact") {
+          this.log(
+            `Save chip: ${chip.name} (${formatBytes(chip.sizeBytes)}) — ` +
+              `JEDEC ${jedecStr}, family 0x${familyHex} [exact match]`,
+          );
+        } else if (chip.source === "family") {
+          this.log(
+            `Save chip: ${chip.name} — JEDEC ${jedecStr}, family 0x${familyHex} ` +
+              `[inferred from manufacturer + device-type bits; cmd table assumed]`,
+          );
+        } else if (chip.source === "eeprom-family") {
+          // Run wrap-probe to pin down the exact size. Read-only —
+          // can't corrupt the chip.
+          this.log(
+            `Save chip: ${chip.name} — JEDEC ${jedecStr} (M95 family; ` +
+              `no JEDEC RDID), family 0x${familyHex}. ` +
+              `Running wrap-probe to determine exact size...`,
+          );
+          const probed = await this.wrapProbeEepromSize(
+            chip.cmdTable,
+            chip.flag,
+          );
+          if (probed !== null) {
+            this.cachedSaveChip = {
+              ...chip,
+              source: "wrap-probed",
+              sizeBytes: probed,
+              name: "M95 EEPROM",
+            };
+            this.log(
+              `Wrap-probe: chip is ${formatBytes(probed)} — confirmed by ` +
+                `address aliasing at 0x${(probed - 1).toString(16)}.`,
+            );
+          } else {
+            this.log(
+              `Wrap-probe didn't detect aliasing at any standard NDS ` +
+                `EEPROM size (512 B / 8 KB / 64 KB). Chip is larger or ` +
+                `non-standard — use the override dropdown.`,
+              "warn",
+            );
+          }
+        } else {
+          this.log(
+            `Save-chip JEDEC probe: ${jedecStr}, family 0x${familyHex} — ` +
+              `chip not recognized by any family template. ` +
+              `Use the override dropdown to pick a similar chip.`,
+            "warn",
+          );
+        }
+        if (!parsed.jedecConsistent) {
+          this.log(
+            "Save-chip probe: firmware's two JEDEC reads disagreed " +
+              "(bytes 0..2 != bytes 5..7) — chip contact may be marginal.",
+            "warn",
+          );
+        }
+      } catch (e) {
+        this.log(
+          `Save-chip JEDEC probe failed: ${(e as Error).message}`,
+          "warn",
+        );
+        this.cachedSaveChip = null;
+      }
+      if (this.cachedHeader.validHeader) {
+        this.log(
+          `Card: ${this.cachedHeader.title} ` +
+            `[${this.cachedHeader.gameCode}] — ` +
+            `${this.cachedHeader.romSizeMiB} MiB ROM ` +
+            `(chip ID ${chipIdHex})`,
+        );
+      } else if (this.cachedHeader.headerAllFF) {
+        this.log(
+          "Header was all 0xFF — likely a 3DS cart (slot-1 format mismatch) " +
+            "or an NDS cart with dirty contacts.",
+          "warn",
+        );
+      } else {
+        this.log(
+          `Header CRC validation failed after ${HEADER_READ_RETRIES} attempts ` +
+            `(chip ID ${chipIdHex}). The cart is detected but its header was ` +
+            "not read cleanly.",
+          "warn",
+        );
+      }
+    }
+
+    return this.buildCartInfo();
+  }
+
+  get cartInfo(): NDSCartridgeInfo | null {
+    if (!this.cachedHeader) return null;
+    return this.buildCartInfo();
+  }
+
+  async readROM(): Promise<Uint8Array> {
+    throw new Error(
+      "SMS4: ROM dump is not implemented in this build (save preservation only).",
+    );
+  }
+
+  /**
+   * Dump the cart's save chip. Iterates `0x60 0xA2` save-read packets in
+   * SAVE_READ_CHUNK chunks until the configured size is read, emitting
+   * `onProgress` after each chunk for the scanner UI.
+   *
+   * Reads ride on the chip's cmd table (READ DATA opcode at byte 1, 0x03
+   * for every supported family). The SMS4 firmware drives the chip's SPI
+   * lines accordingly and returns the page on bulk-IN; no chip-side state
+   * machine is touched, so this is non-destructive.
+   *
+   * `config.params` may carry an override `{ saveSize, cmdTable, flag }`
+   * (the scanner sends one when the user picks a chip in the dropdown);
+   * otherwise we fall back to whatever `cachedSaveChip` settled on during
+   * `detectCartridge`. If neither path supplies a usable cmd table, throw
+   * before issuing any USB transfers — better than reading 64 KB of 0xFF
+   * and writing it to disk.
+   */
+  async readSave(
+    config: ReadConfig,
+    signal?: AbortSignal,
+  ): Promise<Uint8Array> {
+    const override = config?.params as
+      | {
+          saveSize?: number;
+          cmdTable?: readonly number[];
+          flag?: 0x07 | 0x0f;
+        }
+      | undefined;
+
+    const cmdTable = override?.cmdTable ?? this.cachedSaveChip?.cmdTable;
+    const flag = override?.flag ?? this.cachedSaveChip?.flag;
+    const sizeBytes =
+      override?.saveSize ??
+      (this.cachedSaveChip && this.cachedSaveChip.sizeBytes > 0
+        ? this.cachedSaveChip.sizeBytes
+        : 0);
+
+    if (!cmdTable || cmdTable.length !== 14 || !flag) {
+      throw new Error(
+        "Cannot read save: no save-chip identified. Insert a cart, wait for " +
+          "detection, then pick a chip from the override dropdown if " +
+          "auto-detect failed.",
+      );
+    }
+    if (sizeBytes <= 0) {
+      throw new Error(
+        "Cannot read save: save-chip size is unknown. Pick a specific chip " +
+          "in the override dropdown so we know how many bytes to read.",
+      );
+    }
+
+    this.log(
+      `Reading ${formatBytes(sizeBytes)} save in ${SAVE_READ_CHUNK}-byte chunks...`,
+    );
+
+    const result = new Uint8Array(sizeBytes);
+    let offset = 0;
+    while (offset < sizeBytes) {
+      if (signal?.aborted) throw new Error("Aborted");
+      const n = Math.min(SAVE_READ_CHUNK, sizeBytes - offset);
+      const chunk = await this.readSavePage(offset, n, cmdTable, flag);
+      if (chunk.length < n) {
+        throw new Error(
+          `Short read at offset 0x${offset.toString(16)}: expected ${n} bytes, ` +
+            `got ${chunk.length}. Save dump aborted to avoid silent zero-fill.`,
+        );
+      }
+      result.set(chunk.subarray(0, n), offset);
+      offset += n;
+      this.emitProgress("save", offset, sizeBytes);
+    }
+
+    this.log(`Save read complete: ${offset} bytes.`);
+    return result;
+  }
+
+  async writeSave(): Promise<void> {
+    throw new Error("SMS4: save write is not implemented (read-only build).");
+  }
+
+  on<K extends keyof DeviceDriverEvents>(
+    event: K,
+    handler: DeviceDriverEvents[K],
+  ): void {
+    this.events[event] = handler;
+  }
+
+  // ─── Cart operations ───────────────────────────────────────────────────
+
+  private async resetCart(): Promise<void> {
+    this.log("Resetting cart...");
+    const pkt = buildCartPacket({
+      ntrCmd: new Uint8Array(8),
+      responseLen: 0,
+      subcmd: SUBCMD.RESET,
+    });
+    await this.bulkWrite(pkt);
+    await sleep(RESET_SETTLE_MS);
+  }
+
+  private async readChipId(): Promise<Uint8Array> {
+    return this.sendNtr(NTR_CMD.GET_CHIP_ID, CHIP_ID_LEN);
+  }
+
+  /**
+   * Read `length` bytes from the cart's save chip starting at `address`.
+   * Sends a `0x60 0xA2` save-read packet using the supplied chip cmd
+   * table; the SMS4 firmware drives the chip's SPI lines accordingly
+   * and returns the response on bulk IN.
+   */
+  private async readSavePage(
+    address: number,
+    length: number,
+    cmdTable: readonly number[],
+    flag: 0x07 | 0x0f,
+  ): Promise<Uint8Array> {
+    const pkt = buildSaveReadPacket({ cmdTable, flag, address, length });
+    await this.bulkWrite(pkt);
+    return this.bulkRead(length);
+  }
+
+  /**
+   * Wrap-probe to determine the exact size of an M95-family EEPROM.
+   *
+   * Mechanism: M95 chips have an SPI address bus only as wide as their
+   * actual capacity. Reading at offset `sz - 1` on a chip of exactly
+   * `sz` bytes returns chip[sz-1] then bytes that wrap to chip[0..],
+   * because higher address bits are ignored. We read 16 bytes at 0 as
+   * a "base", then 16 bytes at each candidate `sz - 1` and check
+   * whether bytes 1..15 match base[0..14]. The match identifies the
+   * exact chip size with high confidence (false-positive odds: 1 in
+   * 2^120 if save data is random; even less for sparse 0xFF saves).
+   *
+   * Pure reads — never writes. Cannot corrupt the chip.
+   *
+   * Returns the detected size in bytes, or null if no aliasing matched.
+   */
+  private async wrapProbeEepromSize(
+    cmdTable: readonly number[],
+    flag: 0x07 | 0x0f,
+  ): Promise<number | null> {
+    const base = await this.readSavePage(0, 16, cmdTable, flag);
+    if (base.length < 16) {
+      this.log(
+        `Wrap-probe: read at 0 returned only ${base.length} bytes; aborting.`,
+        "warn",
+      );
+      return null;
+    }
+    // Standard NDS EEPROM sizes: 4 Kbit (512 B), 64 Kbit (8 KB),
+    // 512 Kbit (64 KB).
+    const candidates = [0x200, 0x2000, 0x10000];
+    for (const sz of candidates) {
+      const r = await this.readSavePage(sz - 1, 16, cmdTable, flag);
+      if (r.length < 16) continue;
+      let wraps = true;
+      for (let i = 0; i < 15; i++) {
+        if (r[i + 1] !== base[i]) {
+          wraps = false;
+          break;
+        }
+      }
+      if (wraps) return sz;
+    }
+    return null;
+  }
+
+  /**
+   * Probe the cart's save chip via the SMS4 firmware's JEDEC RDID
+   * shortcut: send a 32-byte packet with opcode `0x60 0xA0` and
+   * response length 9, the firmware drives SPI to the save chip's
+   * 0x9F (RDID) lines and returns 9 bytes: family code + 3-byte JEDEC
+   * ID + flag bit + padding.
+   */
+  private async probeJedec(): Promise<Uint8Array> {
+    const pkt = new Uint8Array(PACKET_LEN);
+    pkt[0] = PROBE_JEDEC_OPCODE[0];
+    pkt[1] = PROBE_JEDEC_OPCODE[1];
+    pkt[6] = PROBE_JEDEC_RESPONSE_LEN & 0xff;
+    pkt[7] = (PROBE_JEDEC_RESPONSE_LEN >> 8) & 0xff;
+    pkt[8] = (PROBE_JEDEC_RESPONSE_LEN >> 16) & 0xff;
+    pkt[9] = (PROBE_JEDEC_RESPONSE_LEN >> 24) & 0xff;
+    await this.bulkWrite(pkt);
+    return this.bulkRead(PROBE_JEDEC_RESPONSE_LEN);
+  }
+
+  /**
+   * Read the NDS header. Retries up to HEADER_READ_RETRIES on CRC
+   * mismatch — the cart bus can be in a transient state right after
+   * the reset+chip-ID sequence; a couple of repeats usually settles
+   * it. parseNDSHeader does both the header-CRC at 0x15E and the
+   * Nintendo-logo-CRC at 0x15C, so a corrupt read fails validation
+   * even if the bytes look plausible.
+   *
+   * `readLen` is per-cart-class: 0x200 for plain NDS, 0x1000 for DSi
+   * carts (the cart firmware buffers the larger response and stalls if
+   * we under-request).
+   */
+  private async readAndValidateHeader(readLen: number): Promise<CardHeader> {
+    let parsed: CardHeader = parseNDSHeader(new Uint8Array(HEADER_LEN));
+    for (let attempt = 0; attempt < HEADER_READ_RETRIES; attempt++) {
+      const bytes = await this.sendNtr(NTR_CMD.READ_HEADER, readLen);
+      parsed = parseNDSHeader(bytes);
+      if (parsed.validHeader || parsed.headerAllFF) return parsed;
+      this.log(
+        `Header CRC mismatch on attempt ${attempt + 1}; retrying.`,
+        "warn",
+      );
+    }
+    return parsed;
+  }
+
+  /**
+   * Issue an NDS NTR command (opcode + 7 zero bytes) and read back the
+   * cart's response. The response length is encoded into the cart-bus
+   * packet so the device firmware knows how many bytes to bulk back.
+   */
+  private async sendNtr(opcode: number, responseLen: number): Promise<Uint8Array> {
+    const ntr =
+      opcode === NTR_CMD.GET_CHIP_ID
+        ? ntrGetChipId()
+        : opcode === NTR_CMD.READ_HEADER
+          ? ntrReadHeader()
+          : (() => {
+              const c = new Uint8Array(8);
+              c[0] = opcode;
+              return c;
+            })();
+    const pkt = buildCartPacket({ ntrCmd: ntr, responseLen });
+    await this.bulkWrite(pkt);
+    if (responseLen === 0) return new Uint8Array(0);
+    return this.bulkRead(responseLen);
+  }
+
+  // ─── Low-level transport ────────────────────────────────────────────────
+
+  /**
+   * Issue the SMS4's "open session" vendor control transfer (0xA3).
+   * No data stage — the device just acknowledges. Marks the firmware
+   * as ready to accept and respond to cart commands.
+   */
+  private async openSession(): Promise<void> {
+    await this.transport.controlTransferIn(
+      {
+        requestType: "vendor",
+        recipient: "device",
+        request: VENDOR_CTRL.OPEN_SESSION,
+        value: 0x0001,
+        index: 0x0000,
+      },
+      0,
+    );
+  }
+
+  /**
+   * 8-byte status read via vendor IN control transfer. Used as a device-
+   * liveness probe at init.
+   */
+  private async queryStatus(): Promise<Uint8Array> {
+    const data = await this.transport.controlTransferIn(
+      {
+        requestType: "vendor",
+        recipient: "device",
+        request: VENDOR_CTRL.QUERY_STATUS,
+        value: 0x01,
+        index: 0x00,
+      },
+      STATUS_RESPONSE_LEN,
+    );
+    if (data.byteLength < STATUS_RESPONSE_LEN) {
+      throw new Error(
+        `Device did not respond to QueryStatus ` +
+          `(got ${data.byteLength} bytes, expected ${STATUS_RESPONSE_LEN}). ` +
+          "Check that this is a Neoflash SMS4 (VID 0xFFAB PID 0xDD03), not " +
+          "a different device on the same VID/PID.",
+      );
+    }
+    return data;
+  }
+
+  /** Best-effort halt clear on both bulk endpoints — see initialize(). */
+  private async tryClearHalt(): Promise<void> {
+    try {
+      await this.transport.clearHalt("in", ENDPOINT.IN);
+    } catch {
+      /* endpoint not halted, ignore */
+    }
+    try {
+      await this.transport.clearHalt("out", ENDPOINT.OUT);
+    } catch {
+      /* endpoint not halted, ignore */
+    }
+  }
+
+  /**
+   * Bulk OUT + Zero-Length Packet. The SMS4 firmware uses USB
+   * end-of-transfer semantics: after the 32-byte cart packet, it waits
+   * for an empty bulk OUT to know the transfer is complete before it
+   * processes the command. Without the ZLP, bulk IN hangs indefinitely
+   * while the firmware waits for more OUT data that never arrives.
+   * This is the single most important non-obvious piece of the wire
+   * protocol.
+   */
+  private async bulkWrite(data: Uint8Array): Promise<void> {
+    if (data.length === 0) return;
+    await this.transport.send(data);
+    await this.transport.send(new Uint8Array(0));
+  }
+
+  /** Raw bulk IN. */
+  private async bulkRead(length: number): Promise<Uint8Array> {
+    if (length === 0) return new Uint8Array(0);
+    return this.transport.receive(length);
+  }
+
+  // ─── Helpers ───────────────────────────────────────────────────────────
+
+  private buildCartInfo(): NDSCartridgeInfo {
+    const jedecHex = this.cachedSaveChip
+      ? this.cachedSaveChip.jedec.map(hex).join(" ")
+      : undefined;
+    const sizeBytes =
+      this.cachedSaveChip && this.cachedSaveChip.sizeBytes > 0
+        ? this.cachedSaveChip.sizeBytes
+        : undefined;
+    return buildNDSCartInfoFromHeader({
+      header: this.cachedHeader,
+      chipIdHex: this.cachedChipId,
+      saveSize: sizeBytes,
+      // Save Type cell shows just the kind (EEPROM / FLASH). The detailed
+      // chip name + JEDEC + source live in the event log via this.log(...)
+      // calls during detect.
+      saveType: this.cachedSaveChip?.kind,
+      saveJedec: jedecHex,
+      saveChipName: this.cachedSaveChip?.name,
+      saveChipSource: this.cachedSaveChip?.source,
+    });
+  }
+
+  private log(
+    message: string,
+    level: "info" | "warn" | "error" = "info",
+  ): void {
+    this.events.onLog?.(message, level);
+  }
+
+  private emitProgress(
+    phase: DumpProgress["phase"],
+    bytesRead: number,
+    totalBytes: number,
+  ): void {
+    this.events.onProgress?.({
+      phase,
+      bytesRead,
+      totalBytes,
+      fraction: totalBytes === 0 ? 0 : bytesRead / totalBytes,
+    });
+  }
+}
+
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const isNoCart = (id: Uint8Array): boolean =>
+  id.length === 0 ||
+  id.every((b) => b === 0x00) ||
+  id.every((b) => b === 0xff);

--- a/src/lib/systems/nds/nds-header.ts
+++ b/src/lib/systems/nds/nds-header.ts
@@ -272,6 +272,13 @@ export type NDSCartMeta = Record<string, unknown> & {
    * from "DS cart that wouldn't respond" if needed.
    */
   is3DS?: boolean;
+  /** Save chip's JEDEC ID as a 3-byte hex string (e.g. "20 71 12"),
+   *  when the device exposes one. */
+  saveJedec?: string;
+  /** Human-readable save chip name when matched against a chip database. */
+  saveChipName?: string;
+  /** How specific the chip match was. */
+  saveChipSource?: "exact" | "family" | "eeprom-family" | "wrap-probed" | "unknown";
 };
 
 /**
@@ -314,6 +321,9 @@ export function buildNDSCartInfoFromHeader(opts: {
   chipIdHex?: string;
   saveSize?: number;
   saveType?: string;
+  saveJedec?: string;
+  saveChipName?: string;
+  saveChipSource?: NDSCartMeta["saveChipSource"];
 }): NDSCartridgeInfo {
   const valid = opts.header?.validHeader ?? false;
   const headerAllFF = opts.header?.headerAllFF ?? false;
@@ -335,6 +345,9 @@ export function buildNDSCartInfoFromHeader(opts: {
       chipId: opts.chipIdHex || undefined,
       cartFamily,
       is3DS: headerAllFF,
+      saveJedec: opts.saveJedec,
+      saveChipName: opts.saveChipName,
+      saveChipSource: opts.saveChipSource,
     },
   };
 }

--- a/src/lib/systems/nds/nds-header.ts
+++ b/src/lib/systems/nds/nds-header.ts
@@ -112,13 +112,16 @@ export function crc16Modbus(buf: Uint8Array): number {
  * Validation signals per candidate offset:
  *   - title bytes (0..11) are printable ASCII or null
  *   - title[0] is alphanumeric (real titles don't start with punctuation)
- *   - title has ≥ 3 alphanumeric characters
  *   - gameCode (0x0C..0x0F) is all alphanumeric
  *   - gameCode[3] is a known NDS region letter
  *   - capacity byte (0x14) is ≤ 0x0F (real carts are 3..12)
  *
  * Together these reject the nondeterministic preamble bytes some
- * firmwares return before the real header.
+ * firmwares return before the real header. Title content past byte 0
+ * is intentionally NOT constrained beyond "printable ASCII or null" —
+ * some legitimate commercial titles are very short (e.g. a 2-character
+ * indie port), and the gameCode/region/capacity checks below already
+ * reject random preambles with high confidence.
  */
 export function findHeaderStart(raw: Uint8Array): number {
   const isAlnum = (b: number) =>
@@ -129,18 +132,14 @@ export function findHeaderStart(raw: Uint8Array): number {
   const limit = Math.min(raw.length - 0x20, 64);
   for (let offset = 0; offset < limit; offset++) {
     let titleOk = true;
-    let titleAlnum = 0;
     for (let i = 0; i < 12; i++) {
-      const b = raw[offset + i];
-      if (!isTitleByte(b)) {
+      if (!isTitleByte(raw[offset + i])) {
         titleOk = false;
         break;
       }
-      if (isAlnum(b)) titleAlnum++;
     }
     if (!titleOk) continue;
     if (!isAlnum(raw[offset])) continue;
-    if (titleAlnum < 3) continue;
 
     let codeOk = true;
     for (let i = 0x0c; i < 0x12; i++) {

--- a/src/lib/systems/nds/nds-save-system-handler.ts
+++ b/src/lib/systems/nds/nds-save-system-handler.ts
@@ -123,12 +123,15 @@ export class NDSSaveSystemHandler implements SystemHandler {
   buildOutputFile(rawData: Uint8Array, config: ReadConfig): OutputFile {
     const title = config.params.title as string | undefined;
     const gameCode = config.params.gameCode as string | undefined;
-    // Fall back AFTER sanitization too: a title that's entirely punctuation
-    // or non-ASCII would otherwise sanitize to "" and we'd write ".sav".
+    // Strip only the characters that are actually unsafe across Windows,
+    // Linux, and macOS filesystems — parens, commas, periods, spaces,
+    // apostrophes are all fine and let the filename match the No-Intro
+    // title verbatim. Fall back to a generic name if sanitization wipes
+    // the string (only possible if the title is entirely path-reserved
+    // punctuation).
     const sanitized = (title ?? gameCode ?? "")
-      .replace(/[^a-zA-Z0-9_ -]/g, "")
-      .trim()
-      .replace(/\s+/g, "_");
+      .replace(/[<>:"/\\|?*]/g, "")
+      .trim();
     const basename = sanitized || "nds_save";
 
     return {

--- a/src/lib/transport/usb-transport.ts
+++ b/src/lib/transport/usb-transport.ts
@@ -42,6 +42,31 @@ export class UsbTransport implements Transport {
     return this.device?.opened ?? false;
   }
 
+  /** Best-effort halt-clear on a bulk endpoint. Used by drivers whose
+   *  device firmware can leave a STALL on an endpoint after the host
+   *  aborts a transfer mid-flight. */
+  async clearHalt(direction: "in" | "out", endpoint: number): Promise<void> {
+    if (!this.device) throw new Error("USB device not connected");
+    await this.device.clearHalt(direction, endpoint);
+  }
+
+  /** Vendor-class control IN transfer. Returns the response data as a
+   *  Uint8Array (zero-length if the device returned no data stage). */
+  async controlTransferIn(
+    setup: USBControlTransferParameters,
+    length: number,
+  ): Promise<Uint8Array> {
+    if (!this.device) throw new Error("USB device not connected");
+    const result = await this.device.controlTransferIn(setup, length);
+    return result.data
+      ? new Uint8Array(
+          result.data.buffer,
+          result.data.byteOffset,
+          result.data.byteLength,
+        )
+      : new Uint8Array(0);
+  }
+
   /** Prompt the user to select a USB device. */
   async connect(_options?: TransportConnectOptions): Promise<DeviceIdentity> {
     if (!navigator.usb) {

--- a/src/lib/transport/usb-transport.ts
+++ b/src/lib/transport/usb-transport.ts
@@ -42,6 +42,18 @@ export class UsbTransport implements Transport {
     return this.device?.opened ?? false;
   }
 
+  /** Returns the device's USB descriptor `bcdDevice` as a 16-bit BCD
+   *  number, or null if not connected. Used by drivers whose firmware
+   *  version lives in the USB descriptor rather than in a vendor query. */
+  getBcdDevice(): number | null {
+    if (!this.device) return null;
+    return (
+      (this.device.deviceVersionMajor << 8) |
+      (this.device.deviceVersionMinor << 4) |
+      this.device.deviceVersionSubminor
+    );
+  }
+
   /** Best-effort halt-clear on a bulk endpoint. Used by drivers whose
    *  device firmware can leave a STALL on an endpoint after the host
    *  aborts a transfer mid-flight. */

--- a/src/web-apis.d.ts
+++ b/src/web-apis.d.ts
@@ -130,6 +130,7 @@ interface USBDevice {
     setup: USBControlTransferParameters,
     data?: BufferSource,
   ): Promise<USBOutTransferResult>;
+  clearHalt(direction: "in" | "out", endpointNumber: number): Promise<void>;
 }
 
 interface USBConfiguration {


### PR DESCRIPTION
## Summary

- New WebUSB driver for the **Neoflash SMS4** (`NEO NDS SMS4 V6G`, VID `0xFFAB` PID `0xDD03`) — a discontinued NDS slot-1 cartridge adapter. Implements DS cartridge save-data preservation via the device's cart-bus SPI passthrough.
- Save-chip identification covers exact JEDEC match (M25P / M25PE / M45PE / LE25FW), family inference for unknown device-types within a known manufacturer, and an M95-EEPROM wrap-probe for chips that don't answer JEDEC RDID. Identified chip + JEDEC ID + match source are surfaced in the event log during detect.
- ROM dump and save write throw "not supported" stubs in this build. Save preservation only.

## Side cleanups bundled in

Two small, related fixes that the SMS4 work surfaced — bundled to land alongside the driver rather than as a separate noise PR:

- `NDSScanner` no longer polls for cart insertion. PowerSaves 3DS already required disconnect-and-reconnect between cartridges; SMS4 has the same requirement (firmware can't recover cleanly from aborted ops). One-shot detect on connect + "insert cart, reconnect" message when nothing is present.
- `PowerSave3DSDriver.readSave` now contains the save-dump logic directly instead of forwarding to `readROM`. `readROM` throws "not supported" since the device cannot dump ROMs. The scanner hook calls `readSave` rather than `readROM` (which it was already supposed to — the forwarding was a workaround).

## SlimLoader IV note

The SMS4 was also marketed in some channels as the "SlimLoader IV". The protocol is the same family, so this driver probably works against that device too — but no SlimLoader IV unit has been tested, so the picker advertises only "Neoflash SMS4". If a SlimLoader IV user confirms compatibility, we can add the alias to `models` and the display name in a follow-up.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean (TypeScript + Vite)
- [x] `npm test` — 87 passing, including 32 new tests for `sms4-commands` packet framing and `sms4-chip-database` JEDEC matching / capacity decoder / probe parser
- [x] Plug in SMS4 V6G, confirm device-info bar shows "Neoflash SMS4" + fw status hex
- [ ] With no cart inserted: confirm new "insert a DS cartridge and reconnect" prompt renders (not the old polling spinner)
- [ ] Insert a DS cart with a small save (SRAM / FLASH / EEPROM); reconnect; confirm cart detect populates title / gameCode / region / ROM-size / save-type / save-size, and JEDEC + chip identification appear in the event log
- [x] Dump auto-runs; on completion confirm hash + download button; compare against a prior known-good dump for byte-identical match
- [x] Repeat with an M95-family EEPROM cart to exercise the wrap-probe path
- [x] Regression: PowerSaves 3DS without cart → "insert cart, reconnect" prompt; with cart → dump auto-runs byte-identical to pre-refactor; 3DS cart still rejected; IR-blocked DS cart still rejected
- [ ] Install `linux/99-nabu.rules`; confirm device picker shows SMS4 without sudo