### PR TITLE
SMS4: source save-chip JEDEC from firmware's second internal read

### DIFF
--- a/src/lib/drivers/sms4/sms4-chip-database.test.ts
+++ b/src/lib/drivers/sms4/sms4-chip-database.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   decodeSpiCapacityByte,
   identifyByJedec,
+  KNOWN_JEDEC_MANUFACTURERS,
   parseProbeResponse,
   SAVE_CHIPS,
 } from "./sms4-chip-database";
@@ -106,11 +107,52 @@ describe("parseProbeResponse", () => {
     expect(parsed.jedecConsistent).toBe(false);
   });
 
+  it("sources jedec from the second read (bytes 5..7), not the first", () => {
+    // On DS carts with an infrared transceiver sharing the auxiliary-SPI
+    // bus, the IR module corrupts the firmware's first JEDEC RDID read
+    // but not the second — the firmware's inter-transaction CS handling
+    // quiets the IR chip before the re-read. Observed on a Sanyo
+    // LE25FW403 IR-equipped cart returning `4f 80 00 01 00 62 11 00 03`:
+    // bytes 0..2 garbage, bytes 5..7 the real `62 11 00`.
+    const raw = new Uint8Array([0x4f, 0x80, 0x00, 0x01, 0x00, 0x62, 0x11, 0x00, 0x03]);
+    const parsed = parseProbeResponse(raw);
+    expect(parsed.jedec).toEqual([0x62, 0x11, 0x00]);
+    expect(parsed.familyCode).toBe(0x03);
+    expect(parsed.jedecConsistent).toBe(false);
+  });
+
   it("doesn't crash on a short response — missing bytes read as 0", () => {
     const parsed = parseProbeResponse(new Uint8Array([0x20, 0x50, 0x12]));
-    expect(parsed.jedec).toEqual([0x20, 0x50, 0x12]);
+    expect(parsed.jedec).toEqual([0x00, 0x00, 0x00]);
     expect(parsed.familyCode).toBe(0);
     expect(parsed.jedecConsistent).toBe(false);
+  });
+});
+
+describe("KNOWN_JEDEC_MANUFACTURERS", () => {
+  it("includes the manufacturers actually present in SAVE_CHIPS", () => {
+    const mfrsInDb = new Set(
+      SAVE_CHIPS.filter((c) => c.jedecId).map((c) => c.jedecId![0]),
+    );
+    for (const m of mfrsInDb) {
+      expect(KNOWN_JEDEC_MANUFACTURERS.has(m)).toBe(true);
+    }
+  });
+});
+
+describe("parseProbeResponse → identifyByJedec end-to-end", () => {
+  it("identifies an IR-cart probe response as the real Sanyo chip", () => {
+    // Full pipeline: a Pokémon HG/SS-class cart's `60 A0` response goes
+    // through parseProbeResponse → identifyByJedec → "LE25FW403", not
+    // "Unknown chip from the IR-module garbage in bytes 0..2".
+    const raw = new Uint8Array([0x4f, 0x80, 0x00, 0x01, 0x00, 0x62, 0x11, 0x00, 0x03]);
+    const parsed = parseProbeResponse(raw);
+    const chip = identifyByJedec(parsed.jedec, parsed.familyCode);
+    expect(chip.source).toBe("exact");
+    expect(chip.name).toBe("LE25FW403");
+    expect(chip.kind).toBe("FLASH");
+    expect(chip.sizeBytes).toBe(512 * 1024);
+    expect(chip.flag).toBe(0x0f);
   });
 });
 

