### PR TITLE
Add NES mappers: RAMBO-1 (64), Quattro (232), FME-7 (69)

### DIFF
--- a/src/components/shared/config-field.tsx
+++ b/src/components/shared/config-field.tsx
@@ -1,3 +1,4 @@
+import { AlertTriangle } from "lucide-react";
 import type { ResolvedConfigField } from "@/lib/types";
 import {
   Select,
@@ -129,6 +130,13 @@ export function ConfigField({ field, onChange }: ConfigFieldProps) {
 
       {field.lockedReason && (
         <span className="text-[11px] text-primary/70">{field.lockedReason}</span>
+      )}
+
+      {field.warning && (
+        <span className="flex items-start gap-1 text-[11px] text-chart-3">
+          <AlertTriangle className="mt-px size-3 shrink-0" />
+          <span>{field.warning}</span>
+        </span>
       )}
     </div>
   );

--- a/src/lib/systems/nes/mappers/fme7.ts
+++ b/src/lib/systems/nes/mappers/fme7.ts
@@ -1,0 +1,137 @@
+/**
+ * FME-7 / 5A / 5B (iNES mapper 69) — a command/parameter ASIC mapper,
+ * mostly seen on Famicom boards (the 5B adds expansion audio; all three
+ * variants are register-identical for dumping).
+ *
+ * Every register is reached through a two-write protocol:
+ *   $8000-$9FFF  command select (low 4 bits)
+ *   $A000-$BFFF  parameter — this write invokes the selected command
+ * The chip is an ASIC, so neither write suffers a bus conflict.
+ *
+ * Commands $0-$7 are eight independent 1 KiB CHR windows covering PPU
+ * $0000-$1FFF (8-bit bank numbers, up to 256 KiB CHR-ROM). Commands $9/$A/$B
+ * switch 8 KiB PRG-ROM banks at $8000/$A000/$C000; $E000-$FFFF is hardwired
+ * to the last bank. Walking command $9 alone covers all of PRG (the FME-7
+ * decodes 6 bank bits, the 5A/5B 5 — both beyond any released cart).
+ *
+ * Command $8 controls the $6000-$7FFF window: `ERbBBBBB`, where bit 6
+ * selects RAM over ROM and bit 7 is the RAM chip-enable (6264 +CE). Only
+ * $C0|bank exposes the battery WRAM; $40-$7F reads open bus (RAM selected
+ * but disabled), and any value with bit 6 clear ($00-$3F, $80-$BF) maps a
+ * PRG-ROM bank there instead — so dumping leaves it at $00 (RAM
+ * disconnected) and `dumpSave` brackets the save read with $C0 / $00.
+ *
+ * Two write-hazards shape the protocol, both avoided by construction:
+ * commands $D-$F are the IRQ control/counter (never selected), and on the
+ * 5B all CPU writes to $C000-$FFFF land on the expansion-audio PSG ports
+ * (reads there still return PRG-ROM) — every register access above stays
+ * within $8000-$BFFF.
+ *
+ * Reference: nesdev wiki, iNES mapper 069.
+ */
+
+import type { NesBus } from "../bus";
+import type { NesMapper } from "./types";
+import { walkBanks } from "./bank-walk";
+
+const COMMAND_REG = 0x8000; // $8000-$9FFF: command select
+const PARAMETER_REG = 0xa000; // $A000-$BFFF: parameter, invokes the command
+
+// Commands $0-$7: 1 KiB CHR window N at PPU $0000 + N*$400.
+const CMD_PRG_6000 = 0x8; // $6000-$7FFF window: ERbBBBBB (see header)
+const CMD_PRG_8000 = 0x9; // 8 KiB PRG-ROM bank at $8000-$9FFF
+// $A/$B (the $A000/$C000 windows) are unneeded — command $9 reaches every
+// bank — and $C (mirroring) doesn't affect dumped content. $D-$F are IRQ.
+
+const PRG_BANK_KB = 8;
+const PRG_BANK_BYTES = PRG_BANK_KB * 1024;
+const CHR_WINDOWS = 8; // eight 1 KiB windows = one 8 KiB stride per read
+const CHR_STRIDE_KB = 8;
+const CHR_STRIDE_BYTES = CHR_STRIDE_KB * 1024;
+
+/** Two-write register protocol: select `command`, then write its parameter. */
+async function writeReg(
+  bus: NesBus,
+  command: number,
+  value: number,
+): Promise<void> {
+  await bus.writeCpu(COMMAND_REG, command);
+  await bus.writeCpu(PARAMETER_REG, value);
+}
+
+/**
+ * Park the $6000-$7FFF window in a known, RAM-safe state: ROM bank 0,
+ * WRAM deselected and chip-disabled — so nothing during a ROM pass can
+ * touch a battery save (the same protective intent as MMC3's PRG-RAM
+ * write-protect init).
+ */
+async function init(bus: NesBus): Promise<void> {
+  await writeReg(bus, CMD_PRG_6000, 0x00);
+}
+
+export const fme7: NesMapper = {
+  id: 69,
+  name: "FME-7",
+
+  async dumpSave(bus, sramKB, onProgress) {
+    await bus.setup();
+    // $C0 = RAM selected (bit 6) + chip enabled (bit 7), WRAM bank 0 —
+    // the only command-$8 state that exposes the save SRAM at $6000.
+    await writeReg(bus, CMD_PRG_6000, 0xc0);
+    const data = await bus.readCpu(0x6000, sramKB * 1024, onProgress);
+    // Re-park the window ROM-side as soon as the read completes (the
+    // reference dumper does the same): deasserting the 6264's chip-enable
+    // shields a battery save from stray bus cycles for the rest of the
+    // session — including the unplug power-down, the riskiest window.
+    await writeReg(bus, CMD_PRG_6000, 0x00);
+    return data;
+  },
+
+  async dumpPrgRom(bus, sizeKB, onProgress) {
+    await bus.setup();
+    await init(bus);
+    return walkBanks(
+      {
+        label: "FME-7 PRG",
+        bankBytes: PRG_BANK_BYTES,
+        numBanks: sizeKB / PRG_BANK_KB,
+        readBank: async (bank) => {
+          await writeReg(bus, CMD_PRG_8000, bank);
+          return bus.readCpu(0x8000, PRG_BANK_BYTES);
+        },
+      },
+      onProgress,
+    );
+  },
+
+  async dumpChrRom(bus, sizeKB, onProgress) {
+    if (sizeKB === 0) return new Uint8Array(0); // CHR-RAM cart
+    if (!bus.readPpu) {
+      throw new Error(
+        "FME-7 CHR-ROM dump requires a PPU-bus read primitive, which this driver does not expose. Provide a driver-specific `dumpChrRom` override for mapper 69.",
+      );
+    }
+
+    const readPpu = bus.readPpu.bind(bus);
+
+    await bus.setup();
+    await init(bus);
+
+    return walkBanks(
+      {
+        label: "FME-7 CHR",
+        bankBytes: CHR_STRIDE_BYTES,
+        numBanks: sizeKB / CHR_STRIDE_KB,
+        // Program all eight 1 KiB windows to consecutive banks, then read
+        // the whole PPU $0000-$1FFF span in one stride.
+        readBank: async (stride) => {
+          for (let w = 0; w < CHR_WINDOWS; w++) {
+            await writeReg(bus, w, stride * CHR_WINDOWS + w);
+          }
+          return readPpu(0x0000, CHR_STRIDE_BYTES);
+        },
+      },
+      onProgress,
+    );
+  },
+};

--- a/src/lib/systems/nes/mappers/index.ts
+++ b/src/lib/systems/nes/mappers/index.ts
@@ -20,6 +20,7 @@ import { uxrom } from "./uxrom";
 import { cxrom } from "./cxrom";
 import { mmc2 } from "./mmc2";
 import { mmc3 } from "./mmc3";
+import { rambo1 } from "./rambo1";
 import { axrom } from "./axrom";
 import { colorDreams } from "./color-dreams";
 import { gxrom } from "./gxrom";
@@ -34,6 +35,7 @@ export const NES_MAPPERS: Record<number, NesMapper> = {
   7: axrom,
   9: mmc2,
   11: colorDreams,
+  64: rambo1,
   66: gxrom,
 };
 

--- a/src/lib/systems/nes/mappers/index.ts
+++ b/src/lib/systems/nes/mappers/index.ts
@@ -24,6 +24,7 @@ import { rambo1 } from "./rambo1";
 import { axrom } from "./axrom";
 import { colorDreams } from "./color-dreams";
 import { gxrom } from "./gxrom";
+import { quattro } from "./quattro";
 import type { NesMapper } from "./types";
 
 export const NES_MAPPERS: Record<number, NesMapper> = {
@@ -37,6 +38,7 @@ export const NES_MAPPERS: Record<number, NesMapper> = {
   11: colorDreams,
   64: rambo1,
   66: gxrom,
+  232: quattro,
 };
 
 export function getNesMapper(id: number): NesMapper | undefined {

--- a/src/lib/systems/nes/mappers/index.ts
+++ b/src/lib/systems/nes/mappers/index.ts
@@ -24,6 +24,7 @@ import { rambo1 } from "./rambo1";
 import { axrom } from "./axrom";
 import { colorDreams } from "./color-dreams";
 import { gxrom } from "./gxrom";
+import { fme7 } from "./fme7";
 import { quattro } from "./quattro";
 import type { NesMapper } from "./types";
 
@@ -38,6 +39,7 @@ export const NES_MAPPERS: Record<number, NesMapper> = {
   11: colorDreams,
   64: rambo1,
   66: gxrom,
+  69: fme7,
   232: quattro,
 };
 

--- a/src/lib/systems/nes/mappers/mappers.test.ts
+++ b/src/lib/systems/nes/mappers/mappers.test.ts
@@ -7,6 +7,7 @@ import { uxrom } from "./uxrom";
 import { cxrom } from "./cxrom";
 import { mmc2 } from "./mmc2";
 import { mmc3 } from "./mmc3";
+import { rambo1 } from "./rambo1";
 import { axrom } from "./axrom";
 import { colorDreams } from "./color-dreams";
 import { gxrom } from "./gxrom";
@@ -700,5 +701,77 @@ describe("readChrBankLatched seam (fused-CHR devices)", () => {
     const chr = makeImage(32 * 1024); // 4 banks of 8 KiB
     const out = await gxrom.dumpChrRom(new FusedChrBus(prg, chr), 32);
     expectSameBytes(out, chr);
+  });
+});
+
+describe("RAMBO-1 (mapper 64)", () => {
+  // RAMBO-1 dumps through the shared MMC3 core. This models the
+  // MMC3-compatible registers it uses for dumping — R6 (8 KiB PRG at $8000)
+  // and R0/R1 (CHR, 1 KiB units → 2 KiB windows) — and ASSERTS $A001 is
+  // never written: unlike MMC3, RAMBO-1 has no PRG-RAM control register, so
+  // a stray write there would be a bug (the reason RAMBO-1 has its own init).
+  class Rambo1Bus implements NesBus {
+    private select = 0;
+    private r = new Array<number>(16).fill(0);
+    private readonly prg: Uint8Array;
+    private readonly chr: Uint8Array;
+    constructor(prg: Uint8Array, chr: Uint8Array) {
+      this.prg = prg;
+      this.chr = chr;
+    }
+    async setup() {}
+    async writeCpu(addr: number, value: number) {
+      if (addr === 0xa001) {
+        throw new Error(
+          "RAMBO-1 has no $A001 PRG-RAM register — the dumper must not write it",
+        );
+      }
+      if (addr === 0x8000) this.select = value & 0x0f; // 4-bit command
+      else if (addr === 0x8001) this.r[this.select] = value;
+      // $A000 (mirroring) is a no-op for content reads.
+    }
+    async readCpu(addr: number, length: number) {
+      expect(addr).toBe(0x8000);
+      expect(length).toBe(8 * 1024);
+      const off = this.r[6] * 0x2000;
+      return this.prg.slice(off, off + length);
+    }
+    async readPpu(addr: number, length: number) {
+      expect(addr).toBe(0x0000);
+      expect(length).toBe(4 * 1024);
+      const b0 = (this.r[0] >> 1) * 0x800;
+      const b1 = (this.r[1] >> 1) * 0x800;
+      const out = new Uint8Array(length);
+      out.set(this.chr.slice(b0, b0 + 0x800), 0);
+      out.set(this.chr.slice(b1, b1 + 0x800), 0x800);
+      return out;
+    }
+  }
+
+  it("walks all PRG banks via R6, never touching $A001 (64 KiB)", async () => {
+    const prg = makeImage(64 * 1024); // 8 banks of 8 KiB
+    const out = await rambo1.dumpPrgRom(
+      new Rambo1Bus(prg, new Uint8Array(0)),
+      64,
+    );
+    expectSameBytes(out, prg);
+  });
+
+  it("walks CHR via R0/R1 (64 KiB)", async () => {
+    const chr = makeImage(64 * 1024);
+    const out = await rambo1.dumpChrRom(
+      new Rambo1Bus(new Uint8Array(0), chr),
+      64,
+    );
+    expectSameBytes(out, chr);
+  });
+
+  it("throws a clear error when the bus has no PPU read", async () => {
+    const noPpu: NesBus = {
+      setup: async () => {},
+      writeCpu: async () => {},
+      readCpu: async () => new Uint8Array(0),
+    };
+    await expect(rambo1.dumpChrRom(noPpu, 64)).rejects.toThrow(/PPU-bus/);
   });
 });

--- a/src/lib/systems/nes/mappers/mappers.test.ts
+++ b/src/lib/systems/nes/mappers/mappers.test.ts
@@ -11,6 +11,7 @@ import { rambo1 } from "./rambo1";
 import { axrom } from "./axrom";
 import { colorDreams } from "./color-dreams";
 import { gxrom } from "./gxrom";
+import { fme7 } from "./fme7";
 import { quattro } from "./quattro";
 
 /**
@@ -786,6 +787,138 @@ describe("RAMBO-1 (mapper 64)", () => {
       readCpu: async () => new Uint8Array(0),
     };
     await expect(rambo1.dumpChrRom(noPpu, 64)).rejects.toThrow(/PPU-bus/);
+  });
+});
+
+describe("FME-7 (mapper 69)", () => {
+  // Models the two-write command/parameter protocol: $8000-$9FFF latches the
+  // command (low 4 bits), $A000-$BFFF invokes it with the parameter. Eight
+  // 1 KiB CHR windows (commands $0-$7), 8 KiB PRG bank at $8000 via $9, and
+  // the command-$8 $6000 window — RAM only when bits 7+6 are both set
+  // ($C0|bank), open bus when RAM is selected but disabled ($40-$7F), a ROM
+  // bank otherwise. The model THROWS on the two write-hazards the dumper
+  // must never hit: IRQ commands $D-$F, and any CPU write at or above $C000
+  // (the 5B's expansion-audio ports live there). `drops` simulates a
+  // flaky latch by ignoring the first N non-zero PRG bank parameters.
+  class Fme7Bus implements NesBus {
+    private command = 0;
+    private r = new Array<number>(13).fill(0); // commands $0-$C
+    private readonly prg: Uint8Array;
+    private readonly chr: Uint8Array;
+    private readonly wram: Uint8Array;
+    private drops: number;
+    constructor(
+      prg: Uint8Array,
+      chr: Uint8Array,
+      wram = new Uint8Array(0),
+      drops = 0,
+    ) {
+      this.prg = prg;
+      this.chr = chr;
+      this.wram = wram;
+      this.drops = drops;
+    }
+    async setup() {}
+    async writeCpu(addr: number, value: number) {
+      if (addr >= 0xc000) {
+        throw new Error(
+          "CPU write at/above $C000 — the 5B's audio ports; the dumper must not write here",
+        );
+      }
+      if (addr < 0xa000) {
+        expect(addr).toBeGreaterThanOrEqual(0x8000);
+        this.command = value & 0x0f;
+        return;
+      }
+      if (this.command >= 0x0d) {
+        throw new Error(
+          "IRQ command $D-$F invoked — the dumper must not touch the IRQ registers",
+        );
+      }
+      if (this.command === 0x09 && value !== 0 && this.drops > 0) {
+        this.drops--; // dropped latch: register keeps its old value
+        return;
+      }
+      this.r[this.command] = value;
+    }
+    async readCpu(addr: number, length: number) {
+      expect(length).toBe(8 * 1024);
+      if (addr === 0x6000) {
+        const reg8 = this.r[0x08];
+        // Bit 6 selects RAM, bit 7 enables the chip; both → WRAM (the
+        // single 8 KiB chip on real carts ignores the bank bits).
+        if ((reg8 & 0xc0) === 0xc0) return this.wram.slice(0, length);
+        // RAM selected but disabled → open bus.
+        if (reg8 & 0x40) return new Uint8Array(length).fill(0xff);
+        const off = (reg8 & 0x3f) * 0x2000;
+        return this.prg.slice(off, off + length);
+      }
+      expect(addr).toBe(0x8000);
+      const off = this.r[0x09] * 0x2000;
+      return this.prg.slice(off, off + length);
+    }
+    async readPpu(addr: number, length: number) {
+      expect(addr).toBe(0x0000);
+      expect(length).toBe(8 * 1024);
+      // Each of the eight 1 KiB windows resolves independently.
+      const out = new Uint8Array(length);
+      for (let w = 0; w < 8; w++) {
+        const off = this.r[w] * 0x400;
+        out.set(this.chr.slice(off, off + 0x400), w * 0x400);
+      }
+      return out;
+    }
+  }
+
+  it("walks all PRG banks via command $9 (128 KiB)", async () => {
+    const prg = makeImage(128 * 1024); // 16 banks of 8 KiB
+    const out = await fme7.dumpPrgRom(new Fme7Bus(prg, new Uint8Array(0)), 128);
+    expectSameBytes(out, prg);
+  });
+
+  it("walks CHR through the eight 1 KiB windows (256 KiB)", async () => {
+    const chr = makeImage(256 * 1024);
+    const out = await fme7.dumpChrRom(new Fme7Bus(new Uint8Array(0), chr), 256);
+    expectSameBytes(out, chr);
+  });
+
+  it("brackets the save read: $C0 exposes WRAM, $00 re-disables it after", async () => {
+    const prg = makeImage(16 * 1024);
+    // Inverted so WRAM can't collide with ROM bank 0 (makeImage is
+    // deterministic — a plain 8 KiB image would equal PRG's first bank).
+    const wram = Uint8Array.from(makeImage(8 * 1024), (b) => b ^ 0xff);
+    const bus = new Fme7Bus(prg, new Uint8Array(0), wram);
+    const out = await fme7.dumpSave!(bus, 8);
+    expectSameBytes(out, wram);
+    // The trailing $00 must have re-parked the window ROM-side (RAM
+    // chip-disabled), so $6000 reads ROM bank 0 again — not the WRAM.
+    expectSameBytes(
+      await bus.readCpu(0x6000, 8 * 1024),
+      prg.slice(0, 8 * 1024),
+    );
+  });
+
+  it("recovers from a dropped PRG bank latch via the bank-0 retry", async () => {
+    const prg = makeImage(128 * 1024);
+    const out = await fme7.dumpPrgRom(
+      new Fme7Bus(prg, new Uint8Array(0), new Uint8Array(0), 1),
+      128,
+    );
+    expectSameBytes(out, prg);
+  });
+
+  it("returns an empty CHR dump for CHR-RAM carts (size 0)", async () => {
+    const out = await fme7.dumpChrRom({} as NesBus, 0);
+    expect(out.length).toBe(0);
+  });
+
+  it("throws a clear error when the bus has no PPU read", async () => {
+    const noPpu: NesBus = {
+      setup: async () => {},
+      writeCpu: async () => {},
+      readCpu: async () => new Uint8Array(0),
+    };
+    await expect(fme7.dumpChrRom(noPpu, 128)).rejects.toThrow(/PPU-bus/);
   });
 });
 

--- a/src/lib/systems/nes/mappers/mappers.test.ts
+++ b/src/lib/systems/nes/mappers/mappers.test.ts
@@ -11,6 +11,7 @@ import { rambo1 } from "./rambo1";
 import { axrom } from "./axrom";
 import { colorDreams } from "./color-dreams";
 import { gxrom } from "./gxrom";
+import { quattro } from "./quattro";
 
 /**
  * A deterministic, well-mixed cart image. The multiplicative hash makes
@@ -38,6 +39,18 @@ function expectSameBytes(actual: Uint8Array, expected: Uint8Array) {
 function imageWithGate(bytes: number): Uint8Array {
   const a = makeImage(bytes);
   a[3] = 0xff;
+  return a;
+}
+
+/**
+ * Like `imageWithGate`, but seeds a 0xFF write gate at offset 3 of *every*
+ * `bankBytes`-sized bank. The two-register Quattro (mapper 232) gates its
+ * page selects through whichever bank sits in the $C000 window — a different
+ * bank per outer block — not just bank 0, so each needs a gate byte.
+ */
+function imageWithGatePerBank(bytes: number, bankBytes: number): Uint8Array {
+  const a = makeImage(bytes);
+  for (let off = 0; off < bytes; off += bankBytes) a[off + 3] = 0xff;
   return a;
 }
 
@@ -773,5 +786,80 @@ describe("RAMBO-1 (mapper 64)", () => {
       readCpu: async () => new Uint8Array(0),
     };
     await expect(rambo1.dumpChrRom(noPpu, 64)).rejects.toThrow(/PPU-bus/);
+  });
+});
+
+describe("Quattro (mapper 232)", () => {
+  // Two-register BF9096 multicart, modeled WITH a bus conflict on both
+  // registers (the gate path must work either way). $8000-$BFFF latches
+  // `value & rom` → block in bits 4-3; $C000-$FFFF latches `value & rom` →
+  // page in bits 1-0. The $8000 window maps block*4+page; the $C000 window
+  // is fixed to block*4+3. The rom gate byte for a write comes from whichever
+  // 16 KiB window the address lands in. `drops` simulates a flaky latch by
+  // ignoring the first N non-zero PAGE selects, leaving page 0 — which on
+  // block 0 reads back as bank 0, the recoverable dropout.
+  class QuattroBus implements NesBus {
+    private block = 0;
+    private page = 0;
+    private readonly prg: Uint8Array;
+    private drops: number;
+    constructor(prg: Uint8Array, drops = 0) {
+      this.prg = prg;
+      this.drops = drops;
+    }
+    async setup() {}
+    private bankIn(window: 0 | 1): number {
+      // 0 = $8000-$BFFF (switchable), 1 = $C000-$FFFF (fixed last page)
+      return window === 0 ? this.block * 4 + this.page : this.block * 4 + 3;
+    }
+    async writeCpu(addr: number, value: number) {
+      expect(addr).toBeGreaterThanOrEqual(0x8000);
+      const window = addr < 0xc000 ? 0 : 1;
+      const romByte = this.prg[this.bankIn(window) * 0x4000 + (addr & 0x3fff)];
+      const latched = value & (romByte ?? 0xff);
+      if (window === 0) {
+        // submapper 1: D4 = block bit 0, D3 = block bit 1 (swapped order)
+        this.block = (((latched >> 3) & 1) << 1) | ((latched >> 4) & 1);
+      } else {
+        const newPage = latched & 0x03;
+        if (newPage !== 0 && this.drops > 0) {
+          this.drops--; // dropped page latch: register keeps its old value
+          return;
+        }
+        this.page = newPage;
+      }
+    }
+    async readCpu(addr: number, length: number) {
+      expect(length).toBe(0x4000); // 16 KiB window
+      const window = addr === 0x8000 ? 0 : addr === 0xc000 ? 1 : -1;
+      expect(window).not.toBe(-1);
+      const off = this.bankIn(window as 0 | 1) * 0x4000;
+      return this.prg.slice(off, off + length);
+    }
+  }
+
+  it("dumps all sixteen 16 KiB banks across four blocks (256 KiB)", async () => {
+    const prg = imageWithGatePerBank(256 * 1024, 0x4000);
+    const out = await quattro.dumpPrgRom(new QuattroBus(prg), 256);
+    expectSameBytes(out, prg);
+  });
+
+  it("recovers from a dropped page select via the bank-0 retry", async () => {
+    const prg = imageWithGatePerBank(256 * 1024, 0x4000);
+    // Drop the first non-zero page select (block 0, page 1): it reads back as
+    // bank 0, and readBankWithRetry re-issues the select and re-reads.
+    const out = await quattro.dumpPrgRom(new QuattroBus(prg, 1), 256);
+    expectSameBytes(out, prg);
+  });
+
+  it("returns an empty CHR dump for the CHR-RAM cart (size 0)", async () => {
+    const out = await quattro.dumpChrRom({} as NesBus, 0);
+    expect(out.length).toBe(0);
+  });
+
+  it("throws if asked to dump CHR-ROM (Quattro is CHR-RAM)", async () => {
+    await expect(quattro.dumpChrRom({} as NesBus, 8)).rejects.toThrow(
+      /CHR-RAM/,
+    );
   });
 });

