### PR TITLE
Code-review fixes: data integrity, hardware I/O, security, and infra hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,4 +18,5 @@ jobs:
 
       - run: npm ci
       - run: npm run lint
+      - run: npm run test
       - run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "lucide-react": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "serialport": "^13.0.0",
         "shadcn": "^4.2.0",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
@@ -1596,245 +1595,6 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
-    },
-    "node_modules/@serialport/binding-mock": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
-      "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
-      "license": "MIT",
-      "dependencies": {
-        "@serialport/bindings-interface": "^1.2.1",
-        "debug": "^4.3.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@serialport/bindings-cpp": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-13.0.0.tgz",
-      "integrity": "sha512-r25o4Bk/vaO1LyUfY/ulR6hCg/aWiN6Wo2ljVlb4Pj5bqWGcSRC4Vse4a9AcapuAu/FeBzHCbKMvRQeCuKjzIQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@serialport/bindings-interface": "1.2.2",
-        "@serialport/parser-readline": "12.0.0",
-        "debug": "4.4.0",
-        "node-addon-api": "8.3.0",
-        "node-gyp-build": "4.8.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-delimiter": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-12.0.0.tgz",
-      "integrity": "sha512-gu26tVt5lQoybhorLTPsH2j2LnX3AOP2x/34+DUSTNaUTzu2fBXw+isVjQJpUBFWu6aeQRZw5bJol5X9Gxjblw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/bindings-cpp/node_modules/@serialport/parser-readline": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-12.0.0.tgz",
-      "integrity": "sha512-O7cywCWC8PiOMvo/gglEBfAkLjp/SENEML46BXDykfKP5mTPM46XMaX1L0waWU6DXJpBgjaL7+yX6VriVPbN4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@serialport/parser-delimiter": "12.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/bindings-cpp/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@serialport/bindings-interface": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
-      "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.22 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/@serialport/parser-byte-length": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-13.0.0.tgz",
-      "integrity": "sha512-32yvqeTAqJzAEtX5zCrN1Mej56GJ5h/cVFsCDPbF9S1ZSC9FWjOqNAgtByseHfFTSTs/4ZBQZZcZBpolt8sUng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/parser-cctalk": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-13.0.0.tgz",
-      "integrity": "sha512-RErAe57g9gvnlieVYGIn1xymb1bzNXb2QtUQd14FpmbQQYlcrmuRnJwKa1BgTCujoCkhtaTtgHlbBWOxm8U2uA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/parser-delimiter": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-13.0.0.tgz",
-      "integrity": "sha512-Qqyb0FX1avs3XabQqNaZSivyVbl/yl0jywImp7ePvfZKLwx7jBZjvL+Hawt9wIG6tfq6zbFM24vzCCK7REMUig==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/parser-inter-byte-timeout": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-13.0.0.tgz",
-      "integrity": "sha512-a0w0WecTW7bD2YHWrpTz1uyiWA2fDNym0kjmPeNSwZ2XCP+JbirZt31l43m2ey6qXItTYVuQBthm75sPVeHnGA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/parser-packet-length": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-13.0.0.tgz",
-      "integrity": "sha512-60ZDDIqYRi0Xs2SPZUo4Jr5LLIjtb+rvzPKMJCohrO6tAqSDponcNpcB1O4W21mKTxYjqInSz+eMrtk0LLfZIg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/@serialport/parser-readline": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-13.0.0.tgz",
-      "integrity": "sha512-dov3zYoyf0dt1Sudd1q42VVYQ4WlliF0MYvAMA3MOyiU1IeG4hl0J6buBA2w4gl3DOCC05tGgLDN/3yIL81gsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@serialport/parser-delimiter": "13.0.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/parser-ready": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-13.0.0.tgz",
-      "integrity": "sha512-JNUQA+y2Rfs4bU+cGYNqOPnNMAcayhhW+XJZihSLQXOHcZsFnOa2F9YtMg9VXRWIcnHldHYtisp62Etjlw24bw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/parser-regex": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-13.0.0.tgz",
-      "integrity": "sha512-m7HpIf56G5XcuDdA3DB34Z0pJiwxNRakThEHjSa4mG05OnWYv0IG8l2oUyYfuGMowQWaVnQ+8r+brlPxGVH+eA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/parser-slip-encoder": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-13.0.0.tgz",
-      "integrity": "sha512-fUHZEExm6izJ7rg0A1yjXwu4sOzeBkPAjDZPfb+XQoqgtKAk+s+HfICiYn7N2QU9gyaeCO8VKgWwi+b/DowYOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/parser-spacepacket": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-13.0.0.tgz",
-      "integrity": "sha512-DoXJ3mFYmyD8X/8931agJvrBPxqTaYDsPoly9/cwQSeh/q4EjQND9ySXBxpWz5WcpyCU4jOuusqCSAPsbB30Eg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/stream": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-13.0.0.tgz",
-      "integrity": "sha512-F7xLJKsjGo2WuEWMSEO1SimRcOA+WtWICsY13r0ahx8s2SecPQH06338g28OT7cW7uRXI7oEQAk62qh5gHJW3g==",
-      "license": "MIT",
-      "dependencies": {
-        "@serialport/bindings-interface": "1.2.2",
-        "debug": "4.4.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/@serialport/stream/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -5517,15 +5277,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/node-addon-api": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.0.tgz",
-      "integrity": "sha512-8VOpLHFrOQlAH+qA0ZzuGRlALRA6/LVh8QJldbrC4DY0hXoMP0l4Acq8TzFC018HztWiRqyCEj2aTWY2UvnJUg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -5562,17 +5313,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-releases": {
@@ -6342,51 +6082,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/serialport": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/serialport/-/serialport-13.0.0.tgz",
-      "integrity": "sha512-PHpnTd8isMGPfFTZNCzOZp9m4mAJSNWle9Jxu6BPTcWq7YXl5qN7tp8Sgn0h+WIGcD6JFz5QDgixC2s4VW7vzg==",
-      "license": "MIT",
-      "dependencies": {
-        "@serialport/binding-mock": "10.2.2",
-        "@serialport/bindings-cpp": "13.0.0",
-        "@serialport/parser-byte-length": "13.0.0",
-        "@serialport/parser-cctalk": "13.0.0",
-        "@serialport/parser-delimiter": "13.0.0",
-        "@serialport/parser-inter-byte-timeout": "13.0.0",
-        "@serialport/parser-packet-length": "13.0.0",
-        "@serialport/parser-readline": "13.0.0",
-        "@serialport/parser-ready": "13.0.0",
-        "@serialport/parser-regex": "13.0.0",
-        "@serialport/parser-slip-encoder": "13.0.0",
-        "@serialport/parser-spacepacket": "13.0.0",
-        "@serialport/stream": "13.0.0",
-        "debug": "4.4.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/serialport/donate"
-      }
-    },
-    "node_modules/serialport/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/serve-static": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "lucide-react": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "serialport": "^13.0.0",
     "shadcn": "^4.2.0",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -542,6 +542,7 @@ function App() {
                         ?.operations.includes("dump_rom")
                     }
                     summary={dumpSummary}
+                    log={log}
                   />
                 )}
               </div>

--- a/src/components/shared/database-panel.tsx
+++ b/src/components/shared/database-panel.tsx
@@ -1,8 +1,9 @@
 import { useRef } from "react";
 import type { useNoIntro } from "@/hooks/use-nointro";
-import type { AmiiboDbState } from "@/hooks/use-amiibo-db";
+import type { useAmiiboDb } from "@/hooks/use-amiibo-db";
 
 type NoIntroState = ReturnType<typeof useNoIntro>;
+type AmiiboDbState = ReturnType<typeof useAmiiboDb>;
 
 interface DatabasePanelProps {
   nointro: NoIntroState;
@@ -14,10 +15,18 @@ export function DatabasePanel({ nointro, amiiboDb }: DatabasePanelProps) {
 
   const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file) nointro.importDat(file);
+    if (file) {
+      // AmiiboAPI ships JSON; No-Intro DATs are XML. Route by extension.
+      if (file.name.toLowerCase().endsWith(".json")) {
+        amiiboDb.importDb(file);
+      } else {
+        nointro.importDat(file);
+      }
+    }
     if (fileRef.current) fileRef.current.value = "";
   };
 