--- a/src/lib/drivers/sms4/sms4-chip-database.ts
+++ b/src/lib/drivers/sms4/sms4-chip-database.ts
@@ -332,17 +332,36 @@ export function identifyByJedec(
  *
  * Layout (confirmed empirically with a Numonyx 0x20/0x50 capacity-0x12
  * test cart returning `20 50 12 00 00 20 50 12 03`):
- *   bytes 0..2 — JEDEC ID (manufacturer + device-type + capacity)
+ *   bytes 0..2 — JEDEC ID (first internal read)
  *   bytes 3..4 — padding / extended-ID space (typically 00 00)
- *   bytes 5..7 — JEDEC ID repeated (firmware-internal verification)
+ *   bytes 5..7 — JEDEC ID (second internal read — firmware re-issues
+ *                the SPI RDID transaction)
  *   byte 8     — family code (0x01 / 0x02 / 0x03 / other)
+ *
+ * On most carts the two reads agree. On DS carts that pair the save
+ * chip with an infrared transceiver on the auxiliary-SPI bus, the IR
+ * module corrupts the first read (driving MISO during the RDID setup
+ * window) but the firmware's second read consistently returns the real
+ * chip ID — whatever the firmware does between the two transactions
+ * (CS toggle, settling delay) quiets the IR chip for the second one.
+ *
+ * Source the JEDEC ID from bytes 5..7 for that reason; bytes 0..2 are
+ * retained only for the `jedecConsistent` diagnostic so we can surface
+ * the IR-interference case in the event log.
  */
 export interface ParsedProbeResponse {
   jedec: readonly [number, number, number];
   /** Family code byte. 0x03 = SPI flash with JEDEC (most retail carts). */
   familyCode: number;
-  /** True if bytes 0..2 match bytes 5..7 — sanity check that the
-   *  firmware's two reads agree on the chip ID. */
+  /** True iff `raw.length >= 8` AND the two internal JEDEC reads agree
+   *  (bytes 0..2 match bytes 5..7). False otherwise — either the
+   *  comparison couldn't run (length < 8) or the reads disagreed.
+   *
+   *  Independent of this flag, callers should treat any response
+   *  shorter than `PROBE_JEDEC_RESPONSE_LEN` (= 9) as a failed probe:
+   *  an 8-byte response with agreeing reads will set this flag to true
+   *  but is still missing the familyCode byte. The driver enforces
+   *  this; downstream consumers of `parseProbeResponse` should too. */
   jedecConsistent: boolean;
 }
 
@@ -353,7 +372,7 @@ const PROBE_CONSISTENT_MIN_LEN = 8;
 
 export function parseProbeResponse(raw: Uint8Array): ParsedProbeResponse {
   return {
-    jedec: [raw[0] ?? 0, raw[1] ?? 0, raw[2] ?? 0],
+    jedec: [raw[5] ?? 0, raw[6] ?? 0, raw[7] ?? 0],
     familyCode: raw[8] ?? 0,
     jedecConsistent:
       raw.length >= PROBE_CONSISTENT_MIN_LEN &&
@@ -362,3 +381,25 @@ export function parseProbeResponse(raw: Uint8Array): ParsedProbeResponse {
       raw[2] === raw[7],
   };
 }
+
+/** SPI manufacturer bytes that real DS save chips have been observed
+ *  to return on JEDEC RDID. Used by the driver's probe handler to
+ *  sanity-check the firmware's second internal JEDEC read against a
+ *  plausible-manufacturer set before trusting an identification from
+ *  a probe whose two reads disagreed. Membership here is necessary
+ *  but not sufficient for `identifyByJedec` to produce an exact or
+ *  family match — only the manufacturer byte is checked, not
+ *  device-type or capacity, and the set is broader than
+ *  SAVE_CHIP_FAMILIES (e.g. Adesto 0x1F is plausible but has no
+ *  entry yet). The driver tightens this to "identifyByJedec
+ *  succeeded with an exact or family source" on inconsistent probes
+ *  before allowing the M95 wrap-probe path to run. */
+export const KNOWN_JEDEC_MANUFACTURERS: ReadonlySet<number> = new Set([
+  0x20, // Numonyx / Micron (M25P, M25PE, M45PE families)
+  0x62, // Sanyo (LE25FW family)
+  0xc2, // Macronix
+  0xef, // Winbond
+  0x9d, // ISSI
+  0x1f, // Adesto
+]);
+

--- a/src/lib/drivers/sms4/sms4-commands.ts
+++ b/src/lib/drivers/sms4/sms4-commands.ts
@@ -64,7 +64,13 @@ export const PACKET_LEN = 32;
 export const PACKET_OPCODE = [0x60, 0xa5] as const;
 
 /** Save-chip JEDEC RDID probe lead bytes (0x60 0xA0). Response is 9 bytes:
- *  family code + 3-byte JEDEC ID + flag bit + padding. Byte layout
+ *  JEDEC ID (first read) at bytes 0..2, padding / extended-ID space at
+ *  bytes 3..4 (sometimes zero, sometimes not — observed `01 00` on a
+ *  Sanyo IR cart), JEDEC ID (second read, the source of truth — see
+ *  `parseProbeResponse`) at bytes 5..7, family code at byte 8. The
+ *  firmware re-issues the RDID transaction internally; the second read
+ *  is clean on IR-equipped DS carts where the first is fouled by the
+ *  infrared transceiver on the auxiliary-SPI bus. Byte layout
  *  established empirically against the SMS4 firmware. */
 export const PROBE_JEDEC_OPCODE = [0x60, 0xa0] as const;
 export const PROBE_JEDEC_RESPONSE_LEN = 9;

--- a/src/lib/drivers/sms4/sms4-driver.ts
+++ b/src/lib/drivers/sms4/sms4-driver.ts
@@ -68,6 +68,7 @@ import {
 import {
   type ChipIdentification,
   identifyByJedec,
+  KNOWN_JEDEC_MANUFACTURERS,
   parseProbeResponse,
 } from "./sms4-chip-database";
 import { formatBytes } from "@/lib/core/hashing";
@@ -291,67 +292,21 @@ export class SMS4Driver implements NDSDeviceDriver {
       // chip stayed unknown.
       try {
         const probe = await this.probeJedec();
-        const parsed = parseProbeResponse(probe);
-        const chip = identifyByJedec(parsed.jedec, parsed.familyCode);
-        this.cachedSaveChip = chip;
-        const jedecStr = parsed.jedec.map(hex).join(" ").toUpperCase();
-        const familyHex = hex(parsed.familyCode);
-        if (chip.source === "exact") {
+        if (probe.length < PROBE_JEDEC_RESPONSE_LEN) {
+          // Don't trust a parsed JEDEC from a short response — the
+          // parser zero-pads missing bytes, which could fabricate a
+          // plausible-looking chip ID (e.g. `[xx, xx, xx, xx, xx, 0x62,
+          // 0x11]` would parse to `62 11 00` → LE25FW403). Bail out
+          // before identifyByJedec rather than caching a fake match.
           this.log(
-            `Save chip: ${chip.name} (${formatBytes(chip.sizeBytes)}) — ` +
-              `JEDEC ${jedecStr}, family 0x${familyHex} [exact match]`,
+            `Save-chip probe: short response (got ${probe.length} B, ` +
+              `expected ${PROBE_JEDEC_RESPONSE_LEN}). Chip identification ` +
+              `skipped; save dumping is not possible from this probe.`,
+            "warn",
           );
-        } else if (chip.source === "family") {
-          this.log(
-            `Save chip: ${chip.name} — JEDEC ${jedecStr}, family 0x${familyHex} ` +
-              `[inferred from manufacturer + device-type bits; cmd table assumed]`,
-          );
-        } else if (chip.source === "eeprom-family") {
-          // Run wrap-probe to pin down the exact size. Read-only —
-          // can't corrupt the chip.
-          this.log(
-            `Save chip: ${chip.name} — JEDEC ${jedecStr} (M95 family; ` +
-              `no JEDEC RDID), family 0x${familyHex}. ` +
-              `Running wrap-probe to determine exact size...`,
-          );
-          const probed = await this.wrapProbeEepromSize(
-            chip.cmdTable,
-            chip.flag,
-          );
-          if (probed !== null) {
-            this.cachedSaveChip = {
-              ...chip,
-              source: "wrap-probed",
-              sizeBytes: probed,
-              name: "M95 EEPROM",
-            };
-            this.log(
-              `Wrap-probe: chip is ${formatBytes(probed)} — confirmed by ` +
-                `address aliasing at 0x${(probed - 1).toString(16)}.`,
-            );
-          } else {
-            this.log(
-              `Wrap-probe didn't detect aliasing at any standard NDS ` +
-                `EEPROM size (512 B / 8 KB / 64 KB). Chip is larger or ` +
-                `non-standard — this cart isn't currently dumpable with ` +
-                `the SMS4.`,
-              "warn",
-            );
-          }
+          this.cachedSaveChip = null;
         } else {
-          this.log(
-            `Save-chip JEDEC probe: ${jedecStr}, family 0x${familyHex} — ` +
-              `chip not recognized by any family template; this cart ` +
-              `isn't currently dumpable with the SMS4.`,
-            "warn",
-          );
-        }
-        if (!parsed.jedecConsistent) {
-          this.log(
-            "Save-chip probe: firmware's two JEDEC reads disagreed " +
-              "(bytes 0..2 != bytes 5..7) — chip contact may be marginal.",
-            "warn",
-          );
+          await this.handleJedecProbe(probe);
         }
       } catch (e) {
         this.log(
@@ -503,6 +458,209 @@ export class SMS4Driver implements NDSDeviceDriver {
   }
 
   /**
+   * Handle a full-length `60 A0` JEDEC probe response: identify the
+   * save chip from the parsed JEDEC ID, run wrap-probe for M95-family
+   * EEPROMs, and log how the firmware's two internal reads compared.
+   *
+   * Caller must guarantee `probe.length >= PROBE_JEDEC_RESPONSE_LEN`.
+   *
+   * Inconsistent-reads bail-out runs *before* identifyByJedec so a
+   * garbage probe with `familyCode` 0x01/0x02 doesn't trigger an
+   * EEPROM wrap-probe (several hardware reads + a misleading
+   * "wrap-probe succeeded" log line) we'd just discard anyway.
+   */
+  private async handleJedecProbe(probe: Uint8Array): Promise<void> {
+    const parsed = parseProbeResponse(probe);
+
+    // Inconsistent-probe pre-check (a): if the second read's manufacturer
+    // byte isn't plausible, drop the probe before identifyByJedec can
+    // fabricate something from zero-padded or IR-corrupted bytes.
+    if (
+      !parsed.jedecConsistent &&
+      !KNOWN_JEDEC_MANUFACTURERS.has(probe[5]!)
+    ) {
+      this.cachedSaveChip = null;
+      this.log(
+        "Save-chip probe: the second JEDEC read (which the firmware " +
+          "treats as the source of truth) isn't a known manufacturer " +
+          "byte. Chip identification skipped; save dumping is not " +
+          "possible from this probe.",
+        "warn",
+      );
+      return;
+    }
+
+    const chip = identifyByJedec(parsed.jedec, parsed.familyCode);
+
+    // Inconsistent-probe pre-check (b): if the only identification we
+    // got was an EEPROM-family match (driven by familyCode at byte 8)
+    // or no match at all, that's data the disagreement signal already
+    // told us not to trust. Bail before the M95 wrap-probe can issue
+    // hardware reads against a chip table that probably isn't the
+    // actual silicon. (Exact / family matches use bytes 0..2-equivalent
+    // data, which we DO trust on an "ir-cart-pattern" probe — the
+    // second read of the SPI RDID is clean even when the first isn't.)
+    if (
+      !parsed.jedecConsistent &&
+      (chip.source === "eeprom-family" || chip.source === "unknown")
+    ) {
+      this.cachedSaveChip = null;
+      this.log(
+        "Save-chip probe: firmware's two JEDEC reads disagreed and " +
+          `identifyByJedec could only produce a "${chip.source}" ` +
+          "match. The family-code byte may be just as corrupted as " +
+          "the bytes that disagreed; skipping wrap-probe and bailing " +
+          "rather than driving hardware reads through a chip table we " +
+          "can't trust.",
+        "warn",
+      );
+      return;
+    }
+
+    this.cachedSaveChip = chip;
+
+    if (!parsed.jedecConsistent) {
+      this.log(
+        "Save-chip probe: firmware's two JEDEC reads disagreed; the " +
+          "second read identifies a real chip via identifyByJedec so " +
+          "we use it. Common on DS carts with an infrared transceiver " +
+          "on the auxiliary-SPI bus (the IR module fouls the " +
+          "firmware's first read).",
+      );
+
+      // SPI-timing sanity check on IR-pattern carts only. Observed
+      // empirically on a Pokémon B/W-class cart (gameCode IRAO): JEDEC
+      // RDID returns a stable `20 40 13` (M45PE40 / Micron) — but the
+      // chip only responds to Sanyo-style timing (flag 0x0F). The
+      // Micron-flag (0x07) read returns 16 bytes of 0x00 at every
+      // offset. Probe three small reads with the identified flag; if
+      // all are all-zero, try the alternate flag. If THAT produces
+      // any non-zero data, switch.
+      //
+      // Gated to FLASH chips because EEPROMs can legitimately read
+      // all-zero on unused regions, and the M95 family already takes
+      // its own dedicated wrap-probe path.
+      //
+      // Three probe offsets (0, 0x80, 0x100) guard against a save
+      // whose leading bytes are legitimately zero — a real save is
+      // overwhelmingly unlikely to be all-zero across 48 sampled
+      // bytes spread over 256-byte boundaries.
+      //
+      // Read-only — only the SPI READ opcode (cmdTable[1] = 0x03) is
+      // sent; the chip cannot be mutated by this check.
+      if (chip.kind === "FLASH") {
+        const probeOffsets = [0, 0x80, 0x100] as const;
+        const altFlag: 0x07 | 0x0f = chip.flag === 0x07 ? 0x0f : 0x07;
+
+        // Probe BOTH flags and compare. Strict "all-zero" doesn't
+        // survive contact with IR-module bus noise — a stray non-zero
+        // byte in one of the wrong-flag reads would silently disable
+        // the fallback. Counting non-zero bytes across all probes and
+        // comparing relative counts is much more robust: a chip
+        // responding to wrong timing produces ~0 non-zero bytes; a
+        // chip responding to right timing produces many (real save
+        // data has structure).
+        const probe = async (flag: 0x07 | 0x0f): Promise<number> => {
+          let nonZero = 0;
+          for (const off of probeOffsets) {
+            const s = await this.readSavePage(off, 16, chip.cmdTable, flag);
+            nonZero += s.reduce((n, b) => n + (b !== 0 ? 1 : 0), 0);
+          }
+          return nonZero;
+        };
+
+        const primaryNonZero = await probe(chip.flag);
+        const altNonZero = await probe(altFlag);
+
+        // Always log the comparison — gives us visibility into the
+        // chip's actual response on every IR-cart probe.
+        this.log(
+          `SPI timing probe: identified flag 0x${chip.flag.toString(16)} ` +
+            `produced ${primaryNonZero}/48 non-zero bytes; alternate flag ` +
+            `0x${altFlag.toString(16)} produced ${altNonZero}/48 non-zero bytes.`,
+        );
+
+        // Switch criteria: alt has at least 4 non-zero bytes AND more
+        // than twice primary's count. The 4-byte floor guards against
+        // single-byte noise spuriously triggering a switch; the 2x
+        // ratio means we only switch when alt is clearly the better
+        // responder (handles the borderline case where the cart has
+        // sparse data and primary happens to land on a few real bytes).
+        if (altNonZero >= 4 && altNonZero > primaryNonZero * 2) {
+          this.cachedSaveChip = { ...chip, flag: altFlag };
+          this.log(
+            `Switching to flag 0x${altFlag.toString(16)} — the chip's ` +
+              `reported JEDEC ID belongs to a family whose timing it ` +
+              `doesn't actually use (Sanyo-compatible chip with a ` +
+              `Numonyx-style JEDEC, or similar).`,
+          );
+        } else if (primaryNonZero === 0 && altNonZero === 0) {
+          this.log(
+            "Both SPI timings returned all-zero across 3 probe reads. " +
+              "Save dumping will likely produce all zeros — the chip " +
+              "isn't responding to either timing.",
+            "warn",
+          );
+        }
+      }
+
+      // TODO(future): expose a UI-level user override for the SPI flag.
+      // The empirical fallback above handles the only currently-known
+      // case (M45PE40-identified-but-Sanyo-timed), but a manual override
+      // would let users recover from any future chip whose JEDEC lies
+      // about its SPI family without us needing to ship a code change.
+    }
+    const jedecStr = parsed.jedec.map(hex).join(" ").toUpperCase();
+    const familyHex = hex(parsed.familyCode);
+    if (chip.source === "exact") {
+      this.log(
+        `Save chip: ${chip.name} (${formatBytes(chip.sizeBytes)}) — ` +
+          `JEDEC ${jedecStr}, family 0x${familyHex} [exact match]`,
+      );
+    } else if (chip.source === "family") {
+      this.log(
+        `Save chip: ${chip.name} — JEDEC ${jedecStr}, family 0x${familyHex} ` +
+          `[inferred from manufacturer + device-type bits; cmd table assumed]`,
+      );
+    } else if (chip.source === "eeprom-family") {
+      this.log(
+        `Save chip: ${chip.name} — JEDEC ${jedecStr} (M95 family; ` +
+          `no JEDEC RDID), family 0x${familyHex}. ` +
+          `Running wrap-probe to determine exact size...`,
+      );
+      const probed = await this.wrapProbeEepromSize(chip.cmdTable, chip.flag);
+      if (probed !== null) {
+        this.cachedSaveChip = {
+          ...chip,
+          source: "wrap-probed",
+          sizeBytes: probed,
+          name: "M95 EEPROM",
+        };
+        this.log(
+          `Wrap-probe: chip is ${formatBytes(probed)} — confirmed by ` +
+            `address aliasing at 0x${(probed - 1).toString(16)}.`,
+        );
+      } else {
+        this.log(
+          `Wrap-probe didn't detect aliasing at any standard NDS ` +
+            `EEPROM size (512 B / 8 KB / 64 KB). Chip is larger or ` +
+            `non-standard — this cart isn't currently dumpable with ` +
+            `the SMS4.`,
+          "warn",
+        );
+      }
+    } else {
+      this.log(
+        `Save-chip JEDEC probe: ${jedecStr}, family 0x${familyHex} — ` +
+          `chip not recognized by any family template; this cart ` +
+          `isn't currently dumpable with the SMS4.`,
+        "warn",
+      );
+    }
+
+  }
+
+  /**
    * Read `length` bytes from the cart's save chip starting at `address`.
    * Sends a `0x60 0xA2` save-read packet using the supplied chip cmd
    * table; the SMS4 firmware drives the chip's SPI lines accordingly
@@ -568,9 +726,14 @@ export class SMS4Driver implements NDSDeviceDriver {
   /**
    * Probe the cart's save chip via the SMS4 firmware's JEDEC RDID
    * shortcut: send a 32-byte packet with opcode `0x60 0xA0` and
-   * response length 9, the firmware drives SPI to the save chip's
-   * 0x9F (RDID) lines and returns 9 bytes: family code + 3-byte JEDEC
-   * ID + flag bit + padding.
+   * response length 9. The firmware issues the SPI 0x9F (RDID)
+   * transaction twice back-to-back and returns 9 bytes laid out as
+   * JEDEC ID (first read) at bytes 0..2, padding / extended-ID space
+   * at bytes 3..4 (often zero but not guaranteed — observed `01 00`
+   * on a Sanyo IR cart), JEDEC ID (second read) at bytes 5..7, family
+   * code at byte 8. `parseProbeResponse` extracts the chip ID from
+   * bytes 5..7 — see its doc for why the second read is the source
+   * of truth.
    */
   private async probeJedec(): Promise<Uint8Array> {
     const pkt = new Uint8Array(PACKET_LEN);


### PR DESCRIPTION
## Summary
- DS carts with an infrared transceiver on the auxiliary-SPI bus corrupt the firmware's *first* internal JEDEC RDID read (bytes 0..2 of the `60 A0` response). The SMS4 firmware re-runs the RDID transaction and bytes 5..7 are reliably clean — source the chip ID from there instead, keeping the old bytes only for the `jedecConsistent` diagnostic.
- The actual `60 A2` save-read path was never broken on these carts; only chip identification was, which gated everything downstream. With the parse fix, saves dump unchanged through the existing Sanyo path.
- Event-log message reworded so the inconsistent-read case calls out IR interference rather than "marginal chip contact".

## Test plan
- [x] `npx vitest run` — 89/89 pass, including a new IR-cart probe-shape fixture (`4f 80 00 01 00 62 11 00 03` → LE25FW403)
- [x] `npx eslint` + `npx tsc -b` clean
- [x] Cross-validated 512 KB save dump from a non-IR DS cart on SMS4 vs PowerSaves — byte-identical (CRC32 `5A5DA3B4`)
- [x] IR-equipped cart dump (512 KB, Sanyo LE25FW403, two independent reads identical SHA-256): all four PKHeX-equivalent save-block CRC16 checks validate cleanly with the expected layout
- [x] Try additional IR-equipped DS carts as available