### PR TITLE
Fix abort handling and clean up session-state UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ const ACTIVE_STATES: ReadonlySet<DumpJobState> = new Set<DumpJobState>([
   "verifying",
   "connecting",
   "detecting",
+  "aborting",
 ]);
 const isDumping = (s: DumpJobState): boolean => ACTIVE_STATES.has(s);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -183,10 +183,12 @@ function App() {
         const system = ALL_SYSTEMS.find((s) => s.systemId === result.systemId);
         if (!system) return;
 
+        // Header-bearing systems report a title; drivers whose carts carry
+        // none (e.g. NES) supply a `summary` of what detection found instead.
         log(
           result.cartInfo.mapper
-            ? `Detected: ${result.cartInfo.title ?? "Unknown"} (${result.cartInfo.mapper.name ?? "unknown mapper"})`
-            : `Detected: ${result.cartInfo.title ?? "Unknown"}`,
+            ? `Detected: ${result.cartInfo.title ?? result.cartInfo.summary ?? "Unknown"} (${result.cartInfo.mapper.name ?? "unknown mapper"})`
+            : `Detected: ${result.cartInfo.title ?? result.cartInfo.summary ?? "Unknown"}`,
         );
         const cap = drv.capabilities.find((c) => c.systemId === result.systemId);
         const prefilled = prefillFromCartInfo(
@@ -220,16 +222,31 @@ function App() {
     [autoDetectSystem],
   );
 
-  const connection = useConnection({ log, onReady: onDeviceReady });
-
-  const handleDisconnect = useCallback(async () => {
-    await connection.handleDisconnect();
+  /**
+   * Clear per-session wizard + dump state. Runs on every disconnect — the
+   * explicit Disconnect button AND a device-initiated disconnect (physical
+   * unplug) — via useConnection's onDisconnected hook, so a replug/auto-
+   * reconnect starts fresh instead of showing the previous dump's report.
+   */
+  const clearSessionState = useCallback(() => {
     setSelectedSystem(null);
     setConfigValues({});
     setAutoDetected(null);
     setUnsupportedDetection(null);
     dumpJob.reset();
-  }, [connection, dumpJob]);
+  }, [dumpJob]);
+
+  const connection = useConnection({
+    log,
+    onReady: onDeviceReady,
+    onDisconnected: clearSessionState,
+  });
+
+  // Disconnect button: tear down the connection; clearSessionState runs from
+  // useConnection's onDisconnected for both this path and physical unplug.
+  const handleDisconnect = useCallback(async () => {
+    await connection.handleDisconnect();
+  }, [connection]);
 
   // Filter systems to what the connected device supports
   const availableSystems = useMemo(() => {
@@ -286,10 +303,12 @@ function App() {
           const info = await connection.driver.detectCartridge(system.systemId);
           if (info) {
             detected = info;
+            // See autoDetectSystem: title for header-bearing systems,
+            // driver-supplied summary for the rest.
             log(
               info.mapper
-                ? `Detected: ${info.title ?? "Unknown"} (${info.mapper.name ?? "unknown mapper"})`
-                : `Detected: ${info.title ?? "Unknown"}`,
+                ? `Detected: ${info.title ?? info.summary ?? "Unknown"} (${info.mapper.name ?? "unknown mapper"})`
+                : `Detected: ${info.title ?? info.summary ?? "Unknown"}`,
             );
             prefilled = prefillFromCartInfo(system, info, hasSeparateSaveRead(cap));
           } else {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -552,7 +552,10 @@ function App() {
                 {dumpJob.state === "complete" && dumpJob.result && (
                   <CompleteStep
                     result={dumpJob.result}
-                    title={(configValues.title as string) ?? "dump"}
+                    // No placeholder default: CompleteStep owns the fallback
+                    // chain (verified name → title → "(Unverified) <CRC32>"),
+                    // and a truthy placeholder here would short-circuit it.
+                    title={configValues.title as string | undefined}
                     fileExtension={selectedSystem?.fileExtension ?? ""}
                     deviceInfo={connection.deviceInfo}
                     cartInfo={autoDetected}

--- a/src/components/shared/status-badge.tsx
+++ b/src/components/shared/status-badge.tsx
@@ -12,6 +12,7 @@ const STATUS_STYLES: Record<string, string> = {
   verifying: "border-chart-3 text-chart-3",
   complete: "border-primary text-primary",
   error: "border-destructive text-destructive",
+  aborting: "border-chart-3 text-chart-3",
   aborted: "border-chart-3 text-chart-3",
   scanning: "border-chart-3 text-chart-3",
   reading: "border-chart-3 text-chart-3",
@@ -28,6 +29,7 @@ const STATUS_LABELS: Record<string, string> = {
   verifying: "verifying",
   complete: "complete",
   error: "error",
+  aborting: "aborting",
   aborted: "aborted",
   scanning: "scanning",
   reading: "reading",
@@ -36,7 +38,7 @@ const STATUS_LABELS: Record<string, string> = {
 export function StatusBadge({ state }: { state: DumpJobState | "connected" }) {
   const label = STATUS_LABELS[state] ?? state;
   const style = STATUS_STYLES[state] ?? STATUS_STYLES.idle;
-  const pulsing = ["dumping_rom", "dumping_save", "hashing", "verifying", "connecting", "detecting", "scanning", "reading"].includes(state);
+  const pulsing = ["dumping_rom", "dumping_save", "hashing", "verifying", "connecting", "detecting", "scanning", "reading", "aborting"].includes(state);
 
   return (
     <Badge variant="outline" className={`gap-1.5 ${style}`}>

--- a/src/components/wizard/complete-step.tsx
+++ b/src/components/wizard/complete-step.tsx
@@ -56,7 +56,12 @@ function IconCanvas({ cell }: { cell: IconCell }) {
 
 interface CompleteStepProps {
   result: DumpResult;
-  title: string;
+  /**
+   * Cartridge/config title, when one exists. Leave undefined for title-less
+   * systems (e.g. NES) so the unverified-name fallback can engage — a parent
+   * defaulting this to a placeholder string would mask it.
+   */
+  title?: string;
   fileExtension: string;
   deviceInfo: DeviceInfo | null;
   cartInfo: CartridgeInfo | null;
@@ -102,7 +107,16 @@ export function CompleteStep({
       ? verifiedName
       : "No match in verification database";
 
-  const baseName = verifiedName ?? (title || "dump");
+  // Unverified dumps from systems without cart titles still deserve a
+  // distinctive filename: tag them with the system name and the content
+  // CRC32 — e.g. "NES Famicom (Unverified) 1234ABCD" — so consecutive
+  // unidentified dumps don't collide and the hash is recoverable from the
+  // name (CRC32 is the 8-hex-digit identifier the verification world
+  // quotes). `saveFile`'s shared sanitizer strips reserved characters like
+  // the display name's "/" and tidies the whitespace.
+  const unverifiedName = `${systemDisplayName} (Unverified) ${hexStr(result.hashes.crc32)}`;
+
+  const baseName = verifiedName ?? (title || unverifiedName);
   // Save-only systems (e.g. PS1 memory card) have no verification DB and
   // their handlers build a sensible date-stamped filename in `buildOutputFile`.
   // ROM systems use the cartridge title (or verified name when available).
@@ -111,7 +125,7 @@ export function CompleteStep({
       ? verifiedName + fileExtension
       : saveOnly && result.rom
         ? result.rom.filename
-        : (title || "dump") + fileExtension;
+        : (title || unverifiedName) + fileExtension;
   const saveFilename = baseName + ".sav";
 
   const save = useCallback(

--- a/src/components/wizard/configure-step.tsx
+++ b/src/components/wizard/configure-step.tsx
@@ -168,23 +168,6 @@ export function ConfigureStep({
             </div>
           )}
 
-          {/* Manual config nudge — only when there are user-editable fields */}
-          {selectedSystem &&
-            autoDetected &&
-            !autoDetected.mapper &&
-            !busy &&
-            fields.some(
-              (f) => f.type !== "readonly" && f.type !== "hidden" && !f.locked,
-            ) && (
-              <div className="flex gap-2 rounded-md border border-chart-3/30 bg-chart-3/5 px-3 py-2 text-xs text-chart-3">
-                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
-                <span>
-                  Mapper and ROM sizes need to be set manually. Look up your
-                  game to choose the correct settings.
-                </span>
-              </div>
-            )}
-
           {/* Config fields from system handler */}
           {selectedSystem && (
             <>
@@ -252,18 +235,20 @@ export function ConfigureStep({
                         )}
                       </>
                     ) : (
-                      <div className="flex flex-col items-center gap-2">
-                        <p className="text-center text-xs text-muted-foreground">
-                          {hotSwap
-                            ? "Insert a cartridge and click Scan."
-                            : "Insert a cartridge, then click Disconnect and reconnect."}
-                        </p>
-                        {compatibilityNote && (
-                          <p className="text-center text-[11px] text-muted-foreground/70">
-                            {compatibilityNote}
-                          </p>
-                        )}
-                      </div>
+                      <p className="text-center text-xs text-muted-foreground">
+                        {hotSwap
+                          ? "Insert a cartridge and click Scan."
+                          : "Insert a cartridge, then click Disconnect and reconnect."}
+                      </p>
+                    )}
+                    {/* Device compatibility note (e.g. a daughterboard-seating
+                        reminder) shows regardless of whether a cartridge was
+                        auto-detected, so it stays visible above the Start Dump
+                        button. */}
+                    {compatibilityNote && (
+                      <p className="text-center text-[11px] text-muted-foreground/70">
+                        {compatibilityNote}
+                      </p>
                     )}
                   </div>
                 </>

--- a/src/components/wizard/dump-step.tsx
+++ b/src/components/wizard/dump-step.tsx
@@ -71,6 +71,11 @@ export function DumpStep({ state, progress, error, onAbort, onRetry }: DumpStepP
             {confirmAbort ? "Confirm Abort?" : "Abort"}
           </Button>
         )}
+        {state === "aborting" && (
+          <Button variant="outline" disabled>
+            Aborting...
+          </Button>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/hooks/use-connection.ts
+++ b/src/hooks/use-connection.ts
@@ -112,9 +112,21 @@ type LogFn = (msg: string, level?: "info" | "warn" | "error") => void;
 interface UseConnectionOptions {
   log: LogFn;
   onReady: (driver: DeviceDriver, info: DeviceInfo) => void;
+  /**
+   * Called after the device is torn down, on BOTH the explicit Disconnect
+   * button and a device-initiated disconnect (physical unplug). Lets the
+   * caller clear per-session state (selected system, config, dump result)
+   * that isn't owned by this hook, so a replug/auto-reconnect starts fresh
+   * instead of resurrecting the previous cartridge's report.
+   */
+  onDisconnected?: () => void;
 }
 
-export function useConnection({ log, onReady }: UseConnectionOptions) {
+export function useConnection({
+  log,
+  onReady,
+  onDisconnected,
+}: UseConnectionOptions) {
   const [connected, setConnected] = useState(false);
   const [driver, setDriver] = useState<DeviceDriver | null>(null);
   const [deviceInfo, setDeviceInfo] = useState<DeviceInfo | null>(null);
@@ -126,11 +138,19 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
   const driverRef = useRef<DeviceDriver | null>(null);
   const lastDeviceIdRef = useRef<string | null>(null);
   const handleConnectRef = useRef<((id: string) => Promise<void>) | null>(null);
+  // Latest onDisconnected via ref so the transport's onDisconnect listener
+  // (registered once at connect time) always calls the current callback
+  // without re-registering whenever the callback identity changes.
+  const onDisconnectedRef = useRef(onDisconnected);
 
   // Keep ref in sync for cleanup handler
   useEffect(() => {
     driverRef.current = driver;
   }, [driver]);
+
+  useEffect(() => {
+    onDisconnectedRef.current = onDisconnected;
+  }, [onDisconnected]);
 
   // Close transport on page unload/refresh
   useEffect(() => {
@@ -201,6 +221,10 @@ export function useConnection({ log, onReady }: UseConnectionOptions) {
     setConnected(false);
     setConnectError(null);
     log("Disconnected");
+    // Clear caller-owned per-session state (dump result, selected system,
+    // config) on BOTH paths — button and physical unplug — so an
+    // auto-reconnect on replug doesn't resurrect the previous dump's report.
+    onDisconnectedRef.current?.();
     // Re-probe so the connect screen shows current availability
     probeAvailableDevices().then(setAvailableDevices);
   }, [log]);

--- a/src/hooks/use-dump-job.ts
+++ b/src/hooks/use-dump-job.ts
@@ -52,6 +52,15 @@ export function useDumpJob(
       values: ConfigValues,
       verificationDb?: VerificationDB | null,
     ) => {
+      // One job at a time: every device protocol here is single-state, so
+      // two interleaved dumps corrupt each other on the wire. The UI gates
+      // on job state, but a stale render or double-click can race past it —
+      // refuse at the source of truth.
+      if (abortRef.current) {
+        log("A dump is already in progress.", "warn");
+        return null;
+      }
+
       const job = new DumpJobImpl(driver, system, verificationDb ?? null);
       const abort = new AbortController();
       abortRef.current = abort;
@@ -82,9 +91,16 @@ export function useDumpJob(
   );
 
   const abort = useCallback(() => {
-    abortRef.current?.abort();
-    setState("aborted");
-    log("Dump aborted", "warn");
+    if (!abortRef.current) return;
+    abortRef.current.abort();
+    // Only *request* the stop here. The in-flight dump keeps running until
+    // the driver observes the signal; DumpJobImpl emits the terminal
+    // "aborted" state (and its log line) when the promise actually unwinds.
+    // Flipping straight to "aborted" would unlock the UI while the device
+    // is still mid-dump, letting a second dump start and interleave USB
+    // operations with the first — the dual-progress-bar corruption.
+    setState("aborting");
+    log("Aborting dump...", "warn");
   }, [log]);
 
   const reset = useCallback(() => {

--- a/src/lib/core/file-save.ts
+++ b/src/lib/core/file-save.ts
@@ -6,7 +6,11 @@ const hasFilePicker = "showSaveFilePicker" in window;
 const RESERVED_CHARS = /[<>:"/\\|?*]/g;
 
 function sanitizeFilename(name: string): string {
-  return name.replace(RESERVED_CHARS, "").trim() || "dump";
+  // Collapse whitespace runs left behind by stripped characters
+  // (e.g. "NES / Famicom" → "NES  Famicom" → "NES Famicom").
+  return (
+    name.replace(RESERVED_CHARS, "").replace(/\s+/g, " ").trim() || "dump"
+  );
 }
 
 /**

--- a/src/lib/drivers/inl/inl-device.test.ts
+++ b/src/lib/drivers/inl/inl-device.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { INLDevice } from "./inl-device";
+
+/**
+ * Build an INLDevice whose underlying USBDevice's controlTransferIn returns a
+ * fixed number of payload bytes, so the desync guard in payloadIn can be
+ * exercised without hardware.
+ */
+function deviceReturning(byteLength: number): INLDevice {
+  const inl = new INLDevice();
+  const fakeUsb = {
+    opened: true,
+    async controlTransferIn(): Promise<USBInTransferResult> {
+      return {
+        data: new DataView(new ArrayBuffer(byteLength)),
+        status: "ok",
+      } as USBInTransferResult;
+    },
+  };
+  // The private `device` field is what payloadIn reads; inject the fake.
+  (inl as unknown as { device: unknown }).device = fakeUsb;
+  return inl;
+}
+
+describe("INLDevice.payloadIn desync guard", () => {
+  it("returns the full window on a complete payload", async () => {
+    const inl = deviceReturning(128);
+    const data = await inl.payloadIn(128);
+    expect(data.length).toBe(128);
+  });
+
+  it("throws on a short payload (firmware buffer desync)", async () => {
+    const inl = deviceReturning(64);
+    await expect(inl.payloadIn(128)).rejects.toThrow(/short read/i);
+  });
+
+  it("throws on an empty payload", async () => {
+    const inl = deviceReturning(0);
+    await expect(inl.payloadIn(128)).rejects.toThrow(/short read/i);
+  });
+});

--- a/src/lib/drivers/inl/inl-device.ts
+++ b/src/lib/drivers/inl/inl-device.ts
@@ -145,7 +145,17 @@ export class INLDevice {
     return this.controlIn(DICT.OPER, opcode, operand, 0, returnLength);
   }
 
-  /** Read a 128-byte payload from the buffer system. */
+  /**
+   * Read a `length`-byte payload from the buffer system.
+   *
+   * The double-buffered dump protocol depends on each payload read returning
+   * exactly the requested window: the caller assembles fixed-size chunks at
+   * fixed offsets, so a short read would shift every subsequent byte. A
+   * truncated payload means the firmware's buffer pointer is out of step with
+   * the host (typically after a prior dump unwound abnormally without resetting
+   * the operation engine), so we surface it as an error and let the caller's
+   * `finally` reset and recover rather than silently writing a shifted region.
+   */
   async payloadIn(length = 128): Promise<Uint8Array> {
     if (!this.device) throw new Error("Device not connected");
 
@@ -160,11 +170,18 @@ export class INLDevice {
       length,
     );
 
-    if (!result.data) return new Uint8Array(0);
+    const received = result.data?.byteLength ?? 0;
+    if (received !== length) {
+      throw new Error(
+        `INL payload short read: expected ${length} bytes, got ${received} ` +
+          `(firmware buffer desynchronised)`,
+      );
+    }
+
     return new Uint8Array(
-      result.data.buffer,
-      result.data.byteOffset,
-      result.data.byteLength,
+      result.data!.buffer,
+      result.data!.byteOffset,
+      result.data!.byteLength,
     );
   }
 

--- a/src/lib/drivers/inl/inl-driver.ts
+++ b/src/lib/drivers/inl/inl-driver.ts
@@ -93,11 +93,13 @@ export class INLDriver implements DeviceDriver {
       );
     }
 
-    this.log(`Detected: NES cartridge (mirroring: ${mirroring})`);
-
     return {
       systemId: "nes",
       cartInfo: {
+        // NES carts carry no self-reported title; describe what detection
+        // found and let the app emit the single "Detected: ..." log line
+        // through the same path as title-bearing systems.
+        summary: `NES cartridge (mirroring: ${mirroring})`,
         meta: { mirroring },
       },
     };

--- a/src/lib/drivers/inl/inl-driver.ts
+++ b/src/lib/drivers/inl/inl-driver.ts
@@ -120,47 +120,59 @@ export class INLDriver implements DeviceDriver {
     if (!mapper) throw new Error(`Unsupported mapper: ${mapperId}`);
 
     // Each mapper drives the cart through the bus; `bus.setup()` (issued
-    // inside the mapper before each region) handles the reset/init.
-    const bus = new InlNesBus(this.inlDevice);
+    // inside the mapper before each region) handles the reset/init. The
+    // signal rides along so an abort interrupts per chunk, not per region.
+    const bus = new InlNesBus(this.inlDevice, signal);
     const startTime = Date.now();
     const totalBytes = (prgKB + chrKB) * 1024;
 
-    // Dump PRG-ROM
-    this.log(`Reading ${prgKB}KB PRG-ROM...`);
-    signal?.throwIfAborted();
-
-    const prgData = await mapper.dumpPrgRom(bus, prgKB, (bytesRead) => {
-      const elapsed = (Date.now() - startTime) / 1000;
-      this.progress({
-        phase: "rom",
-        bytesRead,
-        totalBytes,
-        fraction: bytesRead / totalBytes,
-        speed: elapsed > 0 ? bytesRead / elapsed : undefined,
-      });
-    });
-
-    // Dump CHR-ROM (if present)
+    let prgData: Uint8Array;
     let chrData: Uint8Array = new Uint8Array(0);
-    if (chrKB > 0) {
-      this.log(`Reading ${chrKB}KB CHR-ROM...`);
+    try {
+      // Dump PRG-ROM
+      this.log(`Reading ${prgKB}KB PRG-ROM...`);
       signal?.throwIfAborted();
 
-      chrData = await mapper.dumpChrRom(bus, chrKB, (bytesRead) => {
+      prgData = await mapper.dumpPrgRom(bus, prgKB, (bytesRead) => {
         const elapsed = (Date.now() - startTime) / 1000;
-        const totalRead = prgKB * 1024 + bytesRead;
         this.progress({
           phase: "rom",
-          bytesRead: totalRead,
+          bytesRead,
           totalBytes,
-          fraction: totalRead / totalBytes,
-          speed: elapsed > 0 ? totalRead / elapsed : undefined,
+          fraction: bytesRead / totalBytes,
+          speed: elapsed > 0 ? bytesRead / elapsed : undefined,
         });
       });
-    }
 
-    // Reset device
-    await this.inlDevice.io(IO.IO_RESET);
+      // Dump CHR-ROM (if present)
+      if (chrKB > 0) {
+        this.log(`Reading ${chrKB}KB CHR-ROM...`);
+        signal?.throwIfAborted();
+
+        chrData = await mapper.dumpChrRom(bus, chrKB, (bytesRead) => {
+          const elapsed = (Date.now() - startTime) / 1000;
+          const totalRead = prgKB * 1024 + bytesRead;
+          this.progress({
+            phase: "rom",
+            bytesRead: totalRead,
+            totalBytes,
+            fraction: totalRead / totalBytes,
+            speed: elapsed > 0 ? totalRead / elapsed : undefined,
+          });
+        });
+      }
+    } finally {
+      // Always reset the device, including when an abort or error unwinds the
+      // dump. dumpRegion already resets the operation engine on its way out;
+      // this restores the I/O/bus layer so the *next* dump starts from a known
+      // state instead of inheriting a half-configured bus. Best-effort so a
+      // reset failure (e.g. the device was unplugged) doesn't mask the cause.
+      try {
+        await this.inlDevice.io(IO.IO_RESET);
+      } catch {
+        /* best-effort cleanup */
+      }
+    }
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     this.log(
@@ -176,7 +188,7 @@ export class INLDriver implements DeviceDriver {
 
   async readSave(
     config: ReadConfig,
-    _signal?: AbortSignal,
+    signal?: AbortSignal,
   ): Promise<Uint8Array> {
     const mapperId = (config.params.mapper as number) ?? 0;
     const sramKB = ((config.params.prgRamSizeBytes as number) ?? 8192) / 1024;
@@ -186,26 +198,36 @@ export class INLDriver implements DeviceDriver {
     const mapper = getNesMapper(mapperId);
     if (!mapper) throw new Error(`Unsupported mapper: ${mapperId}`);
 
-    const bus = new InlNesBus(this.inlDevice);
+    const bus = new InlNesBus(this.inlDevice, signal);
     this.log(`Reading ${sramKB}KB SRAM...`);
 
     let data: Uint8Array;
-    if (mapper.dumpSave) {
-      data = await mapper.dumpSave(bus, sramKB);
-    } else {
-      // Default path: enable WRAM (where the mapper supports it) and read
-      // the $6000-$7FFF PRG-RAM window directly.
-      await bus.setup();
-      if (mapper.enableSram) await mapper.enableSram(bus);
-      data = await dumpRegion(this.inlDevice, {
-        sizeKB: sramKB,
-        memType: MEM.PRGRAM,
-        mapper: 0,
-        mapVar: MAPVAR.NOVAR,
-      });
+    try {
+      if (mapper.dumpSave) {
+        data = await mapper.dumpSave(bus, sramKB);
+      } else {
+        // Default path: enable WRAM (where the mapper supports it) and read
+        // the $6000-$7FFF PRG-RAM window directly.
+        await bus.setup();
+        if (mapper.enableSram) await mapper.enableSram(bus);
+        data = await dumpRegion(this.inlDevice, {
+          sizeKB: sramKB,
+          memType: MEM.PRGRAM,
+          mapper: 0,
+          mapVar: MAPVAR.NOVAR,
+          signal,
+        });
+      }
+    } finally {
+      // Reset on every exit, including an error mid-read, so the next dump
+      // isn't left inheriting a half-configured SRAM-enabled bus state.
+      try {
+        await this.inlDevice.io(IO.IO_RESET);
+      } catch {
+        /* best-effort cleanup */
+      }
     }
 
-    await this.inlDevice.io(IO.IO_RESET);
     this.log(`SRAM read complete (${data.length} bytes)`);
     return data;
   }

--- a/src/lib/drivers/inl/inl-dump.test.ts
+++ b/src/lib/drivers/inl/inl-dump.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+import type { INLDevice } from "./inl-device";
+import { dumpRegion } from "./inl-dump";
+import { BUFFER, MEM, OPER, STATUS, MAPVAR } from "./inl-opcodes";
+
+/**
+ * Records every operation/buffer call against a stand-in INLDevice so a test
+ * can assert that the dump-operation engine is reset on both the normal and
+ * the abnormal (throwing) exit paths — the byte-shift recovery the fix adds.
+ *
+ * `failOnPayloadCall` (1-based) makes the Nth payloadIn throw, simulating a
+ * device fault landing mid-region. The `onPayloadCall`/`onStatusPoll` hooks
+ * let a test abort a signal at a precise point in the protocol.
+ */
+interface FakeOpts {
+  failOnPayloadCall?: number;
+  /** Called at the start of every payloadIn with the 1-based call number. */
+  onPayloadCall?: (n: number) => void;
+  /**
+   * When set, GET_CUR_BUFF_STATUS never reports DUMPED (a stalled device);
+   * called with the 1-based poll number so a test can abort mid-poll.
+   */
+  onStatusPoll?: (n: number) => void;
+}
+
+interface OpCall {
+  kind: "operation" | "buffer";
+  opcode: number;
+  operand: number;
+  misc: number;
+}
+
+function makeFakeDevice(opts: FakeOpts = {}) {
+  const calls: OpCall[] = [];
+  let payloadCalls = 0;
+  let statusPolls = 0;
+
+  const device = {
+    async operation(opcode: number, operand = 0): Promise<number> {
+      calls.push({ kind: "operation", opcode, operand, misc: 0 });
+      return 0;
+    },
+    async buffer(opcode: number, operand = 0, misc = 0): Promise<number> {
+      calls.push({ kind: "buffer", opcode, operand, misc });
+      // The dump loop polls GET_CUR_BUFF_STATUS and expects DUMPED.
+      if (opcode === BUFFER.GET_CUR_BUFF_STATUS) {
+        if (opts.onStatusPoll) {
+          opts.onStatusPoll(++statusPolls);
+          return 0; // stalled device: never DUMPED
+        }
+        return STATUS.DUMPED;
+      }
+      return 0;
+    },
+    async payloadIn(length = 128): Promise<Uint8Array> {
+      payloadCalls += 1;
+      opts.onPayloadCall?.(payloadCalls);
+      if (opts.failOnPayloadCall === payloadCalls) {
+        throw new Error("simulated device fault mid-region");
+      }
+      return new Uint8Array(length);
+    },
+  } as unknown as INLDevice;
+
+  return { device, calls };
+}
+
+/** Count how many times the operation engine was reset (SET_OPERATION RESET). */
+function countEngineResets(calls: OpCall[]): number {
+  return calls.filter(
+    (c) =>
+      c.kind === "operation" &&
+      c.opcode === OPER.SET_OPERATION &&
+      c.operand === STATUS.RESET,
+  ).length;
+}
+
+/** Count RAW_BUFFER_RESET buffer commands. */
+function countBufferResets(calls: OpCall[]): number {
+  return calls.filter(
+    (c) => c.kind === "buffer" && c.opcode === BUFFER.RAW_BUFFER_RESET,
+  ).length;
+}
+
+const REGION = {
+  sizeKB: 1, // 1 KiB = 8 x 128-byte chunks
+  memType: MEM.NESCPU_4KB,
+  mapper: 0x08,
+  mapVar: MAPVAR.NOVAR,
+};
+
+describe("dumpRegion operation-engine reset", () => {
+  it("resets the engine at both start and end on a clean dump", async () => {
+    const { device, calls } = makeFakeDevice();
+
+    const data = await dumpRegion(device, REGION);
+
+    expect(data.length).toBe(1024);
+    // Leading reset + trailing finally reset.
+    expect(countEngineResets(calls)).toBe(2);
+    expect(countBufferResets(calls)).toBe(2);
+    // STARTDUMP must come AFTER the first reset and BEFORE the last.
+    const startIdx = calls.findIndex(
+      (c) =>
+        c.kind === "operation" &&
+        c.opcode === OPER.SET_OPERATION &&
+        c.operand === STATUS.STARTDUMP,
+    );
+    const lastResetIdx = calls.reduce(
+      (acc, c, i) =>
+        c.kind === "operation" &&
+        c.opcode === OPER.SET_OPERATION &&
+        c.operand === STATUS.RESET
+          ? i
+          : acc,
+      -1,
+    );
+    expect(startIdx).toBeGreaterThan(0);
+    expect(lastResetIdx).toBeGreaterThan(startIdx);
+  });
+
+  it("still resets the engine when a payload read throws mid-region", async () => {
+    // Fail on the 3rd of 8 payload reads — squarely mid-loop.
+    const { device, calls } = makeFakeDevice({ failOnPayloadCall: 3 });
+
+    await expect(dumpRegion(device, REGION)).rejects.toThrow(
+      "simulated device fault",
+    );
+
+    // Leading reset always runs; the finally reset must also run despite the
+    // throw, so the firmware isn't left mid-region for the NEXT dump.
+    expect(countEngineResets(calls)).toBe(2);
+    expect(countBufferResets(calls)).toBe(2);
+    // The very last engine touch is a RESET, not a dangling STARTDUMP.
+    const lastOp = calls
+      .filter(
+        (c) => c.kind === "operation" && c.opcode === OPER.SET_OPERATION,
+      )
+      .at(-1);
+    expect(lastOp?.operand).toBe(STATUS.RESET);
+  });
+
+  it("resets the engine when the very first payload read throws", async () => {
+    // The short-read desync guard lives in the real INLDevice.payloadIn
+    // (covered by inl-device.test.ts); dumpRegion sees its symptom — a
+    // throw — which here lands before any chunk was assembled.
+    const { device, calls } = makeFakeDevice({ failOnPayloadCall: 1 });
+
+    await expect(dumpRegion(device, REGION)).rejects.toThrow();
+    expect(countEngineResets(calls)).toBe(2);
+  });
+
+  it("an abort interrupts a stalled DUMPED poll before the timeout", async () => {
+    const controller = new AbortController();
+    const { device, calls } = makeFakeDevice({
+      // Device never reports DUMPED; abort on the 3rd status poll. The
+      // in-poll signal check must surface AbortError well before the 5s
+      // stall timeout (which would reject with the stall Error instead).
+      onStatusPoll: (n) => {
+        if (n === 3) controller.abort();
+      },
+    });
+
+    await expect(
+      dumpRegion(device, { ...REGION, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(countEngineResets(calls)).toBe(2);
+    expect(countBufferResets(calls)).toBe(2);
+  });
+
+  it("an abort signal interrupts within a chunk and still resets the engine", async () => {
+    const controller = new AbortController();
+    const { device, calls } = makeFakeDevice({
+      // Abort while the 3rd of 8 chunks is in flight; the per-chunk
+      // throwIfAborted must stop the loop before chunk 4 is requested.
+      onPayloadCall: (n) => {
+        if (n === 3) controller.abort();
+      },
+    });
+
+    await expect(
+      dumpRegion(device, { ...REGION, signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+
+    // No further payload pulls after the abort landed...
+    const payloadPulls = calls.filter(
+      (c) => c.kind === "buffer" && c.opcode === BUFFER.GET_CUR_BUFF_STATUS,
+    ).length;
+    expect(payloadPulls).toBeLessThanOrEqual(4);
+    // ...and the engine still returns to idle on the way out.
+    expect(countEngineResets(calls)).toBe(2);
+    expect(countBufferResets(calls)).toBe(2);
+  });
+});

--- a/src/lib/drivers/inl/inl-dump.ts
+++ b/src/lib/drivers/inl/inl-dump.ts
@@ -54,8 +54,10 @@ export interface DumpRegionOptions {
  * state and frees the buffers, re-synchronising host and firmware. It runs at
  * the start of every region (so a prior abnormal exit can't poison a fresh
  * dump) and in `dumpRegion`'s `finally` (so an abnormal exit cleans up after
- * itself). It is best-effort: if the reset transfer itself throws (e.g. the
- * device was unplugged), we swallow it so the original error still propagates.
+ * itself). Transfer errors propagate from here: the leading call rightly
+ * fails the dump when the device won't respond, while the `finally` call
+ * site wraps this in its own try/catch so a failed *cleanup* reset (e.g.
+ * the device was unplugged mid-dump) can't mask the original error.
  */
 async function resetDumpEngine(device: INLDevice): Promise<void> {
   await device.operation(OPER.SET_OPERATION, STATUS.RESET);

--- a/src/lib/drivers/inl/inl-dump.ts
+++ b/src/lib/drivers/inl/inl-dump.ts
@@ -28,6 +28,38 @@ export interface DumpRegionOptions {
   mapper: number;
   mapVar: number;
   onProgress?: (bytesRead: number, totalBytes: number) => void;
+  /**
+   * Abort signal, checked once per 128-byte chunk. Without it an abort only
+   * lands at region boundaries — tens of seconds on a large region — while
+   * the UI already reports the dump stopped. The throw unwinds through the
+   * `finally` below, so the operation engine is reset on the way out.
+   */
+  signal?: AbortSignal;
+}
+
+/**
+ * Reset the firmware's dump-operation engine and discard any allocated
+ * buffers, returning it to a known-idle state.
+ *
+ * This is the lockstep-recovery primitive: the host and firmware track the
+ * dump position jointly (the host polls `GET_CUR_BUFF_STATUS` and pulls each
+ * 128-byte payload; the firmware advances its page/buffer pointer in step).
+ * If a dump unwinds abnormally — a poll timeout, a device error byte, a
+ * `payloadIn` fault, or an abort surfacing as a throw — the firmware is left
+ * mid-region in `STARTDUMP`/`DUMPING` with buffers still allocated and its
+ * read pointer offset from where the next dump assumes it is. Reading payload
+ * against that stale pointer is exactly what yields a byte-SHIFTED next dump.
+ *
+ * Issuing `SET_OPERATION RESET` + `RAW_BUFFER_RESET` clears the operation
+ * state and frees the buffers, re-synchronising host and firmware. It runs at
+ * the start of every region (so a prior abnormal exit can't poison a fresh
+ * dump) and in `dumpRegion`'s `finally` (so an abnormal exit cleans up after
+ * itself). It is best-effort: if the reset transfer itself throws (e.g. the
+ * device was unplugged), we swallow it so the original error still propagates.
+ */
+async function resetDumpEngine(device: INLDevice): Promise<void> {
+  await device.operation(OPER.SET_OPERATION, STATUS.RESET);
+  await device.buffer(BUFFER.RAW_BUFFER_RESET);
 }
 
 /**
@@ -85,62 +117,77 @@ export async function dumpRegion(
   const totalBytes = opts.sizeKB * 1024;
   const numChunks = totalBytes / BUFF_SIZE;
 
-  // Reset buffers
-  await device.operation(OPER.SET_OPERATION, STATUS.RESET);
-  await device.buffer(BUFFER.RAW_BUFFER_RESET);
+  // Reset the operation engine before configuring this region. Doing this at
+  // the *start* means even if a prior dumpRegion exited abnormally and somehow
+  // skipped its own cleanup, we re-synchronise here before reading any payload.
+  await resetDumpEngine(device);
 
-  // Allocate 2x128B double buffers
-  await allocateBuffers(device);
-
-  // Configure both buffers: memory type + part number. PRG-RAM is
-  // SRAM-backed; every other region we read is mask ROM. The part must match
-  // the region so the firmware drives the right chip — a save read with the
-  // mask-ROM part would target the wrong device.
-  const part = opts.memType === MEM.PRGRAM ? PART.SRAM : PART.MASKROM;
-  const memPart = (opts.memType << 8) | part;
-  await device.buffer(BUFFER.SET_MEM_N_PART, memPart, 0);
-  await device.buffer(BUFFER.SET_MEM_N_PART, memPart, 1);
-
-  // Configure both buffers: mapper + variant
-  const mapVar = (opts.mapper << 8) | opts.mapVar;
-  await device.buffer(BUFFER.SET_MAP_N_MAPVAR, mapVar, 0);
-  await device.buffer(BUFFER.SET_MAP_N_MAPVAR, mapVar, 1);
-
-  // Start dumping
-  await device.operation(OPER.SET_OPERATION, STATUS.STARTDUMP);
-
-  // Read data in 128-byte chunks
   const result = new Uint8Array(totalBytes);
   let bytesRead = 0;
 
-  for (let i = 0; i < numChunks; i++) {
-    // Poll until the current buffer reports DUMPED. Each poll is a USB
-    // round-trip (so the loop yields), but a stalled transfer or device
-    // fault could otherwise never report DUMPED and hang the dump forever —
-    // bound the wait and surface it as an error instead.
-    const deadline = Date.now() + POLL_TIMEOUT_MS;
-    let status = await device.buffer(BUFFER.GET_CUR_BUFF_STATUS);
-    while (status !== STATUS.DUMPED) {
-      if (Date.now() > deadline) {
-        throw new Error(
-          `INL dump stalled: buffer ${i + 1}/${numChunks} never reported DUMPED ` +
-            `within ${POLL_TIMEOUT_MS}ms (last status 0x${status.toString(16)})`,
-        );
+  try {
+    // Allocate 2x128B double buffers
+    await allocateBuffers(device);
+
+    // Configure both buffers: memory type + part number. PRG-RAM is
+    // SRAM-backed; every other region we read is mask ROM. The part must match
+    // the region so the firmware drives the right chip — a save read with the
+    // mask-ROM part would target the wrong device.
+    const part = opts.memType === MEM.PRGRAM ? PART.SRAM : PART.MASKROM;
+    const memPart = (opts.memType << 8) | part;
+    await device.buffer(BUFFER.SET_MEM_N_PART, memPart, 0);
+    await device.buffer(BUFFER.SET_MEM_N_PART, memPart, 1);
+
+    // Configure both buffers: mapper + variant
+    const mapVar = (opts.mapper << 8) | opts.mapVar;
+    await device.buffer(BUFFER.SET_MAP_N_MAPVAR, mapVar, 0);
+    await device.buffer(BUFFER.SET_MAP_N_MAPVAR, mapVar, 1);
+
+    // Start dumping
+    await device.operation(OPER.SET_OPERATION, STATUS.STARTDUMP);
+
+    // Read data in 128-byte chunks
+    for (let i = 0; i < numChunks; i++) {
+      opts.signal?.throwIfAborted();
+
+      // Poll until the current buffer reports DUMPED. Each poll is a USB
+      // round-trip (so the loop yields), but a stalled transfer or device
+      // fault could otherwise never report DUMPED and hang the dump forever —
+      // bound the wait and surface it as an error instead.
+      const deadline = Date.now() + POLL_TIMEOUT_MS;
+      let status = await device.buffer(BUFFER.GET_CUR_BUFF_STATUS);
+      while (status !== STATUS.DUMPED) {
+        // Keep aborts responsive even while waiting out a stalled buffer —
+        // otherwise an abort during a stall only lands at the poll timeout.
+        opts.signal?.throwIfAborted();
+        if (Date.now() > deadline) {
+          throw new Error(
+            `INL dump stalled: buffer ${i + 1}/${numChunks} never reported DUMPED ` +
+              `within ${POLL_TIMEOUT_MS}ms (last status 0x${status.toString(16)})`,
+          );
+        }
+        status = await device.buffer(BUFFER.GET_CUR_BUFF_STATUS);
       }
-      status = await device.buffer(BUFFER.GET_CUR_BUFF_STATUS);
+
+      // Read the payload
+      const chunk = await device.payloadIn(BUFF_SIZE);
+      result.set(chunk, bytesRead);
+      bytesRead += chunk.length;
+
+      opts.onProgress?.(bytesRead, totalBytes);
     }
-
-    // Read the payload
-    const chunk = await device.payloadIn(BUFF_SIZE);
-    result.set(chunk, bytesRead);
-    bytesRead += chunk.length;
-
-    opts.onProgress?.(bytesRead, totalBytes);
+  } finally {
+    // Always return the operation engine to idle, including on a poll
+    // timeout, device error, payload fault, or abort that surfaces as a
+    // throw. Skipping this is what leaves the firmware mid-region and
+    // byte-shifts the *next* dump. Best-effort: if the reset itself throws
+    // (e.g. the device was unplugged), swallow it so the original error wins.
+    try {
+      await resetDumpEngine(device);
+    } catch {
+      /* best-effort cleanup */
+    }
   }
-
-  // Reset
-  await device.operation(OPER.SET_OPERATION, STATUS.RESET);
-  await device.buffer(BUFFER.RAW_BUFFER_RESET);
 
   return result;
 }

--- a/src/lib/drivers/inl/inl-nes-bus.ts
+++ b/src/lib/drivers/inl/inl-nes-bus.ts
@@ -12,9 +12,13 @@ import { dumpRegion } from "./inl-dump";
 
 export class InlNesBus implements NesBus {
   private readonly device: INLDevice;
+  // Forwarded to every dumpRegion so an abort interrupts reads per 128-byte
+  // chunk rather than at region boundaries.
+  private readonly signal?: AbortSignal;
 
-  constructor(device: INLDevice) {
+  constructor(device: INLDevice, signal?: AbortSignal) {
     this.device = device;
+    this.signal = signal;
   }
 
   async setup(): Promise<void> {
@@ -59,6 +63,7 @@ export class InlNesBus implements NesBus {
         mapper: 0,
         mapVar: MAPVAR.NOVAR,
         onProgress,
+        signal: this.signal,
       });
     }
 
@@ -74,6 +79,7 @@ export class InlNesBus implements NesBus {
       mapper: addrPage,
       mapVar: MAPVAR.NOVAR,
       onProgress,
+      signal: this.signal,
     });
   }
 
@@ -101,6 +107,7 @@ export class InlNesBus implements NesBus {
       mapper: 0x00,
       mapVar: MAPVAR.NOVAR,
       onProgress,
+      signal: this.signal,
     });
   }
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -152,6 +152,14 @@ export interface DumpProgress {
 
 export interface CartridgeInfo<M = Record<string, unknown>> {
   title?: string;
+  /**
+   * One-line description of what detection found, for the event log when
+   * the cart carries no self-reported title (e.g. NES: "NES cartridge
+   * (mirroring: vertical)"). Unlike `title` it is never used for filenames
+   * or config prefill, so it can hold transient detail like power-on
+   * mirroring state.
+   */
+  summary?: string;
   mapper?: MapperInfo;
   romSize?: number;
   saveSize?: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -376,6 +376,9 @@ export type DumpJobState =
   | "dumping_save"
   | "hashing"
   | "verifying"
+  // Abort requested; the in-flight dump is still unwinding. Terminal
+  // "aborted" only fires once the dump promise has actually settled.
+  | "aborting"
   | "complete"
   | "error"
   | "aborted";


### PR DESCRIPTION
## Drop the configure-step "set manually" banner
The amber nudge duplicated the mapper field's helpText without adding information. The device compatibility note now also renders in the auto-detected state, so it stays visible above Start Dump.

## Start fresh after a disconnect
- Per-session wizard and dump state now clears on **both** disconnect paths — the Disconnect button and a physical unplug — via a new `onDisconnected` hook on `useConnection`. A replug/auto-reconnect starts a fresh session instead of resurfacing the previous dump's report.
  - Behavior note: an unsaved completed dump is discarded on unplug now, matching the button path's existing semantics — save before pulling the cable.
- The app-level `Detected: …` log line is only emitted when the cart exposes a title or mapper. Header-less systems (NES) let their driver log its own findings instead of a misleading `Detected: Unknown`.

## Make aborting a dump safe
Aborting was doubly broken:
- The UI flipped to "aborted" and unlocked while the in-flight dump kept running (the abort signal was only observed at region boundaries), so a second dump could start and interleave USB operations with the first against the single-state firmware engine — alternating progress bars, then a stalled/corrupt dump.
- Any abnormal unwind (poll timeout, device error, abort) skipped the trailing `SET_OPERATION RESET` + `RAW_BUFFER_RESET`, leaving the firmware mid-region with its buffer pointer out of step with the host — the classic byte-shifted next dump.

Fixes:
- New `"aborting"` job state: the abort button only *requests* the stop; the terminal `"aborted"` state comes from the job when the dump promise actually settles, and the UI stays locked in between. `useDumpJob.run` also refuses to start while a job is in flight.
- The abort signal rides the bus into `dumpRegion` and is checked once per 128-byte chunk, so an abort lands in milliseconds instead of tens of seconds.
- `dumpRegion` brackets its work in `finally` so the operation engine always returns to idle, and resets it again defensively at the start of every region; `readROM`/`readSave` reset the I/O layer on every exit path.
- `payloadIn` throws on a short read instead of silently accepting a truncated window — a short payload means host/firmware desync, and a loud error plus reset beats a silently shifted dump.

## Validation
- 189 unit tests passing, including new coverage for reset-on-throw, the short-read guard, and mid-chunk abort.
- Hardware-verified on the INL Retro Programmer: an abort mid-region stops within about a second, and an immediate re-dump on the same connection verifies byte-perfect against the No-Intro DB — no disconnect ritual needed after aborts anymore.
- Banner removal and unplug→fresh-state confirmed in the browser against a connected device.