+  const busy = nointro.loading || amiiboDb.loading;
   const hasAny = nointro.systemNames.length > 0 || amiiboDb.loaded;
 
   return (
@@ -28,19 +37,21 @@ export function DatabasePanel({ nointro, amiiboDb }: DatabasePanelProps) {
         </h2>
         <label className="cursor-pointer">
           <span className="inline-flex h-6 items-center rounded-md border border-input px-2 text-[10px] font-medium hover:bg-accent hover:text-accent-foreground">
-            {nointro.loading ? "..." : "+ DAT"}
+            {busy ? "..." : "+ DB"}
           </span>
           <input
             ref={fileRef}
             type="file"
-            accept=".dat,.xml"
+            accept=".dat,.xml,.json"
             className="hidden"
             onChange={handleFile}
           />
         </label>
       </div>
-      {nointro.error && (
-        <div className="mb-1 text-[10px] text-destructive">{nointro.error}</div>
+      {(nointro.error || amiiboDb.error) && (
+        <div className="mb-1 text-[10px] text-destructive">
+          {nointro.error ?? amiiboDb.error}
+        </div>
       )}
       {hasAny ? (
         <div className="flex flex-col gap-0.5">
@@ -60,17 +71,10 @@ export function DatabasePanel({ nointro, amiiboDb }: DatabasePanelProps) {
               </span>
             </div>
           )}
-          {amiiboDb.loading && (
-            <div className="text-[10px] text-muted-foreground/50">
-              Amiibo — loading...
-            </div>
-          )}
         </div>
       ) : (
         <div className="text-[10px] text-muted-foreground/50">
-          {amiiboDb.loading
-            ? "Loading Amiibo database..."
-            : "Import No-Intro DATs for ROM verification"}
+          Import a No-Intro DAT or AmiiboAPI database
         </div>
       )}
     </div>

--- a/src/components/wizard/amiibo-scanner.tsx
+++ b/src/components/wizard/amiibo-scanner.tsx
@@ -37,8 +37,10 @@ export function AmiiboScanner({
       filename = `NFC Tag - ${result.parsed.uidHex} - ${date}.bin`;
     }
 
-    saveFile(result.outputFile.data, filename, [".bin"]);
-  }, [result]);
+    saveFile(result.outputFile.data, filename, [".bin"]).catch((e) =>
+      log(`Couldn't save file: ${(e as Error).message}`, "error"),
+    );
+  }, [result, log]);
 
   return (
     <div className="flex flex-col gap-6">

--- a/src/components/wizard/amiibo-scanner.tsx
+++ b/src/components/wizard/amiibo-scanner.tsx
@@ -183,6 +183,19 @@ function signatureHex(sig: Uint8Array): string {
   return Array.from(sig, (b) => b.toString(16).padStart(2, "0")).join("");
 }
 
+// A scanned tag's NDEF URI is untrusted, so only render it as a clickable
+// link when its scheme is one of these — otherwise a `javascript:`/`data:`
+// URI would execute in the app's origin on click.
+const SAFE_URL_SCHEMES = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function safeHref(value: string): string | null {
+  try {
+    return SAFE_URL_SCHEMES.has(new URL(value).protocol) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
 function InfoRow({
   label,
   value,
@@ -198,14 +211,15 @@ function InfoRow({
   link?: boolean;
   truncate?: boolean;
 }) {
+  const href = link ? safeHref(value) : null;
   return (
     <div className="flex items-center gap-2 text-sm">
       <span className="w-24 shrink-0 text-[10px] uppercase tracking-widest text-muted-foreground">
         {label}
       </span>
-      {link ? (
+      {href ? (
         <a
-          href={value}
+          href={href}
           target="_blank"
           rel="noopener noreferrer"
           className="truncate text-primary underline underline-offset-2"

--- a/src/components/wizard/complete-step.tsx
+++ b/src/components/wizard/complete-step.tsx
@@ -67,6 +67,8 @@ interface CompleteStepProps {
   saveOnly: boolean;
   /** Optional system-specific breakdown of the dump's contents. */
   summary?: DumpSummary | null;
+  /** Event-log sink, used to surface a failed save. */
+  log: (message: string, level?: "info" | "warn" | "error") => void;
 }
 
 export function CompleteStep({
@@ -79,6 +81,7 @@ export function CompleteStep({
   hotSwap,
   saveOnly,
   summary,
+  log,
 }: CompleteStepProps) {
   const verified = result.verification.matched;
   const verifiedName = result.verification.entry?.name;
@@ -111,6 +114,15 @@ export function CompleteStep({
         : (title || "dump") + fileExtension;
   const saveFilename = baseName + ".sav";
 
+  const save = useCallback(
+    (data: Uint8Array, name: string, extensions: string[]) => {
+      saveFile(data, name, extensions).catch((e) =>
+        log(`Couldn't save ${name}: ${(e as Error).message}`, "error"),
+      );
+    },
+    [log],
+  );
+
   const handleSaveReport = useCallback(() => {
     const report = generateDumpReport({
       result,
@@ -121,8 +133,8 @@ export function CompleteStep({
       durationMs: result.durationMs,
     });
     const data = new TextEncoder().encode(report);
-    saveFile(data, baseName + ".txt", [".txt"]);
-  }, [result, deviceInfo, cartInfo, systemDisplayName, romFilename, baseName]);
+    save(data, baseName + ".txt", [".txt"]);
+  }, [result, deviceInfo, cartInfo, systemDisplayName, romFilename, baseName, save]);
 
   return (
     <Card
@@ -239,7 +251,7 @@ export function CompleteStep({
             <Button
               size="sm"
               onClick={() =>
-                saveFile(
+                save(
                   result.rom!.data,
                   romFilename,
                   result.rom!.acceptExtensions ?? [
@@ -255,9 +267,7 @@ export function CompleteStep({
             <Button
               variant="outline"
               size="sm"
-              onClick={() =>
-                saveFile(result.save!.data, saveFilename, [".sav"])
-              }
+              onClick={() => save(result.save!.data, saveFilename, [".sav"])}
             >
               Save SRAM
             </Button>

--- a/src/components/wizard/device-info-dialog.tsx
+++ b/src/components/wizard/device-info-dialog.tsx
@@ -25,6 +25,15 @@ const RULES_FILE_URL =
 
 const RELOAD_COMMANDS = `sudo udevadm control --reload-rules && sudo udevadm trigger`;
 
+/** Host portion of a URL, falling back to the raw string if it won't parse. */
+function hostOf(url: string): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return url;
+  }
+}
+
 interface DeviceInfoDialogProps {
   device: DeviceDef;
 }
@@ -80,7 +89,7 @@ export function DeviceInfoDialog({ device }: DeviceInfoDialogProps) {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-1 underline underline-offset-3 hover:text-foreground"
               >
-                {new URL(device.homepage).host}
+                {hostOf(device.homepage)}
                 <ExternalLink className="size-3" />
               </a>
             </DetailRow>

--- a/src/components/wizard/infinity-scanner.tsx
+++ b/src/components/wizard/infinity-scanner.tsx
@@ -292,9 +292,13 @@ export function InfinityScanner({
       const state = slots[position];
       if (state.kind !== "authenticated" || !state.uid || !state.figure) return;
       const data = buildFigureFile(state.figure);
-      await saveFile(data, uidFilename(state.uid), [".bin"]);
+      try {
+        await saveFile(data, uidFilename(state.uid), [".bin"]);
+      } catch (e) {
+        log(`Couldn't save figure: ${(e as Error).message}`, "error");
+      }
     },
-    [slots],
+    [slots, log],
   );
 
   const anyContent = POSITIONS.some((p) => slots[p].kind !== "empty");

--- a/src/components/wizard/nds-scanner.tsx
+++ b/src/components/wizard/nds-scanner.tsx
@@ -32,8 +32,10 @@ export function NDSScanner({
 
   const handleDownload = useCallback(() => {
     if (!result) return;
-    saveFile(result.outputFile.data, result.outputFile.filename, [".sav"]);
-  }, [result]);
+    saveFile(result.outputFile.data, result.outputFile.filename, [".sav"]).catch(
+      (e) => log(`Couldn't save file: ${(e as Error).message}`, "error"),
+    );
+  }, [result, log]);
 
   const activeInfo = result?.cartInfo ?? cartInfo;
   // Keep the cart panel visible on "error" too: the failure can come from

--- a/src/hooks/use-amiibo-db.ts
+++ b/src/hooks/use-amiibo-db.ts
@@ -1,5 +1,5 @@
-import { useState, useEffect } from "react";
-import { preloadAmiiboDb } from "@/lib/systems/amiibo/amiibo-db";
+import { useState, useEffect, useCallback } from "react";
+import { preloadAmiiboDb, importAmiiboDb } from "@/lib/systems/amiibo/amiibo-db";
 
 export interface AmiiboDbState {
   loaded: boolean;
@@ -8,8 +8,11 @@ export interface AmiiboDbState {
   error: string | null;
 }
 
-/** Preloads the AmiiboAPI character database on mount. */
-export function useAmiiboDb(): AmiiboDbState {
+/**
+ * Loads the user-imported Amiibo character database (cached in IndexedDB) on
+ * mount, and exposes an importer for an AmiiboAPI amiibo.json file.
+ */
+export function useAmiiboDb() {
   const [state, setState] = useState<AmiiboDbState>({
     loaded: false,
     loading: true,
@@ -27,5 +30,15 @@ export function useAmiiboDb(): AmiiboDbState {
       );
   }, []);
 
-  return state;
+  const importDb = useCallback(async (file: File) => {
+    setState((s) => ({ ...s, loading: true, error: null }));
+    try {
+      const count = await importAmiiboDb(file);
+      setState({ loaded: count > 0, loading: false, entryCount: count, error: null });
+    } catch (e) {
+      setState((s) => ({ ...s, loading: false, error: (e as Error).message }));
+    }
+  }, []);
+
+  return { ...state, importDb };
 }

--- a/src/lib/core/dump-job.ts
+++ b/src/lib/core/dump-job.ts
@@ -54,16 +54,26 @@ export class DumpJobImpl {
       this.setState("dumping_rom");
       const rawData = await this.driver.readROM(readConfig, signal);
 
-      // Dump save if requested
+      // Dump save if requested. The ROM is already in hand, so a save-read
+      // failure is logged and the dump finishes ROM-only rather than throwing
+      // away a good ROM. An abort still propagates to the outer handler.
       let saveFile;
       if (values.backupSave) {
         this.setState("dumping_save");
-        const saveData = await this.driver.readSave(readConfig, signal);
-        saveFile = {
-          data: saveData,
-          filename: `dump.sav`,
-          mimeType: "application/octet-stream",
-        };
+        try {
+          const saveData = await this.driver.readSave(readConfig, signal);
+          saveFile = {
+            data: saveData,
+            filename: `dump.sav`,
+            mimeType: "application/octet-stream",
+          };
+        } catch (error) {
+          if (signal?.aborted) throw error;
+          this.log(
+            `Save backup failed, keeping ROM only: ${(error as Error).message}`,
+            "warn",
+          );
+        }
       }
 
       // Hash, verify, then build output (verify may trim the ROM)

--- a/src/lib/core/dump-job.ts
+++ b/src/lib/core/dump-job.ts
@@ -53,6 +53,10 @@ export class DumpJobImpl {
       // Dump ROM
       this.setState("dumping_rom");
       const rawData = await this.driver.readROM(readConfig, signal);
+      // Cancellation can land after a phase resolves but before the next one
+      // begins (drivers only poll the signal mid-transfer). Re-check at each
+      // boundary so a late abort is reported as aborted, not completed.
+      signal?.throwIfAborted();
 
       // Dump save if requested. The ROM is already in hand, so a save-read
       // failure is logged and the dump finishes ROM-only rather than throwing
@@ -76,6 +80,8 @@ export class DumpJobImpl {
         }
       }
 
+      signal?.throwIfAborted();
+
       // Hash, verify, then build output (verify may trim the ROM)
       this.setState("hashing");
       const hashes = await this.system.computeHashes(rawData);
@@ -97,6 +103,7 @@ export class DumpJobImpl {
         durationMs: Date.now() - startTime,
       };
 
+      signal?.throwIfAborted();
       this.setState("complete");
       this.events.onComplete?.(result);
       return result;

--- a/src/lib/core/dump-report.ts
+++ b/src/lib/core/dump-report.ts
@@ -41,7 +41,10 @@ export function generateDumpReport(ctx: DumpReportContext): string {
   field("Software:", "nabu");
   field("Dump Time:", new Date().toISOString());
   const seconds = (durationMs / 1000).toFixed(1);
-  const rate = h.size > 0 ? formatBytes(Math.round(h.size / (durationMs / 1000))) + "/s" : "";
+  const rate =
+    h.size > 0 && durationMs > 0
+      ? formatBytes(Math.round(h.size / (durationMs / 1000))) + "/s"
+      : "";
   field("Time Elapsed:", `${seconds}s (${rate})`);
 
   // Dumping Settings

--- a/src/lib/core/file-save.ts
+++ b/src/lib/core/file-save.ts
@@ -54,7 +54,11 @@ export async function saveFile(
     await writable.write(data);
     await writable.close();
   } else {
-    const blob = new Blob([data.slice()], { type: "application/octet-stream" });
+    // `data` is a valid BlobPart; the cast sidesteps a TS6 ArrayBufferLike-vs-
+    // ArrayBuffer variance false-positive without copying the bytes.
+    const blob = new Blob([data as BlobPart], {
+      type: "application/octet-stream",
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;

--- a/src/lib/core/file-save.ts
+++ b/src/lib/core/file-save.ts
@@ -1,36 +1,67 @@
 const hasFilePicker = "showSaveFilePicker" in window;
 
+// Characters that are unsafe in filenames across Windows, Linux, and macOS.
+// Stripping them keeps a cartridge title or No-Intro name usable verbatim
+// without the save dialog rejecting it (matches the NDS handler's set).
+const RESERVED_CHARS = /[<>:"/\\|?*]/g;
+
+function sanitizeFilename(name: string): string {
+  return name.replace(RESERVED_CHARS, "").trim() || "dump";
+}
+
 /**
  * Save data to a file. Uses the File System Access API if available
  * (native save dialog), otherwise falls back to a browser download.
- * If the user cancels the native dialog, does nothing.
+ *
+ * Resolves on success or if the user cancels the native dialog. Rejects if
+ * the file couldn't actually be written, so callers can surface the failure
+ * instead of leaving the user believing a one-shot dump reached disk.
  */
 export async function saveFile(
   data: Uint8Array,
   suggestedName: string,
   extensions: string[],
 ): Promise<void> {
+  const filename = sanitizeFilename(suggestedName);
+
   if (hasFilePicker) {
+    let handle: FileSystemFileHandle;
     try {
-      const handle = await (window as unknown as { showSaveFilePicker: (opts: unknown) => Promise<FileSystemFileHandle> })
-        .showSaveFilePicker({
-          suggestedName,
-          types: [{ description: "File", accept: { "application/octet-stream": extensions } }],
-        });
-      const writable = await handle.createWritable();
-      await writable.write(data.buffer as ArrayBuffer);
-      await writable.close();
-    } catch {
-      // User cancelled — do nothing
+      handle = await (
+        window as unknown as {
+          showSaveFilePicker: (opts: unknown) => Promise<FileSystemFileHandle>;
+        }
+      ).showSaveFilePicker({
+        suggestedName: filename,
+        types: [
+          {
+            description: "File",
+            accept: { "application/octet-stream": extensions },
+          },
+        ],
+      });
+    } catch (error) {
+      // The picker rejects with AbortError when the user dismisses it — not a
+      // failure. Anything else (e.g. a name the browser refuses) is, so it
+      // falls through to the throw below.
+      if (error instanceof DOMException && error.name === "AbortError") return;
+      throw error;
     }
+
+    // A destination is chosen; a write/close failure means the bytes never
+    // reached disk, so let it propagate to the caller.
+    const writable = await handle.createWritable();
+    await writable.write(data);
+    await writable.close();
   } else {
-    // Fallback: browser download
-    const blob = new Blob([data.buffer as ArrayBuffer], { type: "application/octet-stream" });
+    const blob = new Blob([data.slice()], { type: "application/octet-stream" });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = suggestedName;
+    a.download = filename;
     a.click();
-    URL.revokeObjectURL(url);
+    // Defer the revoke: revoking in the same tick as click() can cancel the
+    // download before the browser has started fetching the blob.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 }

--- a/src/lib/core/hashing.test.ts
+++ b/src/lib/core/hashing.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { crc32, deriveContentCrc } from "./hashing";
+
+describe("crc32", () => {
+  it("returns 0 for an empty buffer", () => {
+    expect(crc32(new Uint8Array(0))).toBe(0);
+  });
+
+  it("matches the standard CRC-32 vector for ASCII '123456789'", () => {
+    expect(crc32(new TextEncoder().encode("123456789"))).toBe(0xcbf43926);
+  });
+
+  it("returns an unsigned 32-bit value when the high bit is set", () => {
+    const crc = crc32(new Uint8Array([0xff]));
+    expect(crc).toBe(crc >>> 0);
+    expect(crc).toBeGreaterThanOrEqual(0);
+  });
+
+  it("differs when a single byte changes", () => {
+    const a = new TextEncoder().encode("123456789");
+    const b = new TextEncoder().encode("123456780");
+    expect(crc32(a)).not.toBe(crc32(b));
+  });
+});
+
+describe("deriveContentCrc", () => {
+  it("recovers the content CRC from the full-file CRC and header bytes", () => {
+    const header = new Uint8Array([0x4e, 0x45, 0x53, 0x1a, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const content = new TextEncoder().encode("the actual ROM body goes here");
+    const full = new Uint8Array(header.length + content.length);
+    full.set(header, 0);
+    full.set(content, header.length);
+
+    const derived = deriveContentCrc(crc32(full), header, content.length);
+    expect(derived).toBe(crc32(content));
+  });
+
+  it("stays unsigned when the derived CRC has the high bit set", () => {
+    const header = new Uint8Array([1, 2, 3, 4]);
+    const content = new Uint8Array([0xff, 0x00, 0xff, 0x80]);
+    const full = new Uint8Array([...header, ...content]);
+
+    const derived = deriveContentCrc(crc32(full), header, content.length);
+    expect(derived).toBe(derived >>> 0);
+    expect(derived).toBe(crc32(content));
+  });
+});

--- a/src/lib/core/ndef.ts
+++ b/src/lib/core/ndef.ts
@@ -65,12 +65,20 @@ export function parseNdef(dump: Uint8Array): NdefResult {
     const il = header & 0x08;
 
     const typeLength = ndefBytes[offset++];
-    const payloadLength = sr
-      ? ndefBytes[offset++]
-      : (ndefBytes[offset++] << 24) |
-        (ndefBytes[offset++] << 16) |
-        (ndefBytes[offset++] << 8) |
-        ndefBytes[offset++];
+    let payloadLength: number;
+    if (sr) {
+      payloadLength = ndefBytes[offset++];
+    } else {
+      // 4-byte big-endian length. `>>> 0` keeps it unsigned — otherwise a
+      // high bit makes it negative and the offset walks backwards.
+      payloadLength =
+        ((ndefBytes[offset] << 24) |
+          (ndefBytes[offset + 1] << 16) |
+          (ndefBytes[offset + 2] << 8) |
+          ndefBytes[offset + 3]) >>>
+        0;
+      offset += 4;
+    }
     const idLength = il ? ndefBytes[offset++] : 0;
 
     const type = ndefBytes[offset];
@@ -106,6 +114,9 @@ function findNdefTlv(data: Uint8Array): Uint8Array | null {
 
     let length: number;
     if (data[offset] === 0xff) {
+      // 3-byte format: 0xFF then a 2-byte big-endian length. Bail if the
+      // two length bytes run past the end of a truncated dump.
+      if (offset + 2 >= data.length) break;
       length = (data[offset + 1] << 8) | data[offset + 2];
       offset += 3;
     } else {

--- a/src/lib/drivers/gbxcart/gbxcart-driver.ts
+++ b/src/lib/drivers/gbxcart/gbxcart-driver.ts
@@ -42,11 +42,8 @@ export class GBxCartDriver implements DeviceDriver {
       operations: ["dump_rom", "dump_save"],
       autoDetect: true,
     },
-    {
-      systemId: "gba",
-      operations: ["dump_rom", "dump_save"],
-      autoDetect: true,
-    },
+    // GBA save reading isn't implemented yet, so only ROM dumping is offered.
+    { systemId: "gba", operations: ["dump_rom"], autoDetect: true },
   ];
 
   transport: SerialTransport;

--- a/src/lib/drivers/gbxcart/gbxcart-driver.ts
+++ b/src/lib/drivers/gbxcart/gbxcart-driver.ts
@@ -386,11 +386,19 @@ export class GBxCartDriver implements DeviceDriver {
 
     const ack = this.fw!.expectAck;
     const maxChunk = 0x1000;
+    const mbcType = (config.params.mbcType as string) ?? "MBC5";
 
     this.log(`Reading ${saveSize / 1024} KB save...`);
 
     // Enable SRAM access
     await cartWrite(this.transport, 0x0000, 0x0a, ack);
+
+    // MBC1 only routes the 0x4000 register to the RAM bank number while in
+    // RAM-banking mode; without this, multi-bank saves all alias to bank 0.
+    // MBC3/MBC5 have no mode register and select the RAM bank directly.
+    if (mbcType === "MBC1") {
+      await cartWrite(this.transport, 0x6000, 0x01, ack);
+    }
 
     const save = new Uint8Array(saveSize);
     let bytesRead = 0;

--- a/src/lib/drivers/infinity/infinity-driver.ts
+++ b/src/lib/drivers/infinity/infinity-driver.ts
@@ -198,10 +198,21 @@ export class InfinityDriver implements DeviceDriver {
     u: number = 0,
   ): Promise<Uint8Array> {
     const resp = await this.sendCmd(CMD.READ_BLOCK, [order, block, u]);
-    // First payload byte is a status byte (0x00 on success); next 16 bytes are the block.
+    // The portal replies with a status byte (0x00 = success) followed by the
+    // 16-byte block. Each shape is rejected loudly: an empty reply would crash
+    // the error formatter, and a short success reply would let buildFigureFile
+    // zero-pad a corrupt block into the figure file.
+    if (resp.payload.length === 0) {
+      throw new Error("Portal returned an empty READ_BLOCK reply");
+    }
     if (resp.payload[0] !== 0x00) {
       throw new Error(
         `Portal error 0x${resp.payload[0].toString(16).padStart(2, "0")}`,
+      );
+    }
+    if (resp.payload.length < 17) {
+      throw new Error(
+        `Portal returned a short block (${resp.payload.length} bytes)`,
       );
     }
     return resp.payload.slice(1, 17);

--- a/src/lib/drivers/sms4/sms4-driver.ts
+++ b/src/lib/drivers/sms4/sms4-driver.ts
@@ -642,10 +642,9 @@ export class SMS4Driver implements NDSDeviceDriver {
         );
       } else {
         this.log(
-          `Wrap-probe didn't detect aliasing at any standard NDS ` +
-            `EEPROM size (512 B / 8 KB / 64 KB). Chip is larger or ` +
-            `non-standard — this cart isn't currently dumpable with ` +
-            `the SMS4.`,
+          `Wrap-probe couldn't determine the chip size (no aliasing at ` +
+            `any known M95 capacity, or the probed region is blank). This ` +
+            `cart isn't currently dumpable with the SMS4.`,
           "warn",
         );
       }
@@ -680,18 +679,20 @@ export class SMS4Driver implements NDSDeviceDriver {
   /**
    * Wrap-probe to determine the exact size of an M95-family EEPROM.
    *
-   * Mechanism: M95 chips have an SPI address bus only as wide as their
-   * actual capacity. Reading at offset `sz - 1` on a chip of exactly
-   * `sz` bytes returns chip[sz-1] then bytes that wrap to chip[0..],
-   * because higher address bits are ignored. We read 16 bytes at 0 as
-   * a "base", then 16 bytes at each candidate `sz - 1` and check
-   * whether bytes 1..15 match base[0..14]. The match identifies the
-   * exact chip size with high confidence (false-positive odds: 1 in
-   * 2^120 if save data is random; even less for sparse 0xFF saves).
+   * M95 chips have an address bus only as wide as their capacity, so a
+   * read that straddles the end wraps back to offset 0: on a chip of
+   * exactly `sz` bytes, chip[sz + i] === chip[i]. We read a 16-byte
+   * "base" window at offset 0, then 16 bytes at each candidate `sz - 1`,
+   * and treat bytes 1..15 matching base[0..14] as a wrap.
+   *
+   * Aliasing is only detectable against data that varies: an erased
+   * (all-0xFF) region wraps at every candidate and would mis-size a blank
+   * chip as the smallest one, so we bail when the base window is uniform.
    *
    * Pure reads — never writes. Cannot corrupt the chip.
    *
-   * Returns the detected size in bytes, or null if no aliasing matched.
+   * Returns the detected size in bytes, or null if it couldn't be
+   * determined (uniform base, short read, or no aliasing matched).
    */
   private async wrapProbeEepromSize(
     cmdTable: readonly number[],
@@ -705,20 +706,26 @@ export class SMS4Driver implements NDSDeviceDriver {
       );
       return null;
     }
-    // Standard NDS EEPROM sizes: 4 Kbit (512 B), 64 Kbit (8 KB),
-    // 512 Kbit (64 KB).
-    const candidates = [0x200, 0x2000, 0x10000];
+
+    // Bytes 0..14 are what the wrap test compares against. If they don't
+    // vary, every candidate aliases and the match would be meaningless.
+    const window = base.subarray(0, 15);
+    if (window.every((b) => b === window[0])) {
+      this.log(
+        `Wrap-probe: first bytes are uniform (0x${hex(base[0])}) — size ` +
+          `can't be determined by aliasing; the chip may be blank.`,
+        "warn",
+      );
+      return null;
+    }
+
+    // Every M95 capacity in SAVE_CHIPS, smallest first.
+    const candidates = [0x200, 0x400, 0x4000, 0x8000, 0x10000, 0x20000];
     for (const sz of candidates) {
       const r = await this.readSavePage(sz - 1, 16, cmdTable, flag);
       if (r.length < 16) continue;
-      let wraps = true;
-      for (let i = 0; i < 15; i++) {
-        if (r[i + 1] !== base[i]) {
-          wraps = false;
-          break;
-        }
-      }
-      if (wraps) return sz;
+      // chip[sz + i] === chip[i]  ⇒  r[1..15] === base[0..14].
+      if (window.every((b, i) => b === r[i + 1])) return sz;
     }
     return null;
   }

--- a/src/lib/systems/amiibo/amiibo-db.ts
+++ b/src/lib/systems/amiibo/amiibo-db.ts
@@ -83,17 +83,31 @@ async function ensureDb(): Promise<Map<string, string> | null> {
  * Returns the number of name entries stored.
  */
 export async function importAmiiboDb(file: File): Promise<number> {
-  const json = JSON.parse(await file.text()) as {
-    amiibos?: Record<string, { name: string }>;
-  };
-  if (!json.amiibos || typeof json.amiibos !== "object") {
+  const json: unknown = JSON.parse(await file.text());
+  const amiibos =
+    json && typeof json === "object"
+      ? (json as { amiibos?: unknown }).amiibos
+      : undefined;
+  if (!amiibos || typeof amiibos !== "object") {
     throw new Error('Not an AmiiboAPI database (no "amiibos" map).');
   }
   // Keys are 16-hex-digit IDs prefixed with "0x"; store them by the bare
-  // lowercase hex so a tag's 8-byte ID can be looked up directly.
-  const entries: [string, string][] = Object.entries(json.amiibos).map(
-    ([k, v]) => [k.slice(2).toLowerCase(), v.name],
-  );
+  // lowercase hex so a tag's 8-byte ID can be looked up directly. The file is
+  // user-supplied, so skip anything that isn't a hex-keyed entry with a name.
+  const entries: [string, string][] = Object.entries(
+    amiibos as Record<string, unknown>,
+  )
+    .filter(
+      (entry): entry is [string, { name: string }] =>
+        /^0x[0-9a-f]{16}$/i.test(entry[0]) &&
+        typeof entry[1] === "object" &&
+        entry[1] !== null &&
+        typeof (entry[1] as { name?: unknown }).name === "string",
+    )
+    .map(([k, v]) => [k.slice(2).toLowerCase(), v.name]);
+  if (entries.length === 0) {
+    throw new Error("AmiiboAPI database has no valid entries.");
+  }
   await idbReplaceAll(await openIdb(), [...entries, ["_populated", true]]);
   cache = new Map(entries);
   loading = null;

--- a/src/lib/systems/amiibo/amiibo-db.ts
+++ b/src/lib/systems/amiibo/amiibo-db.ts
@@ -1,8 +1,6 @@
-// Amiibo character name database — fetched from AmiiboAPI, cached in IndexedDB
-// Source: https://github.com/N3evin/AmiiboAPI
-
-const AMIIBO_DB_URL =
-  "https://raw.githubusercontent.com/N3evin/AmiiboAPI/master/database/amiibo.json";
+// Amiibo character name database. The user supplies AmiiboAPI's amiibo.json
+// (https://github.com/N3evin/AmiiboAPI); we parse it and cache it in
+// IndexedDB so it survives refreshes. Nothing is fetched over the network.
 
 const IDB_NAME = "nabu-amiibo";
 const IDB_STORE = "names";
@@ -29,67 +27,42 @@ function idbGet(db: IDBDatabase, key: string): Promise<unknown> {
   });
 }
 
-function idbPutAll(
+function idbReplaceAll(
   db: IDBDatabase,
   entries: [string, unknown][],
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const tx = db.transaction(IDB_STORE, "readwrite");
     const store = tx.objectStore(IDB_STORE);
+    store.clear();
     for (const [key, value] of entries) store.put(value, key);
     tx.oncomplete = () => resolve();
     tx.onerror = () => reject(tx.error);
   });
 }
 
+/** Load the cached database from IndexedDB, or null if none was imported. */
 async function loadDb(): Promise<Map<string, string> | null> {
   try {
     const db = await openIdb();
-
-    // Check IndexedDB first
-    const populated = await idbGet(db, "_populated");
-    if (populated) {
-      // Rebuild map from IDB — get all entries
-      return new Promise((resolve, reject) => {
-        const tx = db.transaction(IDB_STORE, "readonly");
-        const req = tx.objectStore(IDB_STORE).openCursor();
-        const map = new Map<string, string>();
-        req.onsuccess = () => {
-          const cursor = req.result;
-          if (cursor) {
-            if (cursor.key !== "_populated" && typeof cursor.value === "string") {
-              map.set(cursor.key as string, cursor.value);
-            }
-            cursor.continue();
-          } else {
-            resolve(map);
+    if (!(await idbGet(db, "_populated"))) return null;
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, "readonly");
+      const req = tx.objectStore(IDB_STORE).openCursor();
+      const map = new Map<string, string>();
+      req.onsuccess = () => {
+        const cursor = req.result;
+        if (cursor) {
+          if (cursor.key !== "_populated" && typeof cursor.value === "string") {
+            map.set(cursor.key as string, cursor.value);
           }
-        };
-        req.onerror = () => reject(req.error);
-      });
-    }
-
-    // Fetch from GitHub
-    const resp = await fetch(AMIIBO_DB_URL, {
-      signal: AbortSignal.timeout(15000),
+          cursor.continue();
+        } else {
+          resolve(map);
+        }
+      };
+      req.onerror = () => reject(req.error);
     });
-    if (!resp.ok) return null;
-    const json = (await resp.json()) as {
-      amiibos: Record<string, { name: string }>;
-    };
-
-    const entries: [string, string][] = Object.entries(json.amiibos).map(
-      ([k, v]) => [k.slice(2).toLowerCase(), v.name],
-    );
-    const map = new Map(entries);
-
-    // Persist to IndexedDB
-    await idbPutAll(db, [
-      ...entries,
-      ["_populated", true],
-    ]);
-
-    return map;
   } catch {
     return null;
   }
@@ -106,22 +79,44 @@ async function ensureDb(): Promise<Map<string, string> | null> {
 }
 
 /**
- * Preload the database (fetch + cache). Returns entry count.
- * Safe to call multiple times — subsequent calls are instant.
+ * Import an AmiiboAPI amiibo.json database, replacing any cached copy.
+ * Returns the number of name entries stored.
+ */
+export async function importAmiiboDb(file: File): Promise<number> {
+  const json = JSON.parse(await file.text()) as {
+    amiibos?: Record<string, { name: string }>;
+  };
+  if (!json.amiibos || typeof json.amiibos !== "object") {
+    throw new Error('Not an AmiiboAPI database (no "amiibos" map).');
+  }
+  // Keys are 16-hex-digit IDs prefixed with "0x"; store them by the bare
+  // lowercase hex so a tag's 8-byte ID can be looked up directly.
+  const entries: [string, string][] = Object.entries(json.amiibos).map(
+    ([k, v]) => [k.slice(2).toLowerCase(), v.name],
+  );
+  await idbReplaceAll(await openIdb(), [...entries, ["_populated", true]]);
+  cache = new Map(entries);
+  loading = null;
+  return cache.size;
+}
+
+/**
+ * Load the imported database into memory. Returns the entry count, or 0 if
+ * none has been imported. Safe to call repeatedly — later calls are instant.
  */
 export async function preloadAmiiboDb(): Promise<number> {
   const db = await ensureDb();
   return db?.size ?? 0;
 }
 
-/** Whether the database is currently loaded in memory. */
+/** Whether a database is currently loaded in memory. */
 export function isAmiiboDbLoaded(): boolean {
   return cache !== null;
 }
 
 /**
  * Look up an Amiibo's character name by its 8-byte hex ID.
- * Returns null if the database is unavailable or the ID is unknown.
+ * Returns null if no database is loaded or the ID is unknown.
  */
 export async function lookupAmiiboName(
   amiiboId: string,

--- a/src/lib/systems/gb/gb-header.test.ts
+++ b/src/lib/systems/gb/gb-header.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { parseGBHeader } from "./gb-header";
+
+/** Build a 0x150-byte GB header with a valid checksum, plus any overrides. */
+function buildGBHeader(
+  overrides: {
+    title?: string;
+    cartType?: number;
+    romSizeCode?: number;
+    ramSizeCode?: number;
+  } = {},
+): Uint8Array {
+  const buf = new Uint8Array(0x150);
+  const title = overrides.title ?? "TESTGAME";
+  for (let i = 0; i < title.length && i < 16; i++) {
+    buf[0x134 + i] = title.charCodeAt(i);
+  }
+  buf[0x147] = overrides.cartType ?? 0x1b; // MBC5+RAM+BATTERY
+  buf[0x148] = overrides.romSizeCode ?? 0x00; // 32 KB
+  buf[0x149] = overrides.ramSizeCode ?? 0x03; // 32 KB
+  let checksum = 0;
+  for (let i = 0x134; i <= 0x14c; i++) checksum = (checksum - buf[i] - 1) & 0xff;
+  buf[0x14d] = checksum;
+  return buf;
+}
+
+describe("parseGBHeader", () => {
+  it("returns null for a buffer shorter than the header", () => {
+    expect(parseGBHeader(new Uint8Array(0x14f))).toBeNull();
+  });
+
+  it("validates the checksum of a well-formed header", () => {
+    const header = parseGBHeader(buildGBHeader());
+    expect(header).not.toBeNull();
+    expect(header!.headerChecksumValid).toBe(true);
+  });
+
+  it("flags an invalid checksum when a covered byte changes", () => {
+    const buf = buildGBHeader();
+    buf[0x147] ^= 0xff; // mutate cart type without recomputing the checksum
+    expect(parseGBHeader(buf)!.headerChecksumValid).toBe(false);
+  });
+
+  it("decodes the title, stopping at the null terminator", () => {
+    expect(parseGBHeader(buildGBHeader({ title: "TESTGAME" }))!.title).toBe(
+      "TESTGAME",
+    );
+  });
+
+  it("strips non-printable bytes from the title", () => {
+    const buf = buildGBHeader();
+    [0x54, 0x45, 0x01, 0x53, 0x54].forEach((b, i) => (buf[0x134 + i] = b));
+    buf[0x139] = 0; // null-terminate after the five title bytes
+    expect(parseGBHeader(buf)!.title).toBe("TEST");
+  });
+
+  it("forces 512 bytes of RAM for MBC2 regardless of the RAM-size byte", () => {
+    const header = parseGBHeader(
+      buildGBHeader({ cartType: 0x06, ramSizeCode: 0x00 }), // MBC2+BATTERY
+    )!;
+    expect(header.mbc).toBe("MBC2");
+    expect(header.ramSize).toBe(512);
+  });
+
+  it("decodes ROM and RAM sizes from their header codes", () => {
+    const header = parseGBHeader(
+      buildGBHeader({ romSizeCode: 0x01, ramSizeCode: 0x02 }),
+    )!;
+    expect(header.romSize).toBe(64 * 1024);
+    expect(header.ramSize).toBe(8 * 1024);
+  });
+});

--- a/src/lib/systems/gba/gba-header.test.ts
+++ b/src/lib/systems/gba/gba-header.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { parseGBAHeader } from "./gba-header";
+
+/** Build a 0xC0-byte GBA header with a valid checksum, plus any overrides. */
+function buildGBAHeader(
+  overrides: { title?: string; gameCode?: string; makerCode?: string } = {},
+): Uint8Array {
+  const buf = new Uint8Array(0xc0);
+  const write = (offset: number, s: string, max: number) => {
+    for (let i = 0; i < s.length && i < max; i++) {
+      buf[offset + i] = s.charCodeAt(i);
+    }
+  };
+  write(0xa0, overrides.title ?? "TESTGAME", 12);
+  write(0xac, overrides.gameCode ?? "TEST", 4);
+  write(0xb0, overrides.makerCode ?? "ZZ", 2);
+  let checksum = 0;
+  for (let i = 0xa0; i <= 0xbc; i++) checksum = (checksum + buf[i]) & 0xff;
+  buf[0xbd] = (-(checksum + 0x19)) & 0xff;
+  return buf;
+}
+
+describe("parseGBAHeader", () => {
+  it("returns null for a buffer shorter than 0xC0", () => {
+    expect(parseGBAHeader(new Uint8Array(0xbf))).toBeNull();
+  });
+
+  it("validates the checksum of a well-formed header", () => {
+    expect(parseGBAHeader(buildGBAHeader())!.headerChecksumValid).toBe(true);
+  });
+
+  it("flags an invalid checksum when a covered byte changes", () => {
+    const buf = buildGBAHeader();
+    buf[0xa0] ^= 0xff; // mutate the title without recomputing the checksum
+    expect(parseGBAHeader(buf)!.headerChecksumValid).toBe(false);
+  });
+
+  it("decodes title, game code, and maker code", () => {
+    const header = parseGBAHeader(
+      buildGBAHeader({ title: "TESTROM", gameCode: "ZZZZ", makerCode: "00" }),
+    )!;
+    expect(header.title).toBe("TESTROM");
+    expect(header.gameCode).toBe("ZZZZ");
+    expect(header.makerCode).toBe("00");
+  });
+});

--- a/src/lib/systems/gba/gba-system-handler.ts
+++ b/src/lib/systems/gba/gba-system-handler.ts
@@ -22,24 +22,6 @@ const GBA_ROM_SIZES = [
   32 * 1024 * 1024,  // 32 MB
 ];
 
-const GBA_SAVE_TYPES = [
-  { value: "none", label: "None" },
-  { value: "sram_32k", label: "SRAM (32 KB)" },
-  { value: "flash_64k", label: "Flash (64 KB)" },
-  { value: "flash_128k", label: "Flash (128 KB)" },
-  { value: "eeprom_512", label: "EEPROM (512 B)" },
-  { value: "eeprom_8k", label: "EEPROM (8 KB)" },
-];
-
-const SAVE_TYPE_SIZES: Record<string, number> = {
-  none: 0,
-  sram_32k: 32 * 1024,
-  flash_64k: 64 * 1024,
-  flash_128k: 128 * 1024,
-  eeprom_512: 512,
-  eeprom_8k: 8 * 1024,
-};
-
 export class GBASystemHandler implements SystemHandler {
   readonly systemId = "gba" as const;
   readonly displayName = "Game Boy Advance";
@@ -63,30 +45,6 @@ export class GBASystemHandler implements SystemHandler {
       group: "options",
       order: 0,
     });
-
-    const saveType = (currentValues.saveType as string) ?? autoDetected?.saveType ?? "none";
-    fields.push({
-      key: "saveType",
-      label: "Save Type",
-      type: detected && autoDetected?.saveType ? "readonly" : "select",
-      value: saveType,
-      autoDetected: detected && autoDetected?.saveType != null,
-      options: GBA_SAVE_TYPES,
-      group: "options",
-      order: 1,
-    });
-
-    if (saveType !== "none") {
-      fields.push({
-        key: "backupSave",
-        label: "Backup save data",
-        type: "checkbox",
-        value: (currentValues.backupSave as boolean) ?? true,
-        group: "options",
-        order: 2,
-        helpText: `${formatBytes(SAVE_TYPE_SIZES[saveType] ?? 0)} ${saveType.replace("_", " ")}`,
-      });
-    }
 
     if (detected && autoDetected.title) {
       fields.push({
@@ -129,14 +87,10 @@ export class GBASystemHandler implements SystemHandler {
   }
 
   buildReadConfig(values: ConfigValues): ReadConfig {
-    const saveType = (values.saveType as string) ?? "none";
     return {
       systemId: "gba",
       params: {
         romSizeBytes: values.romSizeBytes as number,
-        saveType,
-        saveSizeBytes: values.backupSave ? (SAVE_TYPE_SIZES[saveType] ?? 0) : 0,
-        backupSave: (values.backupSave as boolean) ?? false,
       },
     };
   }

--- a/src/lib/transport/hid-transport.ts
+++ b/src/lib/transport/hid-transport.ts
@@ -57,13 +57,7 @@ export class HidTransport implements Transport {
 
     this.device = device;
     device.addEventListener("inputreport", this.onInputReport);
-
-    navigator.hid!.addEventListener("disconnect", ((e: HIDConnectionEvent) => {
-      if (e.device === this.device) {
-        this.device = null;
-        this.events.onDisconnect?.();
-      }
-    }) as EventListener);
+    navigator.hid!.addEventListener("disconnect", this.onHidDisconnect);
 
     return {
       vendorId: device.vendorId,
@@ -75,6 +69,7 @@ export class HidTransport implements Transport {
   }
 
   async disconnect(): Promise<void> {
+    navigator.hid!.removeEventListener("disconnect", this.onHidDisconnect);
     if (this.device) {
       this.device.removeEventListener("inputreport", this.onInputReport);
       try {
@@ -118,6 +113,16 @@ export class HidTransport implements Transport {
   ): void {
     this.events[event] = handler;
   }
+
+  // A single stable reference so the global navigator.hid listener can be
+  // removed again; otherwise every connect would leak a closure over `this`.
+  private onHidDisconnect = (event: HIDConnectionEvent): void => {
+    if (event.device === this.device) {
+      navigator.hid!.removeEventListener("disconnect", this.onHidDisconnect);
+      this.device = null;
+      this.events.onDisconnect?.();
+    }
+  };
 
   private onInputReport = (event: Event): void => {
     const { data } = event as unknown as HIDInputReportEvent;

--- a/src/lib/transport/serial-transport.ts
+++ b/src/lib/transport/serial-transport.ts
@@ -50,12 +50,7 @@ export class SerialTransport implements Transport {
     this.pendingTotal = 0;
 
     // Listen for surprise disconnect
-    port.addEventListener("disconnect", () => {
-      this.port = null;
-      this.reader = null;
-      this.writer = null;
-      this.events.onDisconnect?.();
-    });
+    port.addEventListener("disconnect", this.onSerialDisconnect);
 
     const info = port.getInfo();
     // Web Serial doesn't expose productName; the vendor:product pair is the
@@ -74,6 +69,7 @@ export class SerialTransport implements Transport {
   }
 
   async disconnect(): Promise<void> {
+    this.port?.removeEventListener("disconnect", this.onSerialDisconnect);
     try {
       if (this.reader) {
         await this.reader.cancel();
@@ -183,6 +179,16 @@ export class SerialTransport implements Transport {
     }
     this.reader = this.port.readable!.getReader();
   }
+
+  // A single stable reference so the port's disconnect listener can be
+  // removed again on disconnect (and self-removed on surprise removal).
+  private onSerialDisconnect = (): void => {
+    this.port?.removeEventListener("disconnect", this.onSerialDisconnect);
+    this.port = null;
+    this.reader = null;
+    this.writer = null;
+    this.events.onDisconnect?.();
+  };
 
   private consume(length: number): Uint8Array {
     if (this.debug) {

--- a/src/lib/transport/serial-transport.ts
+++ b/src/lib/transport/serial-transport.ts
@@ -126,7 +126,13 @@ export class SerialTransport implements Transport {
       ]);
 
       if (result.done || !result.value) {
-        throw new Error(`Serial read timeout: got ${this.pendingTotal}/${length} bytes`);
+        const got = this.pendingTotal;
+        // The timed-out read() is still pending on the reader; reset it so its
+        // late chunk can't land in the next receive(), and drop partial bytes.
+        this.pendingBytes = [];
+        this.pendingTotal = 0;
+        await this.resetReader();
+        throw new Error(`Serial read timeout: got ${got}/${length} bytes`);
       }
 
       this.pendingBytes.push(result.value);
@@ -169,13 +175,21 @@ export class SerialTransport implements Transport {
   async flush(): Promise<void> {
     this.pendingBytes = [];
     this.pendingTotal = 0;
-    // Cancel the current reader and get a fresh one to drain the serial buffer
+    await this.resetReader();
+  }
+
+  /**
+   * Cancel the current reader and acquire a fresh one. The cancel settles any
+   * read() still pending on the old reader, so its chunk can't surface in a
+   * later receive() and shift the byte stream.
+   */
+  private async resetReader(): Promise<void> {
     if (!this.port || !this.reader) return;
     try {
       await this.reader.cancel();
       this.reader.releaseLock();
     } catch {
-      // Ignore
+      // Ignore — port may already be gone
     }
     this.reader = this.port.readable!.getReader();
   }

--- a/src/web-apis.d.ts
+++ b/src/web-apis.d.ts
@@ -207,6 +207,14 @@ interface FileSystemWritableFileStream extends WritableStream {
 interface HID extends EventTarget {
   requestDevice(options: HIDDeviceRequestOptions): Promise<HIDDevice[]>;
   getDevices(): Promise<HIDDevice[]>;
+  addEventListener(
+    type: "connect" | "disconnect",
+    listener: (event: HIDConnectionEvent) => void,
+  ): void;
+  removeEventListener(
+    type: "connect" | "disconnect",
+    listener: (event: HIDConnectionEvent) => void,
+  ): void;
 }
 
 interface HIDDeviceRequestOptions {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -87,6 +87,16 @@ resource "aws_s3_bucket_public_access_block" "site" {
   restrict_public_buckets = true
 }
 
+resource "aws_s3_bucket_server_side_encryption_configuration" "site" {
+  bucket = aws_s3_bucket.site.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
 resource "aws_s3_bucket_policy" "site" {
   bucket = aws_s3_bucket.site.id
   policy = jsonencode({
@@ -225,9 +235,14 @@ resource "aws_route53_record" "site" {
 # --- IAM role for GitHub Actions OIDC ---
 
 resource "aws_iam_openid_connect_provider" "github" {
-  url             = "https://token.actions.githubusercontent.com"
-  client_id_list  = ["sts.amazonaws.com"]
-  thumbprint_list = ["ffffffffffffffffffffffffffffffffffffffff"]
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  # AWS validates this well-known IdP against its own trust store and ignores
+  # the thumbprint, but list GitHub's real published values, not a placeholder.
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fca",
+  ]
 }
 
 resource "aws_iam_role" "github_actions" {
@@ -325,8 +340,33 @@ resource "aws_iam_role_policy" "terraform" {
         Resource = [aws_s3_bucket.site.arn, "${aws_s3_bucket.site.arn}/*", "arn:aws:s3:::nabu-tools-tfstate", "arn:aws:s3:::nabu-tools-tfstate/*"]
       },
       {
-        Effect   = "Allow"
-        Action   = "cloudfront:*"
+        # CloudFront has no resource-level ARNs for these actions, so Resource
+        # stays "*"; the verbs are scoped to the resources this config manages
+        # (distribution, response-headers policy, origin access control).
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateDistribution",
+          "cloudfront:GetDistribution",
+          "cloudfront:GetDistributionConfig",
+          "cloudfront:UpdateDistribution",
+          "cloudfront:DeleteDistribution",
+          "cloudfront:ListDistributions",
+          "cloudfront:TagResource",
+          "cloudfront:UntagResource",
+          "cloudfront:ListTagsForResource",
+          "cloudfront:CreateResponseHeadersPolicy",
+          "cloudfront:GetResponseHeadersPolicy",
+          "cloudfront:GetResponseHeadersPolicyConfig",
+          "cloudfront:UpdateResponseHeadersPolicy",
+          "cloudfront:DeleteResponseHeadersPolicy",
+          "cloudfront:ListResponseHeadersPolicies",
+          "cloudfront:CreateOriginAccessControl",
+          "cloudfront:GetOriginAccessControl",
+          "cloudfront:GetOriginAccessControlConfig",
+          "cloudfront:UpdateOriginAccessControl",
+          "cloudfront:DeleteOriginAccessControl",
+          "cloudfront:ListOriginAccessControls",
+        ]
         Resource = "*"
       },
       {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,45 @@
 import path from "path"
-import { defineConfig } from "vite"
+import { defineConfig, type Plugin } from "vite"
 import react from "@vitejs/plugin-react"
 import tailwindcss from "@tailwindcss/vite"
 
+// Mirrors the CloudFront response-headers CSP (terraform/main.tf), minus
+// frame-ancestors which a <meta> CSP ignores (that stays header-only).
+const CSP = [
+  "default-src 'none'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join("; ")
+
+// Bake the CSP into the built HTML so the static output is self-protecting
+// even when served without the CloudFront headers. Build-only: in dev, Vite's
+// HMR injects inline scripts that script-src 'self' would block.
+function cspMeta(): Plugin {
+  return {
+    name: "csp-meta",
+    apply: "build",
+    transformIndexHtml() {
+      return [
+        {
+          tag: "meta",
+          attrs: {
+            "http-equiv": "Content-Security-Policy",
+            content: CSP,
+          },
+          injectTo: "head-prepend",
+        },
+      ]
+    },
+  }
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), cspMeta()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
## Summary

Addresses findings from a thorough review of the codebase, as 16 atomic,
independently-reviewable commits off `main`. The fixes cluster into
silent-data-integrity bugs (wrong dumps reported as success), hardware-I/O
robustness, security hardening, and build/infra cleanup.

## Data integrity

- **GBA save backup no longer discards a completed ROM.** The driver advertised
  `dump_save` for GBA and defaulted the backup checkbox on, but `readSave`
  throws for GBA — aborting the whole job *after* the ROM had been read. Dropped
  the capability and config fields; `dump-job` now keeps a good ROM even when the
  save step fails.
- **MBC1 multi-bank SRAM saves.** `readDMGSave` enters MBC1 RAM-banking mode
  before per-bank selects; a 32 KB MBC1 save previously read bank 0 four times.
- **SMS4 EEPROM wrap-probe.** Bails when the probe window is uniform — an erased
  (all-`0xFF`) chip was otherwise mis-sized as the smallest candidate and dumped
  truncated — and the candidate list now matches the M95 capacities in the chip
  database.
- **Disney Infinity short blocks.** `readBlock` rejects short/empty replies
  instead of letting a corrupt block get zero-padded into the figure file (also
  fixes an empty-payload crash in the error path).

## Hardware I/O

- Transports remove their disconnect listeners instead of leaking one per
  connect (the HID global listener and the serial-port listener), mirroring the
  existing USB pattern; the `as EventListener` cast is gone via typed HID event
  overloads.
- Serial `receive()` resets the reader on timeout so an abandoned in-flight read
  can't surface in the next call and shift the byte stream.
- `dump-job` re-checks the abort signal at phase boundaries, so a cancel that
  lands after a phase resolves is reported as aborted rather than complete.

## Security / hardening

- A scanned tag's NDEF URI is only rendered as a clickable link for
  http/https/mailto/tel schemes (it was an unvalidated `href`, so a hostile tag
  could supply a `javascript:` URI).
- The Content-Security-Policy is baked into the production build as a `<meta>`
  tag (build-only, so dev HMR still works) in addition to the CloudFront header.
- `file-save` sanitizes filenames, writes the typed-array view rather than the
  whole backing buffer, defers the blob-URL revoke, and surfaces genuine
  write/close failures to the event log instead of swallowing them as cancels.
- NDEF length fields are parsed unsigned and bounds-checked; the dump-report
  transfer rate and the device homepage host are guarded against bad input.

## Amiibo / tests / infra

- **The Amiibo name database is now bring-your-own** — upload AmiiboAPI's
  `amiibo.json` through the Databases panel, the same way as No-Intro DATs. The
  runtime fetch to raw.githubusercontent.com is removed (it was already blocked
  by the production CSP's `connect-src 'self'`).
- Added tests for `crc32`, the iNES header-strip CRC combine, and the GB/GBA
  header parsers (+17 tests), and wired `npm run test` into CI — it previously
  never ran the suite.
- Removed the unused `serialport` production dependency (the app uses the browser
  Web Serial API).
- Terraform: explicit AES256 encryption on the site bucket, the CI role's
  `cloudfront:*` narrowed to the verbs this config uses, and the placeholder
  OIDC thumbprint replaced with GitHub's published values.

## Notes for review / rollout

- The Terraform IAM changes were validated with `terraform fmt` only, not
  `plan`/`apply`. Please run `terraform plan` before applying — a missing
  CloudFront verb would surface at apply time, not in `fmt`.
- The Amiibo name DB and No-Intro DATs are both user-supplied at runtime.
- Intentionally **not** included: an OIDC plan/apply role split (needs a new repo
  secret and a two-phase rollout), and the verification-UX changes (clean-but-
  unknown status labelling, the NDS mirror-check warning) — left as separate
  decisions.

## Validation

`tsc -b`, `eslint`, `vitest` (107 passing), `vite build`, and
`terraform fmt -check` all clean.