--- a/src/lib/systems/nes/mappers/mmc3.ts
+++ b/src/lib/systems/nes/mappers/mmc3.ts
@@ -11,9 +11,15 @@
  * This mapper requires `bus.readPpu` for CHR-ROM dumps. A driver
  * without a generic PPU-bus primitive provides a driver-specific
  * `dumpChrRom` override instead.
+ *
+ * The PRG/CHR dump core is shared with RAMBO-1 (mapper 64), which
+ * is an MMC3 superset that, in the mode we configure for dumping, banks
+ * identically — see `./rambo1`. Only the register init differs (RAMBO-1
+ * has no PRG-RAM), so the variant supplies its own `init`.
  */
 
-import type { NesMapper } from "./types";
+import type { NesBus } from "../bus";
+import type { NesMapper, ProgressCb } from "./types";
 import { walkBanks } from "./bank-walk";
 
 const BANK_SELECT = 0x8000;
@@ -21,13 +27,25 @@ const BANK_DATA = 0x8001;
 const MIRRORING = 0xa000;
 const PRG_RAM_CTRL = 0xa001;
 
-/** Set up MMC3 registers to a known state before dumping. */
-async function initMmc3(bus: Parameters<NesMapper["dumpPrgRom"]>[0]): Promise<void> {
-  // PRG-RAM: disable writes, allow reads (so writes to $6000-$7FFF are ignored)
-  await bus.writeCpu(PRG_RAM_CTRL, 0x40);
+/**
+ * An MMC3-style mapper for the shared dump core: a display name, its iNES
+ * id (used only in the no-PPU error), and the register init to run after
+ * `setup()`. MMC3 and RAMBO-1 differ only in `init`.
+ */
+export interface Mmc3StyleVariant {
+  name: string;
+  id: number;
+  init(bus: NesBus): Promise<void>;
+}
+
+/**
+ * Program R0/R1 (CHR) and R6/R7 (PRG) plus mirroring to a known state —
+ * the bank setup common to MMC3 and RAMBO-1. CHR mode 0, PRG mode 0
+ * ($8000 bit 7 = 0, bit 6 = 0).
+ */
+export async function setupBanks(bus: NesBus): Promise<void> {
   // Vertical mirroring — irrelevant for dumping content but a deterministic start
   await bus.writeCpu(MIRRORING, 0x00);
-  // CHR mode 0, PRG mode 0 (8000 bit 7 = 0, bit 6 = 0)
   // R0 -> 2 KiB CHR at PPU $0000
   await bus.writeCpu(BANK_SELECT, 0x00);
   await bus.writeCpu(BANK_DATA, 0x00);
@@ -42,6 +60,13 @@ async function initMmc3(bus: Parameters<NesMapper["dumpPrgRom"]>[0]): Promise<vo
   await bus.writeCpu(BANK_DATA, 0x01);
 }
 
+/** Set up MMC3 registers to a known state before dumping. */
+async function initMmc3(bus: NesBus): Promise<void> {
+  // PRG-RAM: disable writes, allow reads (so writes to $6000-$7FFF are ignored)
+  await bus.writeCpu(PRG_RAM_CTRL, 0x40);
+  await setupBanks(bus);
+}
+
 /**
  * Map the 8 KiB PRG bank `bank` to $8000 via R6, issued once. This is the
  * pure MMC3 protocol — no clone-cart workaround lives here. Recovery from a
@@ -49,72 +74,93 @@ async function initMmc3(bus: Parameters<NesMapper["dumpPrgRom"]>[0]): Promise<vo
  * handled reactively by `readBankWithRetry` in the dump loop, which
  * re-invokes this select and re-reads when a bank comes back as bank 0.
  */
-async function selectPrgBank(
-  bus: Parameters<NesMapper["dumpPrgRom"]>[0],
-  bank: number,
-): Promise<void> {
+async function selectPrgBank(bus: NesBus, bank: number): Promise<void> {
   await bus.writeCpu(BANK_SELECT, 0x06);
   await bus.writeCpu(BANK_DATA, bank);
 }
+
+/**
+ * Dump PRG-ROM for an MMC3-style variant: walk one 8 KiB bank at a time via
+ * R6 — MMC3's PRG bank granularity, and the granularity at which clone carts
+ * drop a bank-select latch.
+ */
+export async function dumpMmc3StylePrgRom(
+  bus: NesBus,
+  sizeKB: number,
+  variant: Mmc3StyleVariant,
+  onProgress?: ProgressCb,
+): Promise<Uint8Array> {
+  await bus.setup();
+  await variant.init(bus);
+
+  const BANK_KB = 8;
+  const BANK = BANK_KB * 1024;
+  return walkBanks(
+    {
+      label: `${variant.name} PRG`,
+      bankBytes: BANK,
+      numBanks: sizeKB / BANK_KB,
+      // Map bank N to $8000 via R6.
+      readBank: async (bank) => {
+        await selectPrgBank(bus, bank);
+        return bus.readCpu(0x8000, BANK);
+      },
+    },
+    onProgress,
+  );
+}
+
+/**
+ * Dump CHR-ROM for an MMC3-style variant: walk in 4 KiB outer iterations,
+ * R0=bank*2, R1=bank*2+1 (the bank-data register stores 2 KiB units, so
+ * shift left by 1).
+ */
+export async function dumpMmc3StyleChrRom(
+  bus: NesBus,
+  sizeKB: number,
+  variant: Mmc3StyleVariant,
+  onProgress?: ProgressCb,
+): Promise<Uint8Array> {
+  if (sizeKB === 0) return new Uint8Array(0);
+  if (!bus.readPpu) {
+    throw new Error(
+      `${variant.name} CHR-ROM dump requires a PPU-bus read primitive, which this driver does not expose. Provide a driver-specific \`dumpChrRom\` override for mapper ${variant.id}.`,
+    );
+  }
+
+  const readPpu = bus.readPpu.bind(bus);
+
+  await bus.setup();
+  await variant.init(bus);
+
+  const OUTER_KB = 4;
+  const OUTER = OUTER_KB * 1024;
+  return walkBanks(
+    {
+      label: `${variant.name} CHR`,
+      bankBytes: OUTER,
+      numBanks: sizeKB / OUTER_KB,
+      readBank: async (i) => {
+        await bus.writeCpu(BANK_SELECT, 0x00);
+        await bus.writeCpu(BANK_DATA, (i * 2) << 1);
+        await bus.writeCpu(BANK_SELECT, 0x01);
+        await bus.writeCpu(BANK_DATA, (i * 2 + 1) << 1);
+        return readPpu(0x0000, OUTER);
+      },
+    },
+    onProgress,
+  );
+}
+
+const MMC3: Mmc3StyleVariant = { name: "MMC3", id: 4, init: initMmc3 };
 
 export const mmc3: NesMapper = {
   id: 4,
   name: "MMC3",
 
-  async dumpPrgRom(bus, sizeKB, onProgress) {
-    await bus.setup();
-    await initMmc3(bus);
+  dumpPrgRom: (bus, sizeKB, onProgress) =>
+    dumpMmc3StylePrgRom(bus, sizeKB, MMC3, onProgress),
 
-    // Walk PRG one 8 KiB bank at a time — MMC3's PRG bank granularity, and
-    // the granularity at which clone carts drop a bank-select latch.
-    const BANK_KB = 8;
-    const BANK = BANK_KB * 1024;
-    return walkBanks(
-      {
-        label: "MMC3 PRG",
-        bankBytes: BANK,
-        numBanks: sizeKB / BANK_KB,
-        // Map bank N to $8000 via R6.
-        readBank: async (bank) => {
-          await selectPrgBank(bus, bank);
-          return bus.readCpu(0x8000, BANK);
-        },
-      },
-      onProgress,
-    );
-  },
-
-  async dumpChrRom(bus, sizeKB, onProgress) {
-    if (sizeKB === 0) return new Uint8Array(0);
-    if (!bus.readPpu) {
-      throw new Error(
-        "MMC3 CHR-ROM dump requires a PPU-bus read primitive, which this driver does not expose. Provide a driver-specific `dumpChrRom` override for mapper 4.",
-      );
-    }
-
-    const readPpu = bus.readPpu.bind(bus);
-
-    await bus.setup();
-    await initMmc3(bus);
-
-    // Walk CHR in 4 KiB outer iterations: R0=bank*2, R1=bank*2+1
-    // (the bank-data register stores 2 KiB units, so shift left by 1).
-    const OUTER_KB = 4;
-    const OUTER = OUTER_KB * 1024;
-    return walkBanks(
-      {
-        label: "MMC3 CHR",
-        bankBytes: OUTER,
-        numBanks: sizeKB / OUTER_KB,
-        readBank: async (i) => {
-          await bus.writeCpu(BANK_SELECT, 0x00);
-          await bus.writeCpu(BANK_DATA, (i * 2) << 1);
-          await bus.writeCpu(BANK_SELECT, 0x01);
-          await bus.writeCpu(BANK_DATA, (i * 2 + 1) << 1);
-          return readPpu(0x0000, OUTER);
-        },
-      },
-      onProgress,
-    );
-  },
+  dumpChrRom: (bus, sizeKB, onProgress) =>
+    dumpMmc3StyleChrRom(bus, sizeKB, MMC3, onProgress),
 };

--- a/src/lib/systems/nes/mappers/quattro.ts
+++ b/src/lib/systems/nes/mappers/quattro.ts
@@ -1,0 +1,153 @@
+/**
+ * Quattro (iNES mapper 232, BF9096) — a 4-in-1 multicart: 256 KiB PRG as four
+ * 64 KiB outer blocks (one game each), 8 KiB CHR-RAM.
+ *
+ * Two registers, both in PRG-ROM space:
+ *   $8000-$BFFF  PRG block (outer) select — bits 4-3 pick the 64 KiB block.
+ *   $C000-$FFFF  PRG page (inner) select  — bits 1-0 pick the 16 KiB page.
+ * The 16 KiB window at $8000-$BFFF maps `block*4 + page`; the window at
+ * $C000-$FFFF is fixed to `block*4 + 3` (the block's last page). So every
+ * 16 KiB bank is reachable at $8000 by setting block then page.
+ *
+ * Both registers live in PRG-ROM space, so writes go through the same bus
+ * conflict the discrete mappers handle (`./bus-conflict`): re-home with a
+ * conflict-immune 0x00 write, then write the value through a byte that
+ * survives the AND. The gate is correct whether or not the chip actually
+ * conflicts — a clean latch passes the value too. 0x00 homes the block
+ * register to block 0 and the page register to page 0.
+ *
+ * CHR is CHR-RAM, so there is no CHR-ROM to dump.
+ *
+ * The standalone carts are NES 2.0 mapper 232 SUBMAPPER 1: the two outer
+ * block-select bits are wired swapped — D4 = block bit 0, D3 = block bit 1 —
+ * so block selection goes through `blockSelectValue`, not a naive `block << 3`,
+ * which lands the four 64 KiB blocks in catalog order. Hardware-verified; some
+ * docs instead describe the chip's bank bits as 4 & 5, but these boards wire
+ * D3/D4 — don't "correct" it.
+ *
+ * DUMPING / SAFETY — the cart's A/B switch toggles a CIC lockout-defeat
+ * circuit: position A = OFF, position B = ON. A bare cart reader has no CIC
+ * (like a top-loader), so dump with the switch in POSITION A. Leaving it in B
+ * on such a reader makes the cart's charge pump draw heavy current and can
+ * damage the cart if left on.
+ *
+ * Reference: nesdev wiki "INES Mapper 232".
+ */
+
+import type { NesBus } from "../bus";
+import type { NesMapper } from "./types";
+import { selectBank, findWriteGate } from "./bus-conflict";
+import { readBankWithRetry } from "./bank-reliability";
+
+const BLOCK_REG = 0x8000; // $8000-$BFFF: outer block select, bits 4-3
+const PAGE_REG = 0xc000; // $C000-$FFFF: inner page select, bits 1-0
+const PRG_BANK_KB = 16;
+const PRG_BANK_BYTES = PRG_BANK_KB * 1024;
+const PAGES_PER_BLOCK = 4; // 64 KiB block / 16 KiB page
+
+/**
+ * Register value that selects outer block `block` (0-3). Submapper 1 (the
+ * standalone carts) wires the two block bits swapped — D4 = block bit 0,
+ * D3 = block bit 1 — so blocks 1 and 2 trade register values versus a naive
+ * `block << 3`.
+ */
+function blockSelectValue(block: number): number {
+  return ((block & 1) << 4) | ((block >> 1) << 3);
+}
+
+/**
+ * Select outer block `block` (0-3). The block register is at $8000-$BFFF,
+ * so reuse the shared re-home-then-gate select: it homes to block 0 with a
+ * conflict-immune 0x00 write, then writes `blockSelectValue(block)` through a
+ * bank-0 byte that survives the AND. Page is forced to 0 first so the 0x00
+ * re-home lands on bank 0 (the $8000 window is `block*4 + page`), making
+ * `bank0` the correct gate source.
+ */
+async function selectBlock(
+  bus: NesBus,
+  block: number,
+  bank0: Uint8Array,
+): Promise<void> {
+  await bus.writeCpu(PAGE_REG, 0x00); // page 0 first
+  await selectBank(bus, blockSelectValue(block), bank0); // writes to $8000
+}
+
+/**
+ * Select inner page `page` (0-3) within the current block. The page
+ * register is at $C000-$FFFF, whose window is fixed to the block's last
+ * page (`block*4 + 3`) regardless of `page` — `pageGate` is that bank, read
+ * once per block as the gate source. A 0x00 write homes to page 0
+ * (conflict-immune); a non-zero page gates through `pageGate`.
+ */
+async function selectPage(
+  bus: NesBus,
+  page: number,
+  pageGate: Uint8Array,
+): Promise<void> {
+  await bus.writeCpu(PAGE_REG, 0x00); // page 0 (conflict-immune)
+  if (page === 0) return;
+  const gate = findWriteGate(pageGate, page);
+  await bus.writeCpu(gate >= 0 ? PAGE_REG + gate : PAGE_REG, page);
+}
+
+export const quattro: NesMapper = {
+  id: 232,
+  name: "Quattro",
+
+  async dumpPrgRom(bus, sizeKB, onProgress) {
+    await bus.setup();
+
+    const numBanks = sizeKB / PRG_BANK_KB;
+    const numBlocks = numBanks / PAGES_PER_BLOCK;
+    const total = numBanks * PRG_BANK_BYTES;
+
+    // Home to block 0 / page 0 and capture bank 0 — the dropout reference and
+    // the bus-conflict gate source for block selects.
+    await bus.writeCpu(PAGE_REG, 0x00);
+    await bus.writeCpu(BLOCK_REG, 0x00);
+    const bank0 = await bus.readCpu(0x8000, PRG_BANK_BYTES);
+
+    const out = new Uint8Array(total);
+    out.set(bank0, 0);
+    onProgress?.(PRG_BANK_BYTES, total);
+
+    for (let block = 0; block < numBlocks; block++) {
+      // Bring this block in, then snapshot its fixed last page (the $C000
+      // window) as the gate source for the block's page selects.
+      await selectBlock(bus, block, bank0);
+      const pageGate = await bus.readCpu(0xc000, PRG_BANK_BYTES);
+
+      for (let page = 0; page < PAGES_PER_BLOCK; page++) {
+        const index = block * PAGES_PER_BLOCK + page;
+        if (index === 0) continue; // bank 0 already captured above
+        const chunk = await readBankWithRetry({
+          label: `Quattro PRG bank ${index}`,
+          reference: bank0,
+          // Re-establish the full (block, page) selection each attempt so a
+          // dropped latch recovers from a known home. A drop that lands back
+          // on bank 0 is the recoverable signature; a partial two-register
+          // drop within a non-zero block isn't expressible by a single
+          // reference, but genuine BF9096 ASICs latch deterministically.
+          attempt: async () => {
+            await selectBlock(bus, block, bank0);
+            await selectPage(bus, page, pageGate);
+            return bus.readCpu(0x8000, PRG_BANK_BYTES);
+          },
+        });
+        out.set(chunk, index * PRG_BANK_BYTES);
+        onProgress?.((index + 1) * PRG_BANK_BYTES, total);
+      }
+    }
+
+    return out;
+  },
+
+  async dumpChrRom(_bus, sizeKB) {
+    // Quattro carts use CHR-RAM, so there is no CHR-ROM to read. The DB
+    // lists only the 0 KiB CHR size; anything else is a caller error.
+    if (sizeKB === 0) return new Uint8Array(0);
+    throw new Error(
+      `Quattro (mapper 232) has CHR-RAM, not CHR-ROM; cannot dump ${sizeKB}KB of CHR-ROM.`,
+    );
+  },
+};

--- a/src/lib/systems/nes/mappers/rambo1.ts
+++ b/src/lib/systems/nes/mappers/rambo1.ts
@@ -1,0 +1,44 @@
+/**
+ * RAMBO-1 (iNES mapper 64) — an MMC3 superset that adds a third switchable
+ * 8 KiB PRG bank, an all-1 KiB CHR mode, and a CPU-cycle IRQ option.
+ *
+ * None of those extras matter for dumping. In the configuration we program
+ * — bank-select bits 5/6/7 clear → CHR 2 KiB+1 KiB mode, PRG mode 0, no CHR
+ * inversion — RAMBO-1's PRG and CHR banking is bit-for-bit MMC3:
+ *   - PRG mode 0 maps R6 to $8000, so walking R6 reads every 8 KiB bank,
+ *     exactly as MMC3 does (the third bank R15 and the fixed last bank are
+ *     never needed when R6 alone covers all of PRG).
+ *   - CHR mode 0 maps R0/R1 as 2 KiB banks at PPU $0000/$0800 and R2-R5 as
+ *     1 KiB banks at $1000-$1FFF — the same layout MMC3's CHR walk drives.
+ * So the dump reuses the shared MMC3 core verbatim (see `./mmc3`).
+ *
+ * The one init difference: RAMBO-1 has no PRG-RAM, and its $A001 register
+ * is unused (no PRG-RAM protect like MMC3's), so we skip MMC3's PRG-RAM
+ * control write and only program the banks. The free-running IRQ counter is
+ * left disabled (we never touch $C000-$E001) and is irrelevant to a
+ * register-driven static dump.
+ *
+ * Reference: nesdev wiki "RAMBO-1".
+ */
+
+import type { NesMapper } from "./types";
+import {
+  type Mmc3StyleVariant,
+  setupBanks,
+  dumpMmc3StylePrgRom,
+  dumpMmc3StyleChrRom,
+} from "./mmc3";
+
+// RAMBO-1 init = MMC3's bank setup minus the PRG-RAM control write.
+const RAMBO1: Mmc3StyleVariant = { name: "RAMBO-1", id: 64, init: setupBanks };
+
+export const rambo1: NesMapper = {
+  id: 64,
+  name: "RAMBO-1",
+
+  dumpPrgRom: (bus, sizeKB, onProgress) =>
+    dumpMmc3StylePrgRom(bus, sizeKB, RAMBO1, onProgress),
+
+  dumpChrRom: (bus, sizeKB, onProgress) =>
+    dumpMmc3StyleChrRom(bus, sizeKB, RAMBO1, onProgress),
+};

--- a/src/lib/systems/nes/nes-constants.ts
+++ b/src/lib/systems/nes/nes-constants.ts
@@ -18,6 +18,11 @@ export interface NESMapperDef {
    * their RAM size here.
    */
   chrRamKB?: number;
+  /**
+   * Optional per-mapper hardware warning, surfaced as a prominent amber
+   * alert in the config UI (e.g. a cart-handling caveat).
+   */
+  warning?: string;
 }
 
 /**
@@ -122,6 +127,18 @@ export const NES_MAPPER_DB: NESMapperDef[] = [
     mirroring: "selectable",
     commonlyHasBattery: false,
     maxPrgRamKB: 0,
+  },
+  {
+    id: 232,
+    name: "Quattro",
+    prgSizesKB: [256],
+    chrSizesKB: [0],
+    mirroring: "selectable",
+    commonlyHasBattery: false,
+    maxPrgRamKB: 0,
+    chrRamKB: 8,
+    warning:
+      "Set the A/B switch to position A (lockout-defeat OFF) before dumping — leaving it in B can damage the cart or reader.",
   },
 ];
 

--- a/src/lib/systems/nes/nes-constants.ts
+++ b/src/lib/systems/nes/nes-constants.ts
@@ -129,6 +129,16 @@ export const NES_MAPPER_DB: NESMapperDef[] = [
     maxPrgRamKB: 0,
   },
   {
+    id: 69,
+    name: "FME-7 (5A/5B)",
+    prgSizesKB: [128, 256],
+    chrSizesKB: [0, 128, 256],
+    mirroring: "mapper_controlled",
+    commonlyHasBattery: false,
+    maxPrgRamKB: 8,
+    chrRamKB: 8,
+  },
+  {
     id: 232,
     name: "Quattro",
     prgSizesKB: [256],

--- a/src/lib/systems/nes/nes-constants.ts
+++ b/src/lib/systems/nes/nes-constants.ts
@@ -106,6 +106,15 @@ export const NES_MAPPER_DB: NESMapperDef[] = [
     maxPrgRamKB: 0,
   },
   {
+    id: 64,
+    name: "RAMBO-1",
+    prgSizesKB: [64, 128, 256],
+    chrSizesKB: [16, 32, 64, 128, 256],
+    mirroring: "mapper_controlled",
+    commonlyHasBattery: false,
+    maxPrgRamKB: 0,
+  },
+  {
     id: 66,
     name: "GxROM",
     prgSizesKB: [32, 64, 128],

--- a/src/lib/systems/nes/nes-system-handler.ts
+++ b/src/lib/systems/nes/nes-system-handler.ts
@@ -71,6 +71,7 @@ export class NESSystemHandler implements SystemHandler {
       helpText: autoDetected?.mapper
         ? `Auto-detected: ${autoDetected.mapper.name}`
         : "Look up your game's mapper and ROM sizes on nescartdb.com",
+      warning: mapperDef?.warning,
     });
 
     // PRG ROM Size
@@ -90,9 +91,6 @@ export class NESSystemHandler implements SystemHandler {
       type: "select",
       value: prgSizeKB,
       locked: prgLocked,
-      lockedReason: prgLocked
-        ? `${mapperDef?.name} only supports ${validPrgSizes[0]}KB PRG ROM`
-        : undefined,
       autoDetected: autoDetected?.romSize != null,
       options: validPrgSizes.map((s) => ({
         value: s,
@@ -119,23 +117,17 @@ export class NESSystemHandler implements SystemHandler {
       type: chrRamOnly ? "readonly" : "select",
       value: chrSizeKB,
       locked: chrRamOnly,
-      lockedReason: chrRamOnly
-        ? `${mapperDef?.name} uses CHR RAM — no CHR ROM to dump`
-        : undefined,
       autoDetected: false,
       options: chrRamOnly
-        ? [{ value: 0, label: "None (CHR RAM)" }]
+        ? [{ value: 0, label: "CHR-RAM" }]
         : validChrSizes.map((s) => ({
             value: s,
-            label: s === 0 ? "None (CHR RAM)" : `${s} KB`,
+            label: s === 0 ? "CHR-RAM" : `${s} KB`,
             hint: s === 0 ? "Cart uses CHR RAM" : `${s / 8} x 8KB banks`,
           })),
       dependsOn: ["mapper"],
       group: "cartridge",
       order: 2,
-      helpText: chrRamOnly
-        ? "This mapper uses CHR RAM instead of mask ROM. No CHR data to dump."
-        : undefined,
     });
 
     // Battery SRAM — a single opt-in, off by default. Checking it reads

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -266,6 +266,8 @@ export interface ResolvedConfigField {
   autoDetected?: boolean;
   locked?: boolean;
   helpText?: string;
+  /** Prominent amber warning alert (e.g. a hardware/handling caveat). */
+  warning?: string;
   lockedReason?: string;
   group?: string;
   order?: number;


### PR DESCRIPTION
Adds three bank-switched mappers to the shared, device-neutral NES catalog, all driven through the generic `NesBus` and dumped via the INL Retro Programmer.

## RAMBO-1 (mapper 64)
- Extracts the MMC3 PRG/CHR dump core into a shared variant; RAMBO-1 reuses it with its own register init, skipping the unused `$A001` PRG-RAM write (RAMBO-1 has no PRG-RAM control register).

## Quattro (mapper 232)
- Two-register 4-in-1 multicart (BF9096): 256 KB PRG as four 64 KB outer blocks, 8 KB CHR-RAM, submapper-1 block-bit ordering (D4 = block bit 0, D3 = block bit 1 — the standalone carts wire the naive ordering swapped).
- Both registers live in PRG-ROM space, so selects go through the shared bus-conflict write gate.
- Adds an optional per-mapper hardware warning to the config UI, used here for the cart's A/B lockout-defeat switch (dump in position A; position B can damage the cart on a CIC-less reader).
- Config tidy-up: CHR-RAM is a single "CHR-RAM" option; redundant locked-field messages dropped.

## FME-7 (mapper 69)
- Two-write command/parameter ASIC (5A/5B family): command at `$8000-$9FFF`, parameter at `$A000-$BFFF`. PRG walked in 8 KB banks via command `$9`; CHR via the eight independent 1 KB windows (commands `$0-$7`), 8 KB per stride.
- Save dumping brackets the read: WRAM enabled (`$C0` — RAM select + chip enable) only for the read, then re-disabled (`$00`) so a battery save stays electrically disconnected for the rest of the session, including unplug.
- All register writes stay within `$8000-$BFFF` (the 5B variant maps expansion-audio ports at `$C000+`, write-only hazards) and the IRQ commands (`$D-$F`) are never selected.

## Validation
- Unit tests for all three mappers against register-level bus models. The FME-7 model hard-fails on either write hazard (IRQ commands, `$C000+` writes), so the constraints are enforced by the suite, not just documented.
- Hardware-validated on the INL Retro Programmer: ROM dumps for all three mappers verified byte-perfect against the No-Intro DB (canonical headers adopted). The FME-7 WRAM path was additionally confirmed against real silicon — the `$C0` enable demonstrably engages the RAM (reads return structured SRAM power-on bias rather than the open-bus signature).
- Battery save *retention* on mapper 69 remains untested pending a battery-equipped cart; the dump path is identical either way.
