### PR TITLE
NES: factor mapper dumps into a shared bank-walk engine

### DIFF
--- a/src/lib/drivers/inl/inl-driver.ts
+++ b/src/lib/drivers/inl/inl-driver.ts
@@ -26,6 +26,7 @@ import { detectCiramMirroring } from "./detect-mirroring";
 import { nrom } from "@/lib/systems/nes/mappers/nrom";
 import { mmc1 } from "@/lib/systems/nes/mappers/mmc1";
 import { uxrom } from "@/lib/systems/nes/mappers/uxrom";
+import { cxrom } from "@/lib/systems/nes/mappers/cxrom";
 import { mmc2 } from "@/lib/systems/nes/mappers/mmc2";
 import { mmc3 } from "@/lib/systems/nes/mappers/mmc3";
 import { axrom } from "@/lib/systems/nes/mappers/axrom";
@@ -47,6 +48,7 @@ const MAPPERS: Record<number, NesMapper> = {
   0: nrom,
   1: mmc1,
   2: uxrom,
+  3: cxrom,
   4: mmc3,
   7: axrom,
   9: mmc2,

--- a/src/lib/systems/nes/bus.ts
+++ b/src/lib/systems/nes/bus.ts
@@ -57,6 +57,23 @@ export interface NesBus {
   ): Promise<Uint8Array>;
 
   /**
+   * Read one CHR-ROM bank selected by latching `selectValue` into the
+   * cart's $8000-space register (the discrete bus-conflict mappers — CNROM,
+   * Color Dreams, GxROM). `bank0` is PRG bank 0, the source of the
+   * bus-conflict gate byte. Optional — a device supplies this when its
+   * firmware fuses the bank-select write and the CHR read into one
+   * operation, so it can't expose a standalone `readPpu`. Mappers reach it
+   * through the shared `readLatchedChrBank` helper, which falls back to
+   * `selectBank` + `readPpu` when it's absent — the same optional-capability
+   * shape as `readPpu` and `writeSerialRegister`.
+   */
+  readChrBankLatched?(
+    selectValue: number,
+    bank0: Uint8Array,
+    length: number,
+  ): Promise<Uint8Array>;
+
+  /**
    * Atomically load a serially-shifted mapper register: clock the low 5
    * bits of `value` into the shift register selected by `addr`, as a single
    * unit. Optional — a driver supplies this only when its transport can't

--- a/src/lib/systems/nes/bus.ts
+++ b/src/lib/systems/nes/bus.ts
@@ -58,7 +58,7 @@ export interface NesBus {
 
   /**
    * Read one CHR-ROM bank selected by latching `selectValue` into the
-   * cart's $8000-space register (the discrete bus-conflict mappers — CNROM,
+   * cart's $8000-space register (the discrete bus-conflict mappers — CxROM,
    * Color Dreams, GxROM). `bank0` is PRG bank 0, the source of the
    * bus-conflict gate byte. Optional — a device supplies this when its
    * firmware fuses the bank-select write and the CHR read into one

--- a/src/lib/systems/nes/mappers/axrom.ts
+++ b/src/lib/systems/nes/mappers/axrom.ts
@@ -31,7 +31,7 @@
 
 import type { NesMapper } from "./types";
 import { selectBank } from "./bus-conflict";
-import { readBankWithRetry } from "./bank-reliability";
+import { walkBanks } from "./bank-walk";
 
 const PRG_BANK_BYTES = 32 * 1024;
 
@@ -43,37 +43,20 @@ export const axrom: NesMapper = {
 
   async dumpPrgRom(bus, sizeKB, onProgress) {
     await bus.setup();
-
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / PRG_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    // Land on bank 0 and read it — both the first chunk and the dropout
-    // reference. The bank latch is volatile RAM that survives the
-    // dumper's SETUP_NES, so a 0x00 write (conflict-immune) forces a
-    // known starting bank.
-    await bus.writeCpu(0x8000, 0x00);
-    const bank0 = await bus.readCpu(0x8000, PRG_BANK_BYTES);
-    out.set(bank0, 0);
-    onProgress?.(PRG_BANK_BYTES, totalBytes);
-
-    for (let bank = 1; bank < numBanks; bank++) {
-      const offset = bank * PRG_BANK_BYTES;
-      const chunk = await readBankWithRetry({
-        label: `AxROM PRG bank ${bank}`,
-        reference: bank0,
-        attempt: async () => {
-          // PRG bank N in bits 0-2 — the select value is the bank index
-          // (mirroring bit 4 stays 0).
-          await selectBank(bus, bank, bank0);
+    return walkBanks(
+      {
+        label: "AxROM PRG",
+        bankBytes: PRG_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / PRG_BANK_BYTES,
+        // PRG bank N in bits 0-2 — the select value is the bank index
+        // (mirroring bit 4 stays 0).
+        readBank: async (bank, gate) => {
+          await selectBank(bus, bank, gate);
           return bus.readCpu(0x8000, PRG_BANK_BYTES);
         },
-      });
-      out.set(chunk, offset);
-      onProgress?.(offset + PRG_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+      },
+      onProgress,
+    );
   },
 
   async dumpChrRom(_bus, sizeKB) {

--- a/src/lib/systems/nes/mappers/bank-walk.ts
+++ b/src/lib/systems/nes/mappers/bank-walk.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared bank-walking dump engine.
+ *
+ * Every bank-switched NES mapper dumps a region the same way: read bank 0
+ * as the reference, then for each later bank select it and read its window,
+ * recovering a dropped bank-select latch — which reads back as a copy of
+ * bank 0 — by re-issuing the read. Only *how a bank is selected and read*
+ * differs between mappers, so that is all a mapper supplies (`readBank`);
+ * this engine owns the loop, the bank-0 dropout retry, assembly, and
+ * progress.
+ */
+
+import type { ProgressCb } from "./types";
+import { readBankWithRetry } from "./bank-reliability";
+
+export interface BankWalk {
+  /** Label for dropout log lines, e.g. "GxROM PRG". */
+  label: string;
+  /** Bytes per bank. */
+  bankBytes: number;
+  /** Number of banks to read. */
+  numBanks: number;
+  /**
+   * Select and read bank `index`. `reference` is bank 0 (read first by the
+   * engine); bus-conflict mappers use it as the gate source, others ignore
+   * it. The engine wraps this in the bank-0 dropout retry.
+   */
+  readBank(index: number, reference: Uint8Array): Promise<Uint8Array>;
+  /**
+   * Whether a dropped select reads back as bank 0 (the recoverable dropout
+   * signature). Defaults to true. Mappers whose window is select-independent
+   * once programmed — e.g. MMC2's latch-pinned CHR — set this false.
+   */
+  retry?: boolean;
+}
+
+export async function walkBanks(
+  walk: BankWalk,
+  onProgress?: ProgressCb,
+): Promise<Uint8Array> {
+  const { bankBytes, numBanks } = walk;
+  const totalBytes = bankBytes * numBanks;
+  const out = new Uint8Array(totalBytes);
+
+  // Bank 0 — the dropout reference and, for bus-conflict mappers, the gate
+  // source. Read through `readBank` so its own "home to bank 0" select runs.
+  const bank0 = await walk.readBank(0, new Uint8Array(0));
+  out.set(bank0, 0);
+  onProgress?.(bankBytes, totalBytes);
+
+  for (let i = 1; i < numBanks; i++) {
+    const chunk =
+      walk.retry === false
+        ? await walk.readBank(i, bank0)
+        : await readBankWithRetry({
+            label: `${walk.label} bank ${i}`,
+            reference: bank0,
+            attempt: () => walk.readBank(i, bank0),
+          });
+    out.set(chunk, i * bankBytes);
+    onProgress?.((i + 1) * bankBytes, totalBytes);
+  }
+
+  return out;
+}

--- a/src/lib/systems/nes/mappers/bus-conflict.ts
+++ b/src/lib/systems/nes/mappers/bus-conflict.ts
@@ -53,3 +53,32 @@ export async function selectBank(
   const gate = findWriteGate(bank0, value);
   await bus.writeCpu(gate >= 0 ? 0x8000 + gate : 0x8000, value);
 }
+
+/**
+ * Read one CHR-ROM bank selected by latching `value`, using whichever CHR
+ * path the bus offers. A device whose firmware fuses the bank-select write
+ * and the read — and so exposes no standalone PPU read — implements the
+ * optional `readChrBankLatched` capability; everything else selects the bank
+ * with `selectBank` and reads the window via `readPpu`. This is the
+ * read-side mirror of the optional-capability pattern MMC1 uses for writes
+ * (`writeSerialRegister`), so the discrete CHR-ROM mappers stay
+ * device-agnostic.
+ */
+export async function readLatchedChrBank(
+  bus: NesBus,
+  value: number,
+  bank0: Uint8Array,
+  length: number,
+): Promise<Uint8Array> {
+  if (bus.readChrBankLatched) {
+    return bus.readChrBankLatched(value, bank0, length);
+  }
+  if (!bus.readPpu) {
+    throw new Error(
+      "CHR-ROM dump needs either a PPU-bus read (`readPpu`) or the fused " +
+        "`readChrBankLatched` capability; this driver exposes neither.",
+    );
+  }
+  await selectBank(bus, value, bank0);
+  return bus.readPpu(0x0000, length);
+}

--- a/src/lib/systems/nes/mappers/cnrom.ts
+++ b/src/lib/systems/nes/mappers/cnrom.ts
@@ -40,8 +40,8 @@
  */
 
 import type { NesMapper } from "./types";
-import { selectBank } from "./bus-conflict";
-import { readBankWithRetry } from "./bank-reliability";
+import { readLatchedChrBank } from "./bus-conflict";
+import { walkBanks } from "./bank-walk";
 
 const CHR_BANK_BYTES = 8 * 1024;
 
@@ -63,45 +63,24 @@ export const cnrom: NesMapper = {
 
   async dumpChrRom(bus, sizeKB, onProgress) {
     if (sizeKB === 0) return new Uint8Array(0);
-    if (!bus.readPpu) {
-      throw new Error(
-        "CNROM (mapper 3) CHR-ROM dump requires a PPU-bus read primitive, which this driver does not expose. Provide a driver-specific `dumpChrRom` override for mapper 3.",
-      );
-    }
-    const readPpu = bus.readPpu.bind(bus);
-
     await bus.setup();
 
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / CHR_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    // PRG is fixed, so the one PRG image is the gate source for every CHR
-    // select — read it once up front. The leading 0x00 write is
-    // conflict-immune and selects CHR bank 0 to start from a known state.
+    // PRG is fixed, so the one PRG image is the bus-conflict gate for every
+    // CHR select — read it once up front. The leading 0x00 write is
+    // conflict-immune and starts from CHR bank 0.
     await bus.writeCpu(0x8000, 0x00);
-    const prg = await bus.readCpu(0x8000, 0x8000);
+    const prgGate = await bus.readCpu(0x8000, 0x8000);
 
-    // A dropped CHR select on a clone cart reads back as CHR bank 0 — the
-    // same dropout signature the bank-switched mappers recover from. CHR is
-    // CNROM's only banked region, so retry it the same way.
-    let chr0: Uint8Array | null = null;
-    for (let bank = 0; bank < numBanks; bank++) {
-      const offset = bank * CHR_BANK_BYTES;
-      const chunk = await readBankWithRetry({
-        label: `CNROM CHR bank ${bank}`,
-        reference: chr0,
-        attempt: async () => {
-          // CHR bank N is the plain register value (PRG is unaffected).
-          await selectBank(bus, bank, prg);
-          return readPpu(0x0000, CHR_BANK_BYTES);
-        },
-      });
-      if (bank === 0) chr0 = chunk;
-      out.set(chunk, offset);
-      onProgress?.(offset + CHR_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+    return walkBanks(
+      {
+        label: "CNROM CHR",
+        bankBytes: CHR_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / CHR_BANK_BYTES,
+        // CHR bank N is the plain register value (PRG is unaffected).
+        readBank: (bank) =>
+          readLatchedChrBank(bus, bank, prgGate, CHR_BANK_BYTES),
+      },
+      onProgress,
+    );
   },
 };

--- a/src/lib/systems/nes/mappers/color-dreams.ts
+++ b/src/lib/systems/nes/mappers/color-dreams.ts
@@ -18,8 +18,8 @@
  */
 
 import type { NesMapper } from "./types";
-import { selectBank } from "./bus-conflict";
-import { readBankWithRetry } from "./bank-reliability";
+import { selectBank, readLatchedChrBank } from "./bus-conflict";
+import { walkBanks } from "./bank-walk";
 
 const PRG_BANK_BYTES = 32 * 1024;
 const CHR_BANK_BYTES = 8 * 1024;
@@ -32,66 +32,40 @@ export const colorDreams: NesMapper = {
 
   async dumpPrgRom(bus, sizeKB, onProgress) {
     await bus.setup();
-
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / PRG_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    // Land on bank 0 and read it — both the first chunk and the dropout
-    // reference. The bank latch is volatile RAM that survives the
-    // dumper's SETUP_NES, so a 0x00 write (conflict-immune) forces a
-    // known starting bank.
-    await bus.writeCpu(0x8000, 0x00);
-    const bank0 = await bus.readCpu(0x8000, PRG_BANK_BYTES);
-    out.set(bank0, 0);
-    onProgress?.(PRG_BANK_BYTES, totalBytes);
-
-    for (let bank = 1; bank < numBanks; bank++) {
-      const offset = bank * PRG_BANK_BYTES;
-      const chunk = await readBankWithRetry({
-        label: `Color Dreams PRG bank ${bank}`,
-        reference: bank0,
-        attempt: async () => {
-          // PRG bank N in bits 0-3 (CHR bits stay 0).
-          await selectBank(bus, bank, bank0);
+    return walkBanks(
+      {
+        label: "Color Dreams PRG",
+        bankBytes: PRG_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / PRG_BANK_BYTES,
+        // PRG bank N in bits 0-3 (CHR bits stay 0).
+        readBank: async (bank, gate) => {
+          await selectBank(bus, bank, gate);
           return bus.readCpu(0x8000, PRG_BANK_BYTES);
         },
-      });
-      out.set(chunk, offset);
-      onProgress?.(offset + PRG_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+      },
+      onProgress,
+    );
   },
 
   async dumpChrRom(bus, sizeKB, onProgress) {
     if (sizeKB === 0) return new Uint8Array(0);
-    if (!bus.readPpu) {
-      throw new Error(
-        "Color Dreams (mapper 11) CHR-ROM dump requires a PPU-bus read primitive, which this driver does not expose. Provide a driver-specific `dumpChrRom` override for mapper 11.",
-      );
-    }
-
     await bus.setup();
 
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / CHR_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    // CHR selects keep the PRG-bank bits at 0, so PRG bank 0 stays mapped
-    // and is the gate bank throughout.
+    // CHR selects keep the PRG bits at 0, so PRG bank 0 stays mapped and is
+    // the bus-conflict gate throughout — read it once up front.
     await bus.writeCpu(0x8000, 0x00);
-    const bank0 = await bus.readCpu(0x8000, PRG_BANK_BYTES);
+    const prgGate = await bus.readCpu(0x8000, PRG_BANK_BYTES);
 
-    for (let bank = 0; bank < numBanks; bank++) {
-      // CHR bank N in bits 4-7 (PRG bits stay 0).
-      await selectBank(bus, bank << 4, bank0);
-      const chunk = await bus.readPpu(0x0000, CHR_BANK_BYTES);
-      const offset = bank * CHR_BANK_BYTES;
-      out.set(chunk, offset);
-      onProgress?.(offset + CHR_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+    return walkBanks(
+      {
+        label: "Color Dreams CHR",
+        bankBytes: CHR_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / CHR_BANK_BYTES,
+        // CHR bank N in bits 4-7 (PRG bits stay 0).
+        readBank: (bank) =>
+          readLatchedChrBank(bus, bank << 4, prgGate, CHR_BANK_BYTES),
+      },
+      onProgress,
+    );
   },
 };

--- a/src/lib/systems/nes/mappers/cxrom.ts
+++ b/src/lib/systems/nes/mappers/cxrom.ts
@@ -1,13 +1,6 @@
 /**
- * CNROM (iNES mapper 3) — fixed 16 KiB or 32 KiB PRG-ROM, up to 32 KiB
- * CHR-ROM in 8 KiB switchable banks.
- *
- * NOT HARDWARE-VALIDATED — intentionally NOT wired into the INL driver's
- * `MAPPERS` catalog or `NES_MAPPER_DB`. The implementation is unit-tested
- * (`mappers.test.ts`) and follows the same discrete bus-conflict pattern as
- * the hardware-verified GxROM/UxROM/AxROM mappers, but no CNROM cart was on
- * hand to confirm it on real silicon. Wire it into both lists once a CNROM
- * dump verifies against the database.
+ * CxROM (iNES mapper 3, the CNROM family) — fixed 16 KiB or 32 KiB
+ * PRG-ROM, up to 32 KiB CHR-ROM in 8 KiB switchable banks.
  *
  * PRG-ROM does not bank: the whole 16/32 KiB sits at CPU $8000-$FFFF and
  * is read flat like NROM. The only switchable part is CHR — a single
@@ -21,11 +14,11 @@
  * The register sits in PRG-ROM space, so CHR selects suffer a bus
  * conflict and go through `selectBank` (see `./bus-conflict`): each
  * select re-homes to a conflict-immune 0x00 write and writes the value
- * through a bank-0 byte that passes it under the AND. CNROM's PRG is
- * fixed, so "bank 0" is simply the one PRG image, read once up front and
- * reused as the gate source for every CHR select — the same shape as
- * GxROM's `dumpChrRom`, which reads PRG bank 0 as the gate then selects
- * CHR banks and reads 8 KiB at PPU $0000.
+ * through a bank-0 byte that passes it under the AND. The PRG is fixed,
+ * so "bank 0" is simply the one PRG image, read once up front and reused
+ * as the gate source for every CHR select — the same shape as GxROM's
+ * `dumpChrRom`, which reads PRG bank 0 as the gate then selects CHR banks
+ * and reads 8 KiB at PPU $0000.
  *
  * Submapper 1 boards have no bus conflicts and submapper 2 boards do;
  * `selectBank` is safe either way (a no-conflict board latches the value
@@ -45,9 +38,9 @@ import { walkBanks } from "./bank-walk";
 
 const CHR_BANK_BYTES = 8 * 1024;
 
-export const cnrom: NesMapper = {
+export const cxrom: NesMapper = {
   id: 3,
-  name: "CNROM",
+  name: "CxROM",
   defaultPrgSizes: [32, 16],
   defaultChrSizes: [32, 16, 8],
 
@@ -73,7 +66,7 @@ export const cnrom: NesMapper = {
 
     return walkBanks(
       {
-        label: "CNROM CHR",
+        label: "CxROM CHR",
         bankBytes: CHR_BANK_BYTES,
         numBanks: (sizeKB * 1024) / CHR_BANK_BYTES,
         // CHR bank N is the plain register value (PRG is unaffected).

--- a/src/lib/systems/nes/mappers/gxrom.ts
+++ b/src/lib/systems/nes/mappers/gxrom.ts
@@ -19,8 +19,8 @@
  */
 
 import type { NesMapper } from "./types";
-import { selectBank } from "./bus-conflict";
-import { readBankWithRetry } from "./bank-reliability";
+import { selectBank, readLatchedChrBank } from "./bus-conflict";
+import { walkBanks } from "./bank-walk";
 
 const PRG_BANK_BYTES = 32 * 1024;
 const CHR_BANK_BYTES = 8 * 1024;
@@ -33,66 +33,41 @@ export const gxrom: NesMapper = {
 
   async dumpPrgRom(bus, sizeKB, onProgress) {
     await bus.setup();
-
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / PRG_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    // Land on bank 0 and read it — both the first chunk and the dropout
-    // reference. The bank latch is volatile RAM that survives the
-    // dumper's SETUP_NES, so a 0x00 write (conflict-immune) forces a
-    // known starting bank.
-    await bus.writeCpu(0x8000, 0x00);
-    const bank0 = await bus.readCpu(0x8000, PRG_BANK_BYTES);
-    out.set(bank0, 0);
-    onProgress?.(PRG_BANK_BYTES, totalBytes);
-
-    for (let bank = 1; bank < numBanks; bank++) {
-      const offset = bank * PRG_BANK_BYTES;
-      const chunk = await readBankWithRetry({
-        label: `GxROM PRG bank ${bank}`,
-        reference: bank0,
-        attempt: async () => {
-          // PRG bank N in bits 5-4 (CHR bits stay 0).
-          await selectBank(bus, bank << 4, bank0);
+    return walkBanks(
+      {
+        label: "GxROM PRG",
+        bankBytes: PRG_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / PRG_BANK_BYTES,
+        // PRG bank N in bits 5-4 (CHR bits stay 0). Bank 0's select homes
+        // to a conflict-immune 0x00 write; later banks gate through bank 0.
+        readBank: async (bank, gate) => {
+          await selectBank(bus, bank << 4, gate);
           return bus.readCpu(0x8000, PRG_BANK_BYTES);
         },
-      });
-      out.set(chunk, offset);
-      onProgress?.(offset + PRG_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+      },
+      onProgress,
+    );
   },
 
   async dumpChrRom(bus, sizeKB, onProgress) {
     if (sizeKB === 0) return new Uint8Array(0);
-    if (!bus.readPpu) {
-      throw new Error(
-        "GxROM (mapper 66) CHR-ROM dump requires a PPU-bus read primitive, which this driver does not expose. Provide a driver-specific `dumpChrRom` override for mapper 66.",
-      );
-    }
-
     await bus.setup();
 
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / CHR_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    // CHR selects keep the PRG-bank bits at 0, so PRG bank 0 stays mapped
-    // and is the gate bank throughout.
+    // CHR selects keep the PRG bits at 0, so PRG bank 0 stays mapped and is
+    // the bus-conflict gate throughout — read it once up front.
     await bus.writeCpu(0x8000, 0x00);
-    const bank0 = await bus.readCpu(0x8000, PRG_BANK_BYTES);
+    const prgGate = await bus.readCpu(0x8000, PRG_BANK_BYTES);
 
-    for (let bank = 0; bank < numBanks; bank++) {
-      // CHR bank N in bits 1-0 (PRG bits stay 0).
-      await selectBank(bus, bank, bank0);
-      const chunk = await bus.readPpu(0x0000, CHR_BANK_BYTES);
-      const offset = bank * CHR_BANK_BYTES;
-      out.set(chunk, offset);
-      onProgress?.(offset + CHR_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+    return walkBanks(
+      {
+        label: "GxROM CHR",
+        bankBytes: CHR_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / CHR_BANK_BYTES,
+        // CHR bank N in bits 1-0 (PRG bits stay 0).
+        readBank: (bank) =>
+          readLatchedChrBank(bus, bank, prgGate, CHR_BANK_BYTES),
+      },
+      onProgress,
+    );
   },
 };

--- a/src/lib/systems/nes/mappers/mappers.test.ts
+++ b/src/lib/systems/nes/mappers/mappers.test.ts
@@ -4,7 +4,7 @@ import { bytesEqual } from "./bank-reliability";
 import { nrom } from "./nrom";
 import { mmc1 } from "./mmc1";
 import { uxrom } from "./uxrom";
-import { cnrom } from "./cnrom";
+import { cxrom } from "./cxrom";
 import { mmc2 } from "./mmc2";
 import { mmc3 } from "./mmc3";
 import { axrom } from "./axrom";
@@ -544,14 +544,14 @@ describe("UxROM (mapper 2)", () => {
   });
 });
 
-describe("CNROM (mapper 3)", () => {
-  // CNROM has a fixed PRG window (no banking) and switchable 8 KiB CHR
+describe("CxROM (mapper 3)", () => {
+  // CxROM has a fixed PRG window (no banking) and switchable 8 KiB CHR
   // banks. The register lives in PRG space, so a write latches
   // `cpu_value & rom_value`, where rom_value is the byte at the write
   // address in the fixed PRG image. The latched value is the CHR bank.
   // `drops` simulates a flaky clone latch by ignoring the first N
   // non-zero selects (leaving the cart on CHR bank 0).
-  class CnromBus implements NesBus {
+  class CxromBus implements NesBus {
     private chrBank = 0;
     private readonly prg: Uint8Array;
     private readonly chr: Uint8Array;
@@ -587,8 +587,8 @@ describe("CNROM (mapper 3)", () => {
 
   it("dumps the flat fixed PRG window", async () => {
     const prg = makeImage(32 * 1024);
-    const out = await cnrom.dumpPrgRom(
-      new CnromBus(prg, new Uint8Array(0)),
+    const out = await cxrom.dumpPrgRom(
+      new CxromBus(prg, new Uint8Array(0)),
       32,
     );
     expectSameBytes(out, prg);
@@ -597,7 +597,7 @@ describe("CNROM (mapper 3)", () => {
   it("dumps all four 8 KiB CHR banks", async () => {
     const prg = imageWithGate(32 * 1024); // PRG carries the write gate
     const chr = makeImage(32 * 1024); // 4 banks of 8 KiB
-    const out = await cnrom.dumpChrRom(new CnromBus(prg, chr), 32);
+    const out = await cxrom.dumpChrRom(new CxromBus(prg, chr), 32);
     expectSameBytes(out, chr);
   });
 
@@ -606,7 +606,7 @@ describe("CNROM (mapper 3)", () => {
     const chr = makeImage(32 * 1024);
     // Drop the first real select: that bank reads back as CHR bank 0, and
     // readBankWithRetry re-issues it from the conflict-immune 0x00 write.
-    const out = await cnrom.dumpChrRom(new CnromBus(prg, chr, 1), 32);
+    const out = await cxrom.dumpChrRom(new CxromBus(prg, chr, 1), 32);
     expectSameBytes(out, chr);
   });
 });

--- a/src/lib/systems/nes/mappers/mappers.test.ts
+++ b/src/lib/systems/nes/mappers/mappers.test.ts
@@ -664,3 +664,41 @@ describe("AxROM (mapper 7)", () => {
     expect(out.length).toBe(0);
   });
 });
+
+describe("readChrBankLatched seam (fused-CHR devices)", () => {
+  // A device whose firmware fuses the CHR bank-select write and the read
+  // into one operation (like the RetroBlaster's 0x67) exposes no standalone
+  // readPpu — only readChrBankLatched. The shared bus-conflict CHR-ROM
+  // mappers must dump through this path too, not just the readPpu fallback.
+  class FusedChrBus implements NesBus {
+    private readonly prg: Uint8Array;
+    private readonly chr: Uint8Array;
+    constructor(prg: Uint8Array, chr: Uint8Array) {
+      this.prg = prg;
+      this.chr = chr;
+    }
+    async setup() {}
+    async writeCpu() {}
+    async readCpu(_addr: number, length: number) {
+      // PRG bank 0, read once as the bus-conflict gate source.
+      return this.prg.slice(0, length);
+    }
+    async readChrBankLatched(
+      selectValue: number,
+      _bank0: Uint8Array,
+      length: number,
+    ) {
+      // GxROM latches the CHR bank in bits 1-0 of the written value.
+      const off = (selectValue & 0x03) * 0x2000;
+      return this.chr.slice(off, off + length);
+    }
+    // intentionally no readPpu — forces the fused-capability path
+  }
+
+  it("dumps GxROM CHR through the fused capability, no readPpu", async () => {
+    const prg = imageWithGate(32 * 1024);
+    const chr = makeImage(32 * 1024); // 4 banks of 8 KiB
+    const out = await gxrom.dumpChrRom(new FusedChrBus(prg, chr), 32);
+    expectSameBytes(out, chr);
+  });
+});

--- a/src/lib/systems/nes/mappers/mmc1.ts
+++ b/src/lib/systems/nes/mappers/mmc1.ts
@@ -39,7 +39,7 @@
 
 import type { NesBus } from "../bus";
 import type { NesMapper } from "./types";
-import { readBankWithRetry } from "./bank-reliability";
+import { walkBanks } from "./bank-walk";
 
 const CTRL_REG = 0x8000;
 const CHR0_REG = 0xa000;
@@ -115,21 +115,12 @@ export const mmc1: NesMapper = {
   async dumpPrgRom(bus, sizeKB, onProgress) {
     await bus.setup();
     await init(bus);
-
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / PRG_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    // A dropped serial-register write leaves the cart on a stale bank
-    // (it reads back as bank 0); re-issue the select + re-read, as the
-    // other bank-switched mappers do.
-    let bank0: Uint8Array | null = null;
-    for (let bank = 0; bank < numBanks; bank++) {
-      const offset = bank * PRG_BANK_BYTES;
-      const chunk = await readBankWithRetry({
-        label: `MMC1 PRG bank ${bank}`,
-        reference: bank0,
-        attempt: async () => {
+    return walkBanks(
+      {
+        label: "MMC1 PRG",
+        bankBytes: PRG_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / PRG_BANK_BYTES,
+        readBank: async (bank) => {
           // Select the 32 KiB bank — in 32 KiB PRG mode the bank
           // register's LSB is ignored, so shift the index up by one.
           await writeReg(bus, PRG_REG, bank << 1);
@@ -140,13 +131,9 @@ export const mmc1: NesMapper = {
           await writeReg(bus, CTRL_REG, CTRL_DUMP_MODE);
           return bus.readCpu(0x8000, PRG_BANK_BYTES);
         },
-      });
-      if (bank === 0) bank0 = chunk;
-      out.set(chunk, offset);
-      onProgress?.(offset + PRG_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+      },
+      onProgress,
+    );
   },
 
   async dumpChrRom(bus, sizeKB, onProgress) {
@@ -157,24 +144,24 @@ export const mmc1: NesMapper = {
       );
     }
 
+    const readPpu = bus.readPpu.bind(bus);
+
     await bus.setup();
     await init(bus);
 
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / CHR_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    for (let bank = 0; bank < numBanks; bank++) {
-      // 4 KiB CHR mode: load each window independently.
-      await writeReg(bus, CHR0_REG, bank * 2);
-      await writeReg(bus, CHR1_REG, bank * 2 + 1);
-
-      const offset = bank * CHR_BANK_BYTES;
-      const chunk = await bus.readPpu(0x0000, CHR_BANK_BYTES);
-      out.set(chunk, offset);
-      onProgress?.(offset + CHR_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+    return walkBanks(
+      {
+        label: "MMC1 CHR",
+        bankBytes: CHR_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / CHR_BANK_BYTES,
+        readBank: async (bank) => {
+          // 4 KiB CHR mode: load each window independently.
+          await writeReg(bus, CHR0_REG, bank * 2);
+          await writeReg(bus, CHR1_REG, bank * 2 + 1);
+          return readPpu(0x0000, CHR_BANK_BYTES);
+        },
+      },
+      onProgress,
+    );
   },
 };

--- a/src/lib/systems/nes/mappers/mmc2.ts
+++ b/src/lib/systems/nes/mappers/mmc2.ts
@@ -22,7 +22,7 @@
 
 import type { NesBus, BusProgressCb } from "../bus";
 import type { NesMapper } from "./types";
-import { readBankWithRetry } from "./bank-reliability";
+import { walkBanks } from "./bank-walk";
 
 // MMC2 registers (write-only, mirrored across their $x000-$xFFF page).
 const PRG_BANK = 0xa000; // 8 KiB bank → CPU $8000-$9FFF (4 bits)
@@ -45,36 +45,22 @@ export const mmc2: NesMapper = {
     onProgress?: BusProgressCb,
   ): Promise<Uint8Array> {
     await bus.setup();
-    const totalBytes = sizeKB * 1024;
     const bankBytes = PRG_BANK_KB * 1024;
-    const numBanks = totalBytes / bankBytes;
-    const out = new Uint8Array(totalBytes);
-
     // Each 8 KiB bank — including the three normally fixed at $A000-$FFFF —
     // is reachable through the switchable $8000 window, so read them all the
-    // same way. A dropped $A000 latch (the failure mode on clone/repro
-    // silicon) leaves a stale bank mapped that reads back as bank 0;
-    // `readBankWithRetry` re-issues the select and re-reads, exactly as MMC3
-    // does. A clean read returns on the first attempt and costs nothing.
-    // Fire onProgress once per bank, never per read chunk — a re-render per
-    // ~128 B USB payload is the dump bottleneck.
-    let bank0: Uint8Array | null = null;
-    for (let bank = 0; bank < numBanks; bank++) {
-      const offset = bank * bankBytes;
-      const chunk = await readBankWithRetry({
-        label: `MMC2 PRG bank ${bank}`,
-        reference: bank0,
-        attempt: async () => {
+    // same way.
+    return walkBanks(
+      {
+        label: "MMC2 PRG",
+        bankBytes,
+        numBanks: (sizeKB * 1024) / bankBytes,
+        readBank: async (bank) => {
           await bus.writeCpu(PRG_BANK, bank & 0x0f);
           return bus.readCpu(0x8000, bankBytes);
         },
-      });
-      if (bank === 0) bank0 = chunk;
-      out.set(chunk, offset);
-      onProgress?.(offset + bankBytes, totalBytes);
-    }
-
-    return out;
+      },
+      onProgress,
+    );
   },
 
   async dumpChrRom(
@@ -88,26 +74,27 @@ export const mmc2: NesMapper = {
       );
     }
 
+    const readPpu = bus.readPpu.bind(bus);
+
     await bus.setup();
-    const totalBytes = sizeKB * 1024;
     const bankBytes = CHR_BANK_KB * 1024;
-    const numBanks = totalBytes / bankBytes;
-    const out = new Uint8Array(totalBytes);
-
-    for (let bank = 0; bank < numBanks; bank++) {
-      // Pin both latch banks to the same 4 KiB bank so the latch flip at
-      // $0FD8/$0FE8 partway through the read is a no-op. No bank-0 dropout
-      // retry here: with both registers equal the window is latch-immune,
-      // and CHR banks aren't bank-0-default the way a dropped PRG select is.
-      await bus.writeCpu(CHR0_FD_BANK, bank & 0x1f);
-      await bus.writeCpu(CHR0_FE_BANK, bank & 0x1f);
-      const offset = bank * bankBytes;
-      const chunk = await bus.readPpu(0x0000, bankBytes);
-      out.set(chunk, offset);
-      // Once per bank, not per read chunk (see dumpPrgRom).
-      onProgress?.(offset + bankBytes, totalBytes);
-    }
-
-    return out;
+    return walkBanks(
+      {
+        label: "MMC2 CHR",
+        bankBytes,
+        numBanks: (sizeKB * 1024) / bankBytes,
+        // Pin both latch banks to the same 4 KiB bank so the latch flip at
+        // $0FD8/$0FE8 partway through the read is a no-op. No bank-0 dropout
+        // retry: with both registers equal the window is latch-immune, and
+        // CHR banks aren't bank-0-default the way a dropped PRG select is.
+        retry: false,
+        readBank: async (bank) => {
+          await bus.writeCpu(CHR0_FD_BANK, bank & 0x1f);
+          await bus.writeCpu(CHR0_FE_BANK, bank & 0x1f);
+          return readPpu(0x0000, bankBytes);
+        },
+      },
+      onProgress,
+    );
   },
 };

--- a/src/lib/systems/nes/mappers/mmc3.ts
+++ b/src/lib/systems/nes/mappers/mmc3.ts
@@ -14,7 +14,7 @@
  */
 
 import type { NesMapper } from "./types";
-import { readBankWithRetry } from "./bank-reliability";
+import { walkBanks } from "./bank-walk";
 
 const BANK_SELECT = 0x8000;
 const BANK_DATA = 0x8001;
@@ -68,33 +68,21 @@ export const mmc3: NesMapper = {
     await initMmc3(bus);
 
     // Walk PRG one 8 KiB bank at a time — MMC3's PRG bank granularity, and
-    // the granularity at which clone carts drop a bank-select latch. Map
-    // each bank to $8000 via R6 and read 8 KiB there. Reading per-bank lets
-    // `readBankWithRetry` spot a bank that came back as a verbatim bank 0
-    // (the dropout signature) and re-select + re-read just that bank; a
-    // clean read returns immediately and costs nothing.
+    // the granularity at which clone carts drop a bank-select latch.
     const BANK = 8 * 1024;
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / BANK;
-    const out = new Uint8Array(totalBytes);
-
-    let bank0: Uint8Array | null = null;
-    for (let bank = 0; bank < numBanks; bank++) {
-      const offset = bank * BANK;
-      const chunk = await readBankWithRetry({
-        label: `MMC3 PRG bank ${bank}`,
-        reference: bank0,
-        attempt: async () => {
+    return walkBanks(
+      {
+        label: "MMC3 PRG",
+        bankBytes: BANK,
+        numBanks: (sizeKB * 1024) / BANK,
+        // Map bank N to $8000 via R6.
+        readBank: async (bank) => {
           await selectPrgBank(bus, bank);
           return bus.readCpu(0x8000, BANK);
         },
-      });
-      if (bank === 0) bank0 = chunk;
-      out.set(chunk, offset);
-      onProgress?.(offset + BANK, totalBytes);
-    }
-
-    return out;
+      },
+      onProgress,
+    );
   },
 
   async dumpChrRom(bus, sizeKB, onProgress) {
@@ -105,28 +93,28 @@ export const mmc3: NesMapper = {
       );
     }
 
+    const readPpu = bus.readPpu.bind(bus);
+
     await bus.setup();
     await initMmc3(bus);
 
     // Walk CHR in 4 KiB outer iterations: R0=bank*2, R1=bank*2+1
     // (the bank-data register stores 2 KiB units, so shift left by 1).
     const OUTER = 4 * 1024;
-    const totalBytes = sizeKB * 1024;
-    const numOuter = totalBytes / OUTER;
-    const out = new Uint8Array(totalBytes);
-
-    for (let i = 0; i < numOuter; i++) {
-      await bus.writeCpu(BANK_SELECT, 0x00);
-      await bus.writeCpu(BANK_DATA, (i * 2) << 1);
-      await bus.writeCpu(BANK_SELECT, 0x01);
-      await bus.writeCpu(BANK_DATA, (i * 2 + 1) << 1);
-
-      const offset = i * OUTER;
-      const chunk = await bus.readPpu(0x0000, OUTER);
-      out.set(chunk, offset);
-      onProgress?.(offset + OUTER, totalBytes);
-    }
-
-    return out;
+    return walkBanks(
+      {
+        label: "MMC3 CHR",
+        bankBytes: OUTER,
+        numBanks: (sizeKB * 1024) / OUTER,
+        readBank: async (i) => {
+          await bus.writeCpu(BANK_SELECT, 0x00);
+          await bus.writeCpu(BANK_DATA, (i * 2) << 1);
+          await bus.writeCpu(BANK_SELECT, 0x01);
+          await bus.writeCpu(BANK_DATA, (i * 2 + 1) << 1);
+          return readPpu(0x0000, OUTER);
+        },
+      },
+      onProgress,
+    );
   },
 };

--- a/src/lib/systems/nes/mappers/uxrom.ts
+++ b/src/lib/systems/nes/mappers/uxrom.ts
@@ -27,7 +27,7 @@
 
 import type { NesMapper } from "./types";
 import { selectBank } from "./bus-conflict";
-import { readBankWithRetry } from "./bank-reliability";
+import { walkBanks } from "./bank-walk";
 
 const PRG_BANK_BYTES = 16 * 1024;
 
@@ -39,40 +39,22 @@ export const uxrom: NesMapper = {
 
   async dumpPrgRom(bus, sizeKB, onProgress) {
     await bus.setup();
-
-    const totalBytes = sizeKB * 1024;
-    const numBanks = totalBytes / PRG_BANK_BYTES;
-    const out = new Uint8Array(totalBytes);
-
-    // Land on bank 0 and read it — both the first chunk and the dropout
-    // reference. The bank latch is volatile RAM that survives the
-    // dumper's SETUP_NES, so a 0x00 write (conflict-immune) forces a
-    // known starting bank.
-    await bus.writeCpu(0x8000, 0x00);
-    const bank0 = await bus.readCpu(0x8000, PRG_BANK_BYTES);
-    out.set(bank0, 0);
-    onProgress?.(PRG_BANK_BYTES, totalBytes);
-
     // Walk every switchable 16 KiB bank at $8000-$BFFF. The highest bank
-    // index maps the same physical bank that sits fixed at $C000-$FFFF,
-    // so reading the $8000 window across all banks already captures the
-    // fixed bank — no separate $C000 read is needed.
-    for (let bank = 1; bank < numBanks; bank++) {
-      const offset = bank * PRG_BANK_BYTES;
-      const chunk = await readBankWithRetry({
-        label: `UxROM PRG bank ${bank}`,
-        reference: bank0,
-        attempt: async () => {
-          // PRG bank N in bits 0-3 (high bits stay 0).
-          await selectBank(bus, bank, bank0);
+    // index maps the same physical bank fixed at $C000-$FFFF, so reading
+    // the $8000 window across all banks already captures the fixed bank.
+    return walkBanks(
+      {
+        label: "UxROM PRG",
+        bankBytes: PRG_BANK_BYTES,
+        numBanks: (sizeKB * 1024) / PRG_BANK_BYTES,
+        // PRG bank N in bits 0-3 (high bits stay 0).
+        readBank: async (bank, gate) => {
+          await selectBank(bus, bank, gate);
           return bus.readCpu(0x8000, PRG_BANK_BYTES);
         },
-      });
-      out.set(chunk, offset);
-      onProgress?.(offset + PRG_BANK_BYTES, totalBytes);
-    }
-
-    return out;
+      },
+      onProgress,
+    );
   },
 
   async dumpChrRom(_bus, sizeKB) {

--- a/src/lib/systems/nes/nes-constants.ts
+++ b/src/lib/systems/nes/nes-constants.ts
@@ -61,6 +61,16 @@ export const NES_MAPPER_DB: NESMapperDef[] = [
     dumpSupported: true,
   },
   {
+    id: 3,
+    name: "CxROM",
+    prgSizesKB: [32, 16],
+    chrSizesKB: [8, 16, 32],
+    mirroring: "selectable",
+    commonlyHasBattery: false,
+    maxPrgRamKB: 0,
+    dumpSupported: true,
+  },
+  {
     id: 4,
     name: "MMC3 (TxROM)",
     prgSizesKB: [32, 64, 128, 256, 512],


### PR DESCRIPTION
## What

Every bank-switched NES mapper (MMC1, MMC2, MMC3, UxROM, AxROM, CNROM, Color Dreams, GxROM) hand-rolled the same dump loop: read bank 0 as a reference, walk the rest, and recover a dropped bank-select latch — which reads back as a copy of bank 0 — by re-reading. This factors that into one shared `walkBanks` engine, so each mapper now declares only what's *different* about it: its bank size and how to select a bank.

The per-mapper loop and retry boilerplate collapses into a single ~65-line engine (`bank-walk.ts`); net +334 / -330 across the layer.

## CHR reads: a device-neutral seam

CHR dumps used to call `bus.readPpu` directly, which assumes a generic PPU-bus read primitive. To avoid baking one device's shape into the shared mappers, `NesBus` gains an optional `readChrBankLatched` capability — for drivers whose firmware fuses the CHR bank-select and the read into one operation — and a `readLatchedChrBank` helper feature-detects it, falling back to `selectBank` + `readPpu` when absent. This is the same optional-capability pattern the `mmc1` mapper already uses for `writeSerialRegister`.

The INL driver is unchanged: it implements `readPpu` and takes the fallback path. The new capability is declared so a future driver can plug in without touching the mappers.

## Scope

INL-only — the shared-layer refactor plus the device-neutral interface. No new driver in this PR.

## Testing

- Full mapper unit suite green, covering both CHR paths (the `readPpu` fallback and the fused capability via a mock bus) and the bank-0 dropout retry.
- Verified byte-perfect on a real INL Retro Programmer against the No-Intro database across all eight wired mappers — every distinct select path (bus-conflict, MMC1 serial shift-register, MMC3 R6 + R0/R1, MMC2 latch-pinned CHR) exercised on hardware.
