### PR TITLE
Add NES mappers 268 (CoolBoy / Mindkids) and 470 (INX_007T_V01)

### DIFF
--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -19,6 +19,19 @@ See LICENSE in this repository (same license applies to nabu as a whole).
 
 ================================================================================
 
+famicom-dumper-client
+https://github.com/ClusterM/famicom-dumper-client
+
+The Mapper 268 (CoolBoy / Mindkids) GNROM-mode dump register sequence in
+src/lib/systems/nes/mappers/coolboy.ts was derived from the reference
+implementations in FamicomDumper/mappers/AA6023Sub0.cs and AA6023Sub1.cs.
+
+License: GNU General Public License v3.0
+
+See LICENSE in this repository (same license applies to nabu as a whole).
+
+================================================================================
+
 FlashGBX
 https://github.com/lesserkuma/FlashGBX
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -510,6 +510,9 @@ function App() {
                     configValues={configValues}
                     onConfigChange={handleConfigChange}
                     autoDetected={autoDetected}
+                    capability={connection.driver?.capabilities.find(
+                      (c) => c.systemId === selectedSystem?.systemId,
+                    )}
                     unsupportedDetection={unsupportedDetection}
                     suggestLoadDat={
                       !!selectedSystem &&

--- a/src/components/shared/config-field.tsx
+++ b/src/components/shared/config-field.tsx
@@ -43,7 +43,9 @@ export function ConfigField({ field, onChange }: ConfigFieldProps) {
   if (field.type === "hidden") return null;
 
   return (
-    <div className="flex flex-col gap-1">
+    // min-w-0: as a grid item this would otherwise refuse to shrink below
+    // its content (a long select label), overflowing into the next column.
+    <div className="flex min-w-0 flex-col gap-1">
       <label className="text-[10px] uppercase tracking-widest text-muted-foreground">
         {field.label}
         {field.autoDetected && (
@@ -71,18 +73,24 @@ export function ConfigField({ field, onChange }: ConfigFieldProps) {
           }}
           disabled={field.locked}
         >
-          <SelectTrigger className="h-9 bg-background font-mono text-sm">
+          <SelectTrigger className="h-9 w-full bg-background font-mono text-sm">
             <SelectValue>
-              {
-                field.options.find(
-                  (o) => String(o.value) === String(field.value),
-                )?.label
-              }
+              <span className="truncate">
+                {
+                  field.options.find(
+                    (o) => String(o.value) === String(field.value),
+                  )?.label
+                }
+              </span>
             </SelectValue>
           </SelectTrigger>
           <SelectContent>
             {field.options.map((opt) => (
-              <SelectItem key={String(opt.value)} value={String(opt.value)}>
+              <SelectItem
+                key={String(opt.value)}
+                value={String(opt.value)}
+                disabled={opt.disabled}
+              >
                 <span className="flex flex-col">
                   <span>{opt.label}</span>
                   {opt.hint && (

--- a/src/components/wizard/configure-step.tsx
+++ b/src/components/wizard/configure-step.tsx
@@ -14,6 +14,7 @@ import type {
   SystemHandler,
   ConfigValues,
   CartridgeInfo,
+  DeviceCapability,
 } from "@/lib/types";
 
 interface ConfigureStepProps {
@@ -23,6 +24,9 @@ interface ConfigureStepProps {
   configValues: ConfigValues;
   onConfigChange: (key: string, value: unknown) => void;
   autoDetected: CartridgeInfo | null;
+  /** The connected device's capability for the selected system, when known —
+   * lets handlers grey out options the device can't drive. */
+  capability?: DeviceCapability;
   /** A cartridge was detected that the adapter can't read; render an explanation instead of the dump UI. */
   unsupportedDetection?: { title: string; reason: string } | null;
   /** Whether to hint that the user should load a No-Intro DAT. */
@@ -43,6 +47,7 @@ export function ConfigureStep({
   configValues,
   onConfigChange,
   autoDetected,
+  capability,
   unsupportedDetection,
   suggestLoadDat,
   detecting,
@@ -56,8 +61,9 @@ export function ConfigureStep({
       selectedSystem?.getConfigFields(
         configValues,
         autoDetected ?? undefined,
+        capability,
       ) ?? [],
-    [selectedSystem, configValues, autoDetected],
+    [selectedSystem, configValues, autoDetected, capability],
   );
 
   const validation = useMemo(

--- a/src/lib/drivers/inl/inl-driver.test.ts
+++ b/src/lib/drivers/inl/inl-driver.test.ts
@@ -99,6 +99,7 @@ describe("INLDriver teardown", () => {
 
   it.each([
     [268, 2048], // CPLD refuses this device's writes (hardware-classified)
+    [470, 1024], // same refusal family (see UNSUPPORTED_MAPPERS)
   ])(
     "pre-flight-rejects mapper %i without touching the device",
     async (mapper, prgKB) => {

--- a/src/lib/drivers/inl/inl-driver.test.ts
+++ b/src/lib/drivers/inl/inl-driver.test.ts
@@ -97,6 +97,26 @@ describe("INLDriver teardown", () => {
     expectTeardownTail(fake.calls);
   });
 
+  it.each([
+    [268, 2048], // CPLD refuses this device's writes (hardware-classified)
+  ])(
+    "pre-flight-rejects mapper %i without touching the device",
+    async (mapper, prgKB) => {
+      // The driver must reject before any cart traffic rather than
+      // produce a boot-bank-mirrored garbage dump.
+      const fake = new FakeInlDevice();
+      const driver = makeDriver(fake);
+
+      await expect(
+        driver.readROM({
+          systemId: "nes",
+          params: { mapper, prgSizeBytes: prgKB * 1024, chrSizeBytes: 0 },
+        }),
+      ).rejects.toThrow(/INL Retro/);
+      expect(fake.calls).toHaveLength(0);
+    },
+  );
+
   it("readSave (default path) ends with the engine reset and I/O reset", async () => {
     const fake = new FakeInlDevice();
     const driver = makeDriver(fake);

--- a/src/lib/drivers/inl/inl-driver.ts
+++ b/src/lib/drivers/inl/inl-driver.ts
@@ -24,6 +24,10 @@ import { dumpRegion } from "./inl-dump";
 import { InlNesBus } from "./inl-nes-bus";
 import { detectCiramMirroring } from "./detect-mirroring";
 import { getNesMapper } from "@/lib/systems/nes/mappers";
+// Catalog mappers whose CPLD refuses this device's synthesized writes, with
+// the full hardware account of why. Used both to grey them out in the config
+// UI and to pre-flight-reject them in readROM.
+import { UNSUPPORTED_MAPPERS } from "./unsupported-mappers";
 
 export class INLDriver implements DeviceDriver {
   readonly id = "inl-retro";
@@ -33,6 +37,9 @@ export class INLDriver implements DeviceDriver {
       systemId: "nes",
       operations: ["dump_rom"],
       autoDetect: true,
+      // Greys these mappers out in the config UI; readROM pre-flight-
+      // rejects them too. See ./unsupported-mappers for why.
+      unsupportedMappers: [...UNSUPPORTED_MAPPERS.keys()],
     },
   ];
 
@@ -118,6 +125,14 @@ export class INLDriver implements DeviceDriver {
 
     const mapper = getNesMapper(mapperId);
     if (!mapper) throw new Error(`Unsupported mapper: ${mapperId}`);
+    const unsupportedReason = UNSUPPORTED_MAPPERS.get(mapperId);
+    if (unsupportedReason) {
+      throw new Error(
+        `Mapper ${mapperId} (${mapper.name}) can't be dumped with the INL Retro: ` +
+          `${unsupportedReason}. The cart itself is fine — use a dumper this ` +
+          "board accepts.",
+      );
+    }
 
     // Each mapper drives the cart through the bus; `bus.setup()` (issued
     // inside the mapper before each region) handles the reset/init. The

--- a/src/lib/drivers/inl/inl-integration.test.ts
+++ b/src/lib/drivers/inl/inl-integration.test.ts
@@ -27,6 +27,8 @@
  * consensus read pulls every bank twice, which a sequential stream can't
  * serve, so that fake decodes the $5000 outer registers arriving over
  * NES_CPU_WR and snapshots the mapped window at each region start.
+ * Mapper 470 is absent: the INL driver pre-flight-rejects it (same
+ * CPLD-refusal family as 268), and its banking is proven in the shared specs.
  */
 
 import { describe, it, expect, vi } from "vitest";

--- a/src/lib/drivers/inl/inl-integration.test.ts
+++ b/src/lib/drivers/inl/inl-integration.test.ts
@@ -22,9 +22,14 @@
  * is the one catalog mapper absent: its walk assembles banks out of stream
  * order and snapshots per-block $C000 gate banks, which a sequential stream
  * can't model — its banking is proven in the shared specs.
+ *
+ * Mapper 268 is the one register-aware exception (`MindkidsCart` below): its
+ * consensus read pulls every bank twice, which a sequential stream can't
+ * serve, so that fake decodes the $5000 outer registers arriving over
+ * NES_CPU_WR and snapshots the mapped window at each region start.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { INLDevice } from "./inl-device";
 import { InlNesBus } from "./inl-nes-bus";
 import { BUFFER, OPER, STATUS, MEM } from "./inl-opcodes";
@@ -39,6 +44,7 @@ import { colorDreams } from "@/lib/systems/nes/mappers/color-dreams";
 import { gxrom } from "@/lib/systems/nes/mappers/gxrom";
 import { rambo1 } from "@/lib/systems/nes/mappers/rambo1";
 import { fme7 } from "@/lib/systems/nes/mappers/fme7";
+import { mapper268Mindkids } from "@/lib/systems/nes/mappers/coolboy";
 import type { NesMapper } from "@/lib/systems/nes/mappers/types";
 
 interface RegionConfig {
@@ -248,5 +254,93 @@ describe("InlNesBus region configs with real mappers", () => {
 
     expect(out).toEqual(image);
     expect(fake.regions[0].memType).toBe(MEM.PRGRAM);
+  });
+});
+
+/**
+ * Register-aware fake for Mapper 268: tracks the Mindkids outer registers
+ * written via NES_CPU_WR ($5000-$5003) and serves each dump region from the
+ * 16 KiB window those registers map, snapshotted when the region's buffer is
+ * allocated. GNROM-mode decode mirrors the spec-side model in
+ * `mappers/mappers.test.ts`; until GNROM is engaged, reads return the boot
+ * (power-on menu) window.
+ */
+class MindkidsCart extends FakeCart {
+  private regs = [0, 0, 0, 0];
+  private window: Uint8Array = new Uint8Array(0);
+  private winCursor = 0;
+  private readonly flash: Uint8Array;
+  private readonly boot: Uint8Array;
+  constructor(flash: Uint8Array, boot: Uint8Array) {
+    super();
+    this.flash = flash;
+    this.boot = boot;
+  }
+  override async nes(_op?: number, addr = 0, value = 0): Promise<number> {
+    if (addr < 0x5000 || addr > 0x5fff) {
+      throw new Error(`unexpected CPU write $${addr.toString(16)}`);
+    }
+    this.regs[addr & 3] = value;
+    return 0;
+  }
+  override async buffer(op: number, operand = 0, misc = 0): Promise<number> {
+    if (op === BUFFER.ALLOCATE_BUFFER0) {
+      // Region start: snapshot the currently-mapped $8000 window.
+      this.window = this.currentWindow();
+      this.winCursor = 0;
+    }
+    return super.buffer(op, operand, misc);
+  }
+  override async payloadIn(len = 128): Promise<Uint8Array> {
+    const out = this.window.slice(this.winCursor, this.winCursor + len);
+    this.winCursor += len;
+    return out;
+  }
+  private currentWindow(): Uint8Array {
+    const [r0, r1, , r3] = this.regs;
+    if (!(r3 & 0x10) || !(r0 & 0x40) || !(r1 & 0x80)) return this.boot;
+    const bank =
+      ((r3 >> 1) & 7) |
+      ((r0 & 7) << 3) |
+      (((r1 >> 4) & 1) << 6) |
+      (((r1 >> 2) & 3) << 7) |
+      (((r0 >> 4) & 3) << 9);
+    const off = (bank * 0x4000) % this.flash.length;
+    return this.flash.slice(off, off + 0x4000);
+  }
+}
+
+describe("Mapper 268 (Mindkids) on INL", () => {
+  // 512 KiB keeps the 128-byte-chunk pulls tractable; the full 2 MiB
+  // register-bit coverage runs against the fast bank-aware bus in the
+  // shared mapper specs.
+  it("dumps 512 KiB byte-exact via $5000 writes over NES_CPU_WR", async () => {
+    vi.useFakeTimers();
+    const spies = [
+      vi.spyOn(console, "log").mockImplementation(() => {}),
+      vi.spyOn(console, "warn").mockImplementation(() => {}),
+    ];
+    try {
+      const flash = makeImage(512 * 1024); // 32 banks
+      const cart = new MindkidsCart(flash, makeImage(16 * 1024, 5));
+      const bus = new InlNesBus(asDevice(cart));
+
+      const p = mapper268Mindkids.dumpPrgRom(bus, 512);
+      await vi.runAllTimersAsync(); // the per-write settle delays
+      const out = await p;
+
+      expect(out).toEqual(flash);
+      // 32 banks x 2 consensus reads, every region a NESCPU_4KB read
+      // through the $8000 window.
+      expect(cart.regions).toHaveLength(64);
+      expect(
+        cart.regions.every(
+          (r) => r.memType === MEM.NESCPU_4KB && r.mapper === 0x08,
+        ),
+      ).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      spies.forEach((s) => s.mockRestore());
+    }
   });
 });

--- a/src/lib/drivers/inl/inl-opcodes.ts
+++ b/src/lib/drivers/inl/inl-opcodes.ts
@@ -51,6 +51,16 @@ export const NES = {
   NES_CPU_WR: 0x02,
   NES_MMC1_WR: 0x04,
   NES_DUALPORT_WR: 0x05,
+  // Flash-program a byte on an MMC3 board: three JEDEC unlock writes
+  // ($D555/$AAAA/$D555), then the (operand, misc) write, then $8000<-2 and
+  // a stability poll-read — ALL inside one USB transaction, each a full
+  // nes_cpu_wr M2 cycle microseconds apart. Caution: the tail poll re-reads
+  // the WRITTEN address until two consecutive reads agree, so a target
+  // whose reads flicker (e.g. $5xxx on the mapper-268 board) spins the
+  // firmware until a physical replug — which is exactly why it is NOT used
+  // as an M2-burst write primitive (see UNSUPPORTED_MAPPERS in
+  // ./unsupported-mappers).
+  MMC3_PRG_FLASH_WR: 0x07,
   SET_CUR_BANK: 0x20,
   SET_BANK_TABLE: 0x21,
   SET_NUM_PRG_BANKS: 0x24,

--- a/src/lib/drivers/inl/unsupported-mappers.ts
+++ b/src/lib/drivers/inl/unsupported-mappers.ts
@@ -54,6 +54,18 @@
  * (Don't retry the probe via MMC3_PRG_FLASH_WR: its tail polls the written
  * address until two consecutive reads agree, and $5xxx reads flicker on this
  * cart — the firmware spins until a physical replug.)
+ *
+ * ── Mapper 470 (INX_007T_V01 reissue board) ──
+ *
+ * Same refusal family, weaker evidence basis (calibrate accordingly): an
+ * April 2026 session on other hardware recorded "clock-reset blocks bank
+ * progression" for this exact cart on this device class (recalled, the
+ * session itself was lost), and the board's bank latch is demonstrably
+ * cadence-sensitive — it defeated even a dumper whose writes this CPLD
+ * generation otherwise accepts, until the vendor's per-chunk re-latch recipe
+ * was matched (see `inx007t.ts`). Given the formal mapper-268 classification
+ * of this family on this device, pre-flight-rejecting 470 is the honest
+ * default; an instrumented attempt could overturn it.
  */
 
 /** INL-unsupported mapper id → reason shown in the driver's pre-flight error. */
@@ -62,5 +74,11 @@ export const UNSUPPORTED_MAPPERS = new Map<number, string>([
     268,
     "the board's CPLD ignores this device's register writes, so every bank " +
       "reads back as the boot menu (hardware-verified)",
+  ],
+  [
+    470,
+    "the board family refuses this device's synthesized writes (same CPLD " +
+      "family as mapper 268, plus a recorded failure of this exact cart on " +
+      "this device class)",
   ],
 ]);

--- a/src/lib/drivers/inl/unsupported-mappers.ts
+++ b/src/lib/drivers/inl/unsupported-mappers.ts
@@ -1,0 +1,66 @@
+/**
+ * Mappers the INL Retro Programmer cannot drive, even though they exist in
+ * the shared, device-agnostic NES catalog.
+ *
+ * These boards reimplement their mapper in a CPLD that refuses the INL
+ * firmware's synthesized bus writes: the firmware idles M2 and emits a
+ * single pulse per write, while the CPLD's reset detector wants sustained
+ * M2 clocking (a real console runs M2 continuously at 1.79 MHz) before it
+ * will latch a register. Reads are unaffected — the firmware's page-read
+ * loop issues many back-to-back bus cycles inside one USB transaction — so
+ * a dump that ignored this would return a plausible-length file that is
+ * really the boot bank mirrored across every slot.
+ *
+ * `UNSUPPORTED_MAPPERS` maps each such mapper id to the reason shown in
+ * the driver's pre-flight rejection, worded to its own evidence basis. The
+ * driver rejects these ids before any cart traffic (so no garbage dump is
+ * produced) and feeds the key set to `capability.unsupportedMappers`, which
+ * greys the options out in the config UI. The mappers stay in the catalog —
+ * they are implemented, spec-tested, and (mapper 268) dumpable on devices
+ * whose bus drives the CPLD; the INL is simply the wrong tool.
+ *
+ * ── Mapper 268 (CoolBoy / Mindkids MMC3-clone multicart) ──
+ *
+ * Classified on hardware 2026-06-07 with the mapper's built-in
+ * failure-classification pass (see `coolboy.ts`), verdict
+ * `writes-not-landing` with the inner-MMC3 discrimination probe also
+ * negative:
+ *
+ *   - The read path is flawless. All 128 GNROM bank reads returned the
+ *     cart's power-on window byte-perfect (it matches flash offset 0 of a
+ *     reference dump made on other hardware), 256 times in a row — contacts,
+ *     power, and read timing are not in question.
+ *   - Zero of 1,024 outer-register writes ($5000-$5003, the
+ *     hardware-verified two-phase menu-mimicking sequence with 5 ms settles)
+ *     latched.
+ *   - The inner MMC3 registers ($8000/$8001) — the very write path real MMC3
+ *     ASICs accept from this device — did not latch either.
+ *
+ * A follow-up experiment (also 2026-06-07) bounded it from the other side:
+ * ten back-to-back M2 read+write cycles inside ONE USB transaction
+ * (`NES_MMC1_WR`'s burst, microsecond gaps) still did not latch the inner R6
+ * register, so no stock-firmware write primitive can cross the threshold.
+ * Only a firmware modification that keeps M2 running through the write could,
+ * and on this board even that is architecturally hostile: M2 (PC0) has no
+ * timer output on the ATmega164A, so continuous M2 must be bit-banged by the
+ * same core that has to keep answering V-USB's cycle-critical INT0
+ * interrupts mid-operation — gapless M2 and a live USB stack are mutually
+ * exclusive here. The vendor's STM32-based boards (hardware USB, real
+ * timers) would be the realistic platform. Consistent with all of this, a
+ * dumper that drives denser sustained bus activity latches these registers
+ * with only occasional stochastic dropouts; discrete logic and real mapper
+ * ASICs (everything else in the catalog) latch fine from single M2 pulses.
+ *
+ * (Don't retry the probe via MMC3_PRG_FLASH_WR: its tail polls the written
+ * address until two consecutive reads agree, and $5xxx reads flicker on this
+ * cart — the firmware spins until a physical replug.)
+ */
+
+/** INL-unsupported mapper id → reason shown in the driver's pre-flight error. */
+export const UNSUPPORTED_MAPPERS = new Map<number, string>([
+  [
+    268,
+    "the board's CPLD ignores this device's register writes, so every bank " +
+      "reads back as the boot menu (hardware-verified)",
+  ],
+]);

--- a/src/lib/systems/nes/bus.ts
+++ b/src/lib/systems/nes/bus.ts
@@ -85,4 +85,22 @@ export interface NesBus {
    * that via `writeCpu` first.
    */
   writeSerialRegister?(addr: number, value: number): Promise<void>;
+
+  /**
+   * Write `latchValue` to the CPU-bus register at `latchAddr` and read
+   * `length` bytes from `addr`, as ONE fused device operation with no bus
+   * idle between the write and the read. Optional — a driver supplies this
+   * when its firmware has such a fused op (e.g. a bank-write-then-burst-read
+   * dump primitive), for boards whose bank latch does not survive the idle
+   * gap between a separate `writeCpu` transaction and the following
+   * `readCpu` (mapper 470's inner latch is the known case). Mappers that
+   * need it feature-detect and fall back to split write+read — the same
+   * optional-capability shape as `readChrBankLatched`.
+   */
+  readCpuBankLatched?(
+    latchAddr: number,
+    latchValue: number,
+    addr: number,
+    length: number,
+  ): Promise<Uint8Array>;
 }

--- a/src/lib/systems/nes/mappers/bank-reliability.test.ts
+++ b/src/lib/systems/nes/mappers/bank-reliability.test.ts
@@ -4,6 +4,7 @@ import {
   isUniformFill,
   isBankDropout,
   readBankWithRetry,
+  readBankWithConsensus,
 } from "./bank-reliability";
 
 const u8 = (...bytes: number[]) => Uint8Array.from(bytes);
@@ -97,5 +98,56 @@ describe("readBankWithRetry", () => {
     });
     expect(calls).toBe(1);
     expect(Array.from(out)).toEqual([0, 0, 0, 0]);
+  });
+});
+
+describe("readBankWithConsensus", () => {
+  /** A read thunk that serves the scripted values in order. */
+  const scripted = (...values: Uint8Array[]) => {
+    let i = 0;
+    return {
+      read: async () => values[i++],
+      calls: () => i,
+    };
+  };
+
+  it("accepts two agreeing reads at face value (outcome 'first')", async () => {
+    const reads = scripted(u8(1, 2, 3), u8(1, 2, 3));
+    const { data, outcome } = await readBankWithConsensus({
+      read: reads.read,
+      label: "bank 1",
+    });
+    expect(outcome).toBe("first");
+    expect(Array.from(data)).toEqual([1, 2, 3]);
+    expect(reads.calls()).toBe(2);
+  });
+
+  it("keeps reading until a value reproduces (outcome 'retried')", async () => {
+    // First two disagree; the third reproduces the FIRST read — consensus
+    // is on any earlier value, not just the immediately preceding one.
+    const reads = scripted(u8(1, 2, 3), u8(9, 9, 9), u8(1, 2, 3));
+    const { data, outcome } = await readBankWithConsensus({
+      read: reads.read,
+      label: "bank 2",
+      log: () => {},
+    });
+    expect(outcome).toBe("retried");
+    expect(Array.from(data)).toEqual([1, 2, 3]);
+    expect(reads.calls()).toBe(3);
+  });
+
+  it("gives up after maxAttempts and accepts the last read ('unresolved')", async () => {
+    const reads = scripted(u8(1), u8(2), u8(3), u8(4));
+    const logs: string[] = [];
+    const { data, outcome } = await readBankWithConsensus({
+      read: reads.read,
+      label: "bank 3",
+      maxAttempts: 4,
+      log: (m) => logs.push(m),
+    });
+    expect(outcome).toBe("unresolved");
+    expect(Array.from(data)).toEqual([4]);
+    expect(reads.calls()).toBe(4);
+    expect(logs.some((m) => m.includes("never agreed"))).toBe(true);
   });
 });

--- a/src/lib/systems/nes/mappers/bank-reliability.ts
+++ b/src/lib/systems/nes/mappers/bank-reliability.ts
@@ -3,21 +3,29 @@
  *
  * Modern reproduction carts that present as a standard mapper but
  * implement it in a CPLD / clone ASIC (rather than a harvested
- * first-party mapper part) intermittently **fail to latch a bank-select
- * write**. The affected 8 KiB bank then reads back as a verbatim copy of
- * bank 0 — the power-on default mapping — instead of its real content.
- * Which banks drop varies run to run; a bank that does latch is
- * byte-stable. (Original first-party mapper silicon latches
- * deterministically and never trips this.)
+ * first-party mapper part) misbehave in two distinct ways, each with its
+ * own countermeasure here:
  *
- * `readBankWithRetry` is the reactive countermeasure: read a bank, and if
- * it came back identical to bank 0 (a dropout), re-run the bank-select and
- * re-read, up to `maxAttempts`. A clean read returns on the first attempt
- * and costs nothing, so this is safe to leave engaged on every device. It
- * supersedes the older "blindly issue the bank-select sequence twice"
- * double-latch, which only *reduced* the drop rate — verify-and-retry
- * detects the failure and actually recovers from it, and generalises to
- * any bank-switched mapper instead of being baked into one.
+ *   1. **Bank-0 dropout** — the cart intermittently fails to latch a
+ *      bank-select write, so the affected bank reads back as a verbatim
+ *      copy of bank 0 (the power-on default mapping). Countered by
+ *      `readBankWithRetry`.
+ *   2. **Varying misread** — a bank read intermittently returns the wrong
+ *      content with no fixed reference to test against (e.g. the Mapper
+ *      268 CoolBoy/Mindkids clone substitutes a *different* bank).
+ *      Countered by `readBankWithConsensus`.
+ *
+ * (Original first-party mapper silicon latches deterministically and
+ * never trips either.)
+ *
+ * `readBankWithRetry` is the reactive countermeasure for dropout: read a
+ * bank, and if it came back identical to bank 0 (a dropout), re-run the
+ * bank-select and re-read, up to `maxAttempts`. A clean read returns on
+ * the first attempt and costs nothing, so this is safe to leave engaged on
+ * every device. It supersedes the older "blindly issue the bank-select
+ * sequence twice" double-latch, which only *reduced* the drop rate —
+ * verify-and-retry detects the failure and actually recovers from it, and
+ * generalises to any bank-switched mapper instead of being baked into one.
  *
  * The dropout predicate is deliberately "== bank 0", NOT "all 0x00 / all
  * 0xFF": a uniform bank 0 is a blank/dead read (open bus), a separate
@@ -125,4 +133,74 @@ export async function readBankWithRetry(
   }
 
   return result;
+}
+
+export type BankConsensusOutcome = "first" | "retried" | "unresolved";
+
+export interface BankConsensusResult {
+  data: Uint8Array;
+  /**
+   * `first`      — the first two reads agreed.
+   * `retried`    — reads disagreed, but a value repeated within `maxAttempts`.
+   * `unresolved` — no value ever repeated; `data` is the last read.
+   */
+  outcome: BankConsensusOutcome;
+}
+
+export interface BankConsensusOptions {
+  /**
+   * Read the bank's window. Invoked repeatedly to filter transient
+   * read-path noise. The caller must have already selected the bank, and the
+   * selection is NOT re-issued between reads — consensus targets a *varying*
+   * misread, not a dropped bank-select (for the latter use `readBankWithRetry`).
+   */
+  read: () => Promise<Uint8Array>;
+  /** Diagnostic label, e.g. `"Mapper 268 bank 5"`. */
+  label: string;
+  /** Total reads before accepting the last one unverified. Default 5. */
+  maxAttempts?: number;
+  /** Where the unresolved-bank notice goes. Defaults to `console.warn`. */
+  log?: (message: string) => void;
+}
+
+/**
+ * Read a bank repeatedly until two reads agree, returning the agreed value.
+ *
+ * The counterpart to `readBankWithRetry`, for mappers whose failure is a
+ * transient, *varying* misread (e.g. the Mapper 268 CoolBoy/Mindkids clone's
+ * bank substitution) rather than a clean revert to bank 0. There's no
+ * known-bad reference to test against here, so we instead trust a value that
+ * reproduces. A *consistent* (non-varying) misread can't be caught this way
+ * and must be prevented upstream — settle delays, a menu-mimicking register
+ * write — or caught by a multi-pass merge.
+ */
+export async function readBankWithConsensus(
+  opts: BankConsensusOptions,
+): Promise<BankConsensusResult> {
+  const {
+    read,
+    label,
+    maxAttempts = 5,
+    log = (message: string) => console.warn(message),
+  } = opts;
+
+  const first = await read();
+  const second = await read();
+  if (bytesEqual(first, second)) return { data: first, outcome: "first" };
+
+  // Reads disagree: keep reading until one value reproduces an earlier read.
+  const seen: Uint8Array[] = [first, second];
+  while (seen.length < maxAttempts) {
+    const next = await read();
+    if (seen.some((prev) => bytesEqual(prev, next))) {
+      return { data: next, outcome: "retried" };
+    }
+    seen.push(next);
+  }
+
+  log(
+    `[nes] ${label}: ${maxAttempts} reads never agreed — accepting the last ` +
+      `(possible bank substitution; a re-dump or multi-pass merge may differ)`,
+  );
+  return { data: seen[seen.length - 1], outcome: "unresolved" };
 }

--- a/src/lib/systems/nes/mappers/coolboy.ts
+++ b/src/lib/systems/nes/mappers/coolboy.ts
@@ -1,0 +1,196 @@
+/**
+ * iNES 2.0 Mapper 268 — CoolBoy / Mindkids MMC3-clone multicart.
+ *
+ * Two submappers, identical except for the address of their outer
+ * bank-select registers:
+ *   - Submapper 0 (CoolBoy):  registers at $6000-$6FFF
+ *   - Submapper 1 (Mindkids): registers at $5000-$5FFF
+ *
+ * Outer-register bit layout (per nesdev wiki, identical across the two
+ * submappers):
+ *
+ *   $xxx0  A B CC D EEE   A = CHR A17 mask (1 = mask, 0 = offset)
+ *                         B = PRG A17 mask
+ *                         CC = PRG A23/A24 offset
+ *                         D  = CHR A17 offset
+ *                         EEE = PRG A17/A18/A19 offset
+ *   $xxx1  G H I J KK L S G = PRG A18 mask
+ *                         H = PRG A19 mask
+ *                         I = PRG A20 mask
+ *                         J = PRG A20 offset
+ *                         KK = PRG A22/A21 offsets
+ *                         L = GNROM bank size (0 = 16 KiB, 1 = 32 KiB)
+ *                         S = SC0
+ *   $xxx2                 GNROM CHR config (CHR-RAM carts: keep 0)
+ *   $xxx3  N _ _ _ P QQ S N = Lockout (write-once)
+ *                         P = GNROM enable (bit 4)
+ *                         QQ = low PRG bank bits (bits 3..1)
+ *                         S = sound/scroll (keep 0)
+ *
+ * Dump strategy: GNROM mode, 16 KiB banks, one register-write set per
+ * bank. Mirrors ClusterM's famicom-dumper-client reference
+ * implementation (AA6023Sub0.cs / AA6023Sub1.cs). MMC3-mode walks
+ * (the obvious first instinct, since fceux models this as an MMC3
+ * clone) don't work on real hardware: the cart's A17/A18 *mask* bits
+ * default to "follow MMC3," so the outer register's offset bits never
+ * reach the PRG address lines unless the masks are explicitly cleared
+ * — which the GNROM-mode walk does inherently. An MMC3 walk also
+ * runs into the cart's 6-bit R6/R7 limit (only 512 KiB reachable per
+ * outer-register setting) and into bank-decoder quirks at R6 ≥ 48.
+ *
+ * Per-bank register writes (bank index N, 16 KiB units):
+ *
+ *   r0 = ((N >> 3) & 7) | (((N >> 9) & 3) << 4) | (1 << 6)
+ *        bit 6: clear A17 mask (A17 follows offset, not MMC3)
+ *        bits 0..2: PRG offset A17..A19 = N[3..5]
+ *        bits 4..5: PRG offset A23/A24 = N[9..10]
+ *   r1 = (((N >> 7) & 3) << 2) | (((N >> 6) & 1) << 4) | (1 << 7)
+ *        bit 7: clear A18 mask (A18 follows offset, not MMC3)
+ *        bit 4: PRG offset A20 = N[6]
+ *        bits 2..3: PRG offset A22/A21 = N[7..8]
+ *   r2 = 0
+ *   r3 = (1 << 4) | ((N & 7) << 1)
+ *        bit 4: GNROM enable
+ *        bits 1..3: low PRG bank bits = N[0..2]
+ *
+ * Then a 16 KiB read at $8000 returns bank N.
+ *
+ * Cart-side CHR is RAM only on submappers 0/1 — `dumpChrRom` returns
+ * an empty array.
+ *
+ * Hardware caveat: SMD172-family carts have an on-board reset detector
+ * that some forum reports claim re-locks the mapper mid-dump on generic
+ * dumpers (CopyNES and Tengu are reported as clean). A dumper driving
+ * dense back-to-back bus cycles latches these registers with occasional
+ * stochastic dropouts — the consensus read below exists for exactly
+ * that. The INL Retro, which idles M2 low and emits one M2 pulse per
+ * write, never latches a single register write at all; its driver
+ * pre-flight-rejects this mapper — see UNSUPPORTED_MAPPERS in
+ * drivers/inl/unsupported-mappers for the full hardware account.
+ *
+ * References:
+ *   - ClusterM Sub1 (Mindkids, $5000): github.com/ClusterM/famicom-dumper-client
+ *     /blob/master/FamicomDumper/mappers/AA6023Sub1.cs
+ *   - ClusterM Sub0 (CoolBoy, $6000): same repo, AA6023Sub0.cs
+ *   - nesdev wiki: nesdev.org/wiki/NES_2.0_Mapper_268
+ */
+
+import type { NesMapper } from "./types";
+import { readBankWithConsensus } from "./bank-reliability";
+
+export type Mapper268Submapper = 0 | 1;
+
+const COOLBOY_BASE = 0x6000;
+const MINDKIDS_BASE = 0x5000;
+const BANK_SIZE = 16 * 1024;
+
+/**
+ * Build a Mapper 268 implementation for the given submapper variant.
+ * The only difference between 0 and 1 is the address of the outer
+ * register block.
+ */
+export function createMapper268(submapper: Mapper268Submapper): NesMapper {
+  const base = submapper === 1 ? MINDKIDS_BASE : COOLBOY_BASE;
+
+  return {
+    id: 268,
+    // The family name, matching NES_MAPPER_DB — the two submappers differ
+    // only by register base, not by anything the UI/error surfaces, so a
+    // single name keeps the catalog and DB labels from diverging.
+    name: "Mindkids / CoolBoy",
+
+    async dumpPrgRom(bus, sizeKB, onProgress) {
+      await bus.setup();
+
+      // The SMD172-family CPLD intermittently substitutes a *different*
+      // bank for the one selected (~5-10% of reads on a dumper whose
+      // writes it accepts at all). Three defenses:
+      //   (C) `SETTLE_MS` after each register write — lets the CPLD latch
+      //       before the read.
+      //   (B) Menu-mimicking two-phase register write: the cart firmware
+      //       launches each game by writing the outer registers TWICE,
+      //       first in an MMC3-mode transitional state ($xxx1=$90,
+      //       $xxx3=$00), then in the committed GNROM state. Mirroring
+      //       that gives the CPLD a clean mode transition into GNROM.
+      //   (A) Consensus read: read each bank until two reads agree, so a
+      //       transient substitution is caught at the source rather than
+      //       needing a second full dump.
+      const SETTLE_MS = 5;
+      const MAX_READ_ATTEMPTS = 5;
+      // Menu phase 1 values (matches captured launch sequence on
+      // production-released Mindkids multicarts).
+      const PHASE1_R1 = 0x90;
+      const PHASE1_R3 = 0x00;
+
+      const totalBytes = sizeKB * 1024;
+      const numBanks = Math.ceil(totalBytes / BANK_SIZE);
+      const out = new Uint8Array(totalBytes);
+
+      const settle = () => new Promise((r) => setTimeout(r, SETTLE_MS));
+
+      const writeRegs = async (r0: number, r1: number, r3: number) => {
+        // Phase 1: MMC3-mode transitional state. Same offset bits in
+        // $xxx0 as the final state so any masking change in $xxx1
+        // doesn't snap us to a stale offset, but $xxx1/$xxx3 carry the
+        // menu's pre-launch values.
+        await bus.writeCpu(base + 0, r0);
+        await settle();
+        await bus.writeCpu(base + 1, PHASE1_R1);
+        await settle();
+        await bus.writeCpu(base + 2, 0);
+        await settle();
+        await bus.writeCpu(base + 3, PHASE1_R3);
+        await settle();
+
+        // Phase 2: commit our GNROM-mode walk state.
+        await bus.writeCpu(base + 0, r0);
+        await settle();
+        await bus.writeCpu(base + 1, r1);
+        await settle();
+        await bus.writeCpu(base + 2, 0);
+        await settle();
+        await bus.writeCpu(base + 3, r3);
+        await settle();
+      };
+
+      const selectBank = (bank: number) => {
+        const r0 = ((bank >> 3) & 7) | (((bank >> 9) & 3) << 4) | (1 << 6);
+        const r1 =
+          (((bank >> 7) & 3) << 2) | (((bank >> 6) & 1) << 4) | (1 << 7);
+        const r3 = (1 << 4) | ((bank & 7) << 1);
+        return writeRegs(r0, r1, r3);
+      };
+
+      for (let bank = 0; bank < numBanks; bank++) {
+        await selectBank(bank);
+
+        const offset = bank * BANK_SIZE;
+        const len = Math.min(BANK_SIZE, totalBytes - offset);
+
+        // Consensus (not a bank-0 comparison) is the right check for this
+        // clone: its glitch substitutes a *different* bank, with no
+        // known-bad value to test against, and the re-reads target
+        // transient read-path noise — so we re-read the same selection
+        // rather than re-issuing registers.
+        const { data } = await readBankWithConsensus({
+          read: () => bus.readCpu(0x8000, len),
+          label: `Mapper 268 bank ${bank}`,
+          maxAttempts: MAX_READ_ATTEMPTS,
+        });
+
+        out.set(data, offset);
+        onProgress?.(offset + len, totalBytes);
+      }
+
+      return out;
+    },
+
+    async dumpChrRom() {
+      // Submappers 0/1 are CHR-RAM-only. No CHR-ROM to read.
+      return new Uint8Array(0);
+    },
+  };
+}
+
+export const mapper268Coolboy = createMapper268(0);
+export const mapper268Mindkids = createMapper268(1);

--- a/src/lib/systems/nes/mappers/index.ts
+++ b/src/lib/systems/nes/mappers/index.ts
@@ -27,6 +27,7 @@ import { gxrom } from "./gxrom";
 import { fme7 } from "./fme7";
 import { quattro } from "./quattro";
 import { mapper268Mindkids } from "./coolboy";
+import { mapper470 } from "./inx007t";
 import type { NesMapper } from "./types";
 
 export const NES_MAPPERS: Record<number, NesMapper> = {
@@ -50,6 +51,10 @@ export const NES_MAPPERS: Record<number, NesMapper> = {
   // that device's synthesized writes; see UNSUPPORTED_MAPPERS in
   // drivers/inl/unsupported-mappers for the hardware-classified account.
   268: mapper268Mindkids,
+  // Vendor-recipe implementation, not yet hardware-validated on a nabu
+  // driver (see the cadence lesson in inx007t.ts); INL pre-flight-
+  // rejects this id too — same CPLD-refusal family as 268.
+  470: mapper470,
 };
 
 export function getNesMapper(id: number): NesMapper | undefined {

--- a/src/lib/systems/nes/mappers/index.ts
+++ b/src/lib/systems/nes/mappers/index.ts
@@ -26,6 +26,7 @@ import { colorDreams } from "./color-dreams";
 import { gxrom } from "./gxrom";
 import { fme7 } from "./fme7";
 import { quattro } from "./quattro";
+import { mapper268Mindkids } from "./coolboy";
 import type { NesMapper } from "./types";
 
 export const NES_MAPPERS: Record<number, NesMapper> = {
@@ -41,6 +42,14 @@ export const NES_MAPPERS: Record<number, NesMapper> = {
   66: gxrom,
   69: fme7,
   232: quattro,
+  // Submapper 1 (Mindkids, outer registers at $5000) — the variant we've
+  // hardware-verified. Submapper 0 (CoolBoy, registers at $6000) shares
+  // the implementation via createMapper268(0) but needs its own catalog
+  // mechanism (submapper isn't part of the config UI) when a cart shows up.
+  // The INL driver pre-flight-rejects this id — the board's CPLD refuses
+  // that device's synthesized writes; see UNSUPPORTED_MAPPERS in
+  // drivers/inl/unsupported-mappers for the hardware-classified account.
+  268: mapper268Mindkids,
 };
 
 export function getNesMapper(id: number): NesMapper | undefined {

--- a/src/lib/systems/nes/mappers/inx007t.ts
+++ b/src/lib/systems/nes/mappers/inx007t.ts
@@ -1,0 +1,106 @@
+/**
+ * iNES 2.0 Mapper 470 — INX_007T_V01 board (the 2022 licensed
+ * re-release of a 1993 two-franchise crossover title).
+ *
+ * Geometry: 1 MiB PRG flash as 4 outer x 8 inner x 32 KiB banks.
+ *   $5000  outer bank (2 bits, PRG A18-A19) — holds across bus idle.
+ *   $8000  inner bank (PRG A15-A17); the vendor's reference recipe
+ *          writes the GLOBAL 32 KiB bank index 0-31 here (the board
+ *          decodes the low 3 bits) — we match that stream bit-for-bit.
+ * CHR is 8 KiB CHR-RAM — nothing to dump.
+ *
+ * ── The latch lesson (why this walk prefers a fused write+read) ──
+ *
+ * The board's INNER latch does not survive bus idle. An earlier
+ * implementation that latched $8000 in its own transaction and then
+ * streamed each 32 KiB bank produced a structurally dead dump: against
+ * the canonical No-Intro entry, 26 of 32 banks read back as WHOLE
+ * copies of the power-on bank — meaning the latch was already gone
+ * before each read transaction began, not merely decaying partway
+ * through one. The vendor's hardware-validated routine never exposes
+ * the latch to an idle gap: its firmware op performs the $8000 bank
+ * write and a 2 KiB read back-to-back inside ONE transaction, re-issued
+ * for every chunk (established by reverse-engineering the vendor host
+ * app's dump routine against a bus-level trace of the device firmware).
+ *
+ * So this walk prefers the optional `bus.readCpuBankLatched` capability
+ * — a fused latch+read matching the vendor op one-to-one, requested at
+ * the vendor's 2 KiB cadence — and only falls back to split
+ * writeCpu/readCpu sub-reads when the bus lacks it. The fallback
+ * re-latches before every 4 KiB sub-read (readCpu requires 4 KiB-aligned
+ * start addresses, so within one 32 KiB bank that is the finest spacing
+ * at which a fresh read can begin), but every latch write still crosses
+ * a transaction gap before its read: on hardware whose inner latch
+ * decays across any idle, the fallback will reproduce the dead-dump
+ * signature. It exists so the mapper still functions on a bus whose
+ * latch happens to hold; drivers for this board family should supply
+ * the fused capability.
+ *
+ * NOT yet hardware-validated on any nabu driver. The INL Retro is
+ * excluded outright — this board family refuses its synthesized writes;
+ * see UNSUPPORTED_MAPPERS in drivers/inl/unsupported-mappers.
+ *
+ * References:
+ *   - nesdev wiki: nesdev.org/wiki/NES_2.0_Mapper_470
+ */
+
+import type { NesMapper } from "./types";
+
+const OUTER_BANK_REG = 0x5000;
+const INNER_BANK_REG = 0x8000;
+const OUTER_BANKS = 4;
+const INNER_BANKS = 8;
+const BANK_SIZE = 32 * 1024;
+/** The vendor routine's fused latch+read chunk size. */
+const FUSED_CHUNK = 2 * 1024;
+/** Fallback sub-read size: readCpu starts must be 4 KiB-aligned. */
+const SPLIT_CHUNK = 4 * 1024;
+const EXPECTED_PRG_KB = (OUTER_BANKS * INNER_BANKS * BANK_SIZE) / 1024; // 1024
+
+export const mapper470: NesMapper = {
+  id: 470,
+  name: "INX_007T_V01",
+
+  async dumpPrgRom(bus, sizeKB, onProgress) {
+    if (sizeKB !== EXPECTED_PRG_KB) {
+      throw new Error(
+        `Mapper 470 boards carry exactly ${EXPECTED_PRG_KB} KiB PRG; got ${sizeKB} KiB`,
+      );
+    }
+    await bus.setup();
+
+    const fused = bus.readCpuBankLatched?.bind(bus);
+    const totalBytes = sizeKB * 1024;
+    const out = new Uint8Array(totalBytes);
+    let bytesRead = 0;
+
+    for (let outer = 0; outer < OUTER_BANKS; outer++) {
+      await bus.writeCpu(OUTER_BANK_REG, outer);
+      for (let inner = 0; inner < INNER_BANKS; inner++) {
+        // The vendor recipe writes the global 32 KiB bank index (0-31).
+        const globalBank = outer * INNER_BANKS + inner;
+        const chunkSize = fused ? FUSED_CHUNK : SPLIT_CHUNK;
+        for (let off = 0; off < BANK_SIZE; off += chunkSize) {
+          // Latch + read with no idle between them when the bus can
+          // fuse the two; otherwise re-latch as close to the read as
+          // the split primitives allow — see the latch lesson above.
+          const chunk = fused
+            ? await fused(INNER_BANK_REG, globalBank, 0x8000 + off, chunkSize)
+            : await (async () => {
+                await bus.writeCpu(INNER_BANK_REG, globalBank);
+                return bus.readCpu(0x8000 + off, chunkSize);
+              })();
+          out.set(chunk, bytesRead);
+          bytesRead += chunkSize;
+          onProgress?.(bytesRead, totalBytes);
+        }
+      }
+    }
+    return out;
+  },
+
+  async dumpChrRom() {
+    // CHR-RAM board — nothing to dump.
+    return new Uint8Array(0);
+  },
+};

--- a/src/lib/systems/nes/mappers/mappers.test.ts
+++ b/src/lib/systems/nes/mappers/mappers.test.ts
@@ -14,6 +14,7 @@ import { gxrom } from "./gxrom";
 import { fme7 } from "./fme7";
 import { quattro } from "./quattro";
 import { mapper268Mindkids, mapper268Coolboy } from "./coolboy";
+import { mapper470 } from "./inx007t";
 
 /**
  * A deterministic, well-mixed cart image. The multiplicative hash makes
@@ -1126,5 +1127,156 @@ describe("Mapper 268 (Mindkids / CoolBoy)", () => {
     expect(out.length).toBe(512 * 1024);
     expect(writes.some((a) => a >= 0x6000 && a <= 0x6003)).toBe(true);
     expect(writes.some((a) => a >= 0x5000 && a <= 0x5003)).toBe(false);
+  });
+});
+
+describe("Mapper 470 (INX_007T_V01)", () => {
+  /**
+   * Evidence-matched (pessimistic) board model: the inner ($8000) bank
+   * latch does NOT survive any bus idle, so it is usable only inside the
+   * fused `readCpuBankLatched` call; a plain readCpu always serves the
+   * power-on default inner bank (0) because the latch decayed in the gap
+   * after the writeCpu transaction. This is the failure signature the
+   * real cart produced against a split write-then-read walk: whole banks
+   * of default-bank content. The outer ($5000) latch holds — also
+   * observed on the real cart.
+   */
+  class InlRomFusedBus implements NesBus {
+    private outer = 0;
+    readonly fusedCalls: Array<[number, number, number, number]> = [];
+    private readonly flash: Uint8Array;
+    constructor(flash: Uint8Array) {
+      this.flash = flash;
+    }
+    async setup() {}
+    async writeCpu(addr: number, value: number) {
+      if (addr === 0x5000) this.outer = value & 3;
+      // $8000 writes latch... and decay before any later transaction.
+    }
+    private window(inner: number, addr: number, length: number) {
+      const off = this.outer * 0x40000 + inner * 0x8000 + (addr - 0x8000);
+      return this.flash.slice(off, off + length);
+    }
+    async readCpu(addr: number, length: number) {
+      return this.window(0, addr, length); // latch long gone: default bank
+    }
+    async readCpuBankLatched(
+      latchAddr: number,
+      latchValue: number,
+      addr: number,
+      length: number,
+    ) {
+      expect(latchAddr).toBe(0x8000);
+      this.fusedCalls.push([latchAddr, latchValue, addr, length]);
+      return this.window(latchValue & 7, addr, length);
+    }
+  }
+
+  /**
+   * Optimistic board model for the split fallback: the inner latch
+   * survives the write-to-read idle gap but decays after every readCpu
+   * transaction. Validates the fallback's addressing and re-latch
+   * cadence — NOT hardware viability, which the pessimistic model above
+   * shows requires the fused capability.
+   */
+  class InlRomSplitBus implements NesBus {
+    private outer = 0;
+    private inner = 0; // power-on default
+    readonly innerWrites: number[] = [];
+    private readonly flash: Uint8Array;
+    constructor(flash: Uint8Array) {
+      this.flash = flash;
+    }
+    async setup() {}
+    async writeCpu(addr: number, value: number) {
+      if (addr === 0x5000) {
+        this.outer = value & 3;
+      } else if (addr === 0x8000) {
+        this.innerWrites.push(value);
+        this.inner = value & 7; // board decodes the low 3 bits
+      } else {
+        throw new Error(`unexpected write $${addr.toString(16)}`);
+      }
+    }
+    async readCpu(addr: number, length: number) {
+      expect(addr).toBeGreaterThanOrEqual(0x8000);
+      const off = this.outer * 0x40000 + this.inner * 0x8000 + (addr - 0x8000);
+      const win = this.flash.slice(off, off + length);
+      this.inner = 0; // the latch decays at the end of every transaction
+      return win;
+    }
+  }
+
+  it("dumps byte-exact through the fused latch+read on a latch that dies at every idle", async () => {
+    const flash = makeImage(1024 * 1024);
+    const bus = new InlRomFusedBus(flash);
+    const out = await mapper470.dumpPrgRom(bus, 1024);
+    expectSameBytes(out, flash);
+  });
+
+  it("issues the vendor's exact fused-call stream: global bank index, 2 KiB chunks", async () => {
+    const bus = new InlRomFusedBus(makeImage(1024 * 1024));
+    await mapper470.dumpPrgRom(bus, 1024);
+    // 32 banks x 16 chunks of 2 KiB, each call latching $8000 with the
+    // GLOBAL 32 KiB bank index (0-31) — the value stream the vendor's
+    // hardware-validated routine emits.
+    const expected: Array<[number, number, number, number]> = [];
+    for (let g = 0; g < 32; g++) {
+      for (let off = 0; off < 0x8000; off += 0x800) {
+        expected.push([0x8000, g, 0x8000 + off, 0x800]);
+      }
+    }
+    expect(bus.fusedCalls).toEqual(expected);
+  });
+
+  it("documents why the fused capability exists: the split walk dies on the same board", async () => {
+    // Strip the capability so the mapper falls back to split write+read
+    // against the pessimistic model: every bank comes back as its
+    // outer's default (inner-0) bank — the real cart's dead-dump
+    // signature, NOT the flash content.
+    const flash = makeImage(1024 * 1024);
+    const bus = new InlRomFusedBus(flash);
+    (bus as { readCpuBankLatched?: unknown }).readCpuBankLatched = undefined;
+    const out = await mapper470.dumpPrgRom(bus, 1024);
+    expect(bytesEqual(out, flash)).toBe(false);
+    for (let outer = 0; outer < 4; outer++) {
+      const defaultBank = flash.subarray(
+        outer * 0x40000,
+        outer * 0x40000 + 0x8000,
+      );
+      for (let inner = 0; inner < 8; inner++) {
+        const start = (outer * 8 + inner) * 0x8000;
+        expectSameBytes(out.subarray(start, start + 0x8000), defaultBank);
+      }
+    }
+  });
+
+  it("split fallback is byte-exact when the latch survives the write-to-read gap", async () => {
+    const flash = makeImage(1024 * 1024);
+    const out = await mapper470.dumpPrgRom(new InlRomSplitBus(flash), 1024);
+    expectSameBytes(out, flash);
+  });
+
+  it("split fallback re-latches the global bank index before every 4 KiB sub-read", async () => {
+    const bus = new InlRomSplitBus(makeImage(1024 * 1024));
+    await mapper470.dumpPrgRom(bus, 1024);
+    // 32 banks x 8 sub-reads, each preceded by a re-latch carrying the
+    // global 32 KiB bank index — pins both the value stream and the
+    // re-latch cadence of the fallback path.
+    const expected = Array.from({ length: 32 }, (_, g) =>
+      new Array<number>(8).fill(g),
+    ).flat();
+    expect(bus.innerWrites).toEqual(expected);
+  });
+
+  it("rejects any PRG size but the board's 1024 KiB", async () => {
+    await expect(
+      mapper470.dumpPrgRom(new InlRomSplitBus(makeImage(1024 * 1024)), 512),
+    ).rejects.toThrow(/1024 KiB/);
+  });
+
+  it("returns an empty CHR dump (CHR-RAM board)", async () => {
+    const out = await mapper470.dumpChrRom({} as NesBus, 0);
+    expect(out.length).toBe(0);
   });
 });

--- a/src/lib/systems/nes/mappers/mappers.test.ts
+++ b/src/lib/systems/nes/mappers/mappers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import type { NesBus } from "../bus";
 import { bytesEqual } from "./bank-reliability";
 import { nrom } from "./nrom";
@@ -13,16 +13,19 @@ import { colorDreams } from "./color-dreams";
 import { gxrom } from "./gxrom";
 import { fme7 } from "./fme7";
 import { quattro } from "./quattro";
+import { mapper268Mindkids, mapper268Coolboy } from "./coolboy";
 
 /**
  * A deterministic, well-mixed cart image. The multiplicative hash makes
  * every aligned bank distinct (and non-uniform), so the dropout detector
  * never false-positives and bank reconstruction is exactly verifiable.
+ * `seed` makes distinct images distinct (e.g. a boot window that must not
+ * collide with any flash bank).
  */
-function makeImage(bytes: number): Uint8Array {
+function makeImage(bytes: number, seed = 0): Uint8Array {
   const a = new Uint8Array(bytes);
   for (let i = 0; i < bytes; i++)
-    a[i] = (Math.imul(i, 2654435761) >>> 24) & 0xff;
+    a[i] = (Math.imul(i + seed * 0x9e3779b1, 2654435761) >>> 24) & 0xff;
   return a;
 }
 
@@ -994,5 +997,134 @@ describe("Quattro (mapper 232)", () => {
     await expect(quattro.dumpChrRom({} as NesBus, 8)).rejects.toThrow(
       /CHR-RAM/,
     );
+  });
+});
+
+describe("Mapper 268 (Mindkids / CoolBoy)", () => {
+  /**
+   * Models the Mindkids variant (submapper 1) from the silicon side: outer
+   * registers at $5000-$5003, GNROM-mode decode per the nesdev bit layout.
+   * The bank decode inverts the register *layout spec* (which bit field
+   * carries which PRG address line), not the mapper's packing math, so a
+   * packing bug shows up as a wrong-bank read.
+   *
+   * `glitchBank = N` makes bank N's first read return one corrupted byte
+   * (subsequent reads clean) — the transient bank-substitution glitch the
+   * consensus read recovers from.
+   */
+  class MindkidsBus implements NesBus {
+    private regs = [0, 0, 0, 0];
+    private glitched = false;
+    glitchBank = -1;
+    readonly writes: Array<[number, number]> = [];
+    private readonly flash: Uint8Array;
+    constructor(flash: Uint8Array) {
+      this.flash = flash;
+    }
+    async setup() {}
+    async writeCpu(addr: number, value: number) {
+      this.writes.push([addr, value]);
+      if (addr >= 0x5000 && addr <= 0x5fff) {
+        this.regs[addr & 3] = value;
+      } else {
+        throw new Error(`unexpected CPU write $${addr.toString(16)}`);
+      }
+    }
+    async readCpu(addr: number, length: number) {
+      expect(addr).toBe(0x8000);
+      const [r0, r1, , r3] = this.regs;
+      // The walk's invariants: GNROM engaged, A17/A18 masks cleared, r2 = 0.
+      expect(r3 & 0x10).toBeTruthy();
+      expect(r0 & 0x40).toBeTruthy();
+      expect(r1 & 0x80).toBeTruthy();
+      expect(this.regs[2]).toBe(0);
+      // Spec-side decode: QQ=r3[3..1] → A14-16, EEE=r0[2..0] → A17-19,
+      // J=r1[4] → A20, KK=r1[3..2] → A22/A21, CC=r0[5..4] → A23/A24.
+      const bank =
+        ((r3 >> 1) & 7) |
+        ((r0 & 7) << 3) |
+        (((r1 >> 4) & 1) << 6) |
+        (((r1 >> 2) & 3) << 7) |
+        (((r0 >> 4) & 3) << 9);
+      const off = (bank * 0x4000) % this.flash.length;
+      const window = this.flash.slice(off, off + length);
+      if (this.glitchBank === bank && !this.glitched) {
+        this.glitched = true;
+        window[0] ^= 0xff; // one transient corrupted read
+      }
+      return window;
+    }
+  }
+
+  /** Run a dump with the per-write settle timers virtualised. */
+  async function dump(
+    bus: NesBus,
+    sizeKB: number,
+    mapper = mapper268Mindkids,
+  ): Promise<Uint8Array> {
+    vi.useFakeTimers();
+    try {
+      const p = mapper.dumpPrgRom(bus, sizeKB);
+      await vi.runAllTimersAsync();
+      return await p;
+    } finally {
+      vi.useRealTimers();
+    }
+  }
+
+  it("walks all 128 GNROM banks of a 2 MiB cart byte-exact", async () => {
+    const flash = makeImage(2048 * 1024);
+    const out = await dump(new MindkidsBus(flash), 2048);
+    expectSameBytes(out, flash);
+  });
+
+  it("issues the exact two-phase register sequence per bank", async () => {
+    const bus = new MindkidsBus(makeImage(32 * 1024)); // 2 banks
+    await dump(bus, 32);
+    // Bank 1: phase 1 carries the menu's transitional $5001=$90/$5003=$00
+    // with the final r0; phase 2 commits r0=$40, r1=$80, r3=$12.
+    expect(bus.writes.slice(8, 16)).toEqual([
+      [0x5000, 0x40],
+      [0x5001, 0x90],
+      [0x5002, 0x00],
+      [0x5003, 0x00],
+      [0x5000, 0x40],
+      [0x5001, 0x80],
+      [0x5002, 0x00],
+      [0x5003, 0x12],
+    ]);
+    // bank 0 + bank 1, 8 writes each, nothing else (no post-walk recheck).
+    expect(bus.writes).toHaveLength(16);
+  });
+
+  it("recovers a transient bank glitch via consensus", async () => {
+    const flash = makeImage(128 * 1024); // 8 banks
+    const bus = new MindkidsBus(flash);
+    bus.glitchBank = 2;
+    const out = await dump(bus, 128);
+    expectSameBytes(out, flash); // the corrupted read never reaches the dump
+  });
+
+  it("returns an empty CHR dump (CHR-RAM-only submapper)", async () => {
+    const out = await mapper268Mindkids.dumpChrRom({} as NesBus, 0);
+    expect(out.length).toBe(0);
+  });
+
+  it("CoolBoy (submapper 0) drives the $6000 outer-register block", async () => {
+    // The only behavioural difference from the Mindkids variant is the
+    // outer-register base; pin that the submapper-0 export targets $6000.
+    const writes: number[] = [];
+    const flash = makeImage(512 * 1024);
+    const bus: NesBus = {
+      setup: async () => {},
+      writeCpu: async (addr) => {
+        writes.push(addr);
+      },
+      readCpu: async (_addr, length) => flash.slice(0, length),
+    };
+    const out = await dump(bus, 512, mapper268Coolboy);
+    expect(out.length).toBe(512 * 1024);
+    expect(writes.some((a) => a >= 0x6000 && a <= 0x6003)).toBe(true);
+    expect(writes.some((a) => a >= 0x5000 && a <= 0x5003)).toBe(false);
   });
 });

--- a/src/lib/systems/nes/nes-constants.ts
+++ b/src/lib/systems/nes/nes-constants.ts
@@ -194,6 +194,20 @@ export const NES_MAPPER_DB: NESMapperDef[] = [
     // (capability.unsupportedMappers greys it out on the INL), and on a
     // device that can drive this board the dump path is hardware-validated.
   },
+  {
+    id: 470,
+    name: "INX_007T_V01",
+    prgSizesKB: [1024],
+    chrSizesKB: [0],
+    mirroring: "horizontal",
+    commonlyHasBattery: false,
+    maxPrgRamKB: 0,
+    chrRamKB: 8,
+    // Device-agnostic maturity caveat (the INL incompatibility itself is
+    // handled per-device via capability.unsupportedMappers).
+    warning:
+      "The dump recipe for this board is vendor-derived and not yet hardware-validated — verify the result against a known-good reference.",
+  },
 ];
 
 export function getMapperDef(id: number): NESMapperDef | undefined {

--- a/src/lib/systems/nes/nes-constants.ts
+++ b/src/lib/systems/nes/nes-constants.ts
@@ -11,7 +11,20 @@ export interface NESMapperDef {
     | "mapper_controlled";
   commonlyHasBattery: boolean;
   alwaysHasBattery?: boolean;
+  /**
+   * Battery-backed SRAM capacity in KiB. Drives the "Back up battery
+   * SRAM" opt-in (and the NVRAM declaration, byte 10 high nibble, when
+   * it's checked). Strictly about saves — boards whose $6000 RAM is
+   * volatile work RAM declare `prgRamKB` instead.
+   */
   maxPrgRamKB: number;
+  /**
+   * Volatile PRG work RAM in KiB, declared in the header (byte 10 low
+   * nibble) regardless of the battery opt-in. For boards that need work
+   * RAM at $6000-$7FFF to function (e.g. mapper 268's bank-switch
+   * trampoline) but have nothing worth backing up.
+   */
+  prgRamKB?: number;
   /**
    * Volatile CHR-RAM size in KiB. Used by the NES 2.0 header builder
    * (byte 11 low nibble). Mostly 0 (ROM carts); CHR-RAM mappers carry
@@ -19,8 +32,13 @@ export interface NESMapperDef {
    */
   chrRamKB?: number;
   /**
-   * Optional per-mapper hardware warning, surfaced as a prominent amber
-   * alert in the config UI (e.g. a cart-handling caveat).
+   * Optional per-mapper warning, surfaced as a prominent amber alert in
+   * the config UI when the mapper is selected. Must be DEVICE-AGNOSTIC —
+   * a cart-handling caveat (e.g. Quattro's A/B switch) or an
+   * implementation-maturity note — because it shows on every driver that
+   * can select the mapper. Device-specific "can't dump here" belongs in
+   * the driver's `capability.unsupportedMappers` (which greys the option
+   * out per-device), never here.
    */
   warning?: string;
 }
@@ -149,6 +167,32 @@ export const NES_MAPPER_DB: NESMapperDef[] = [
     chrRamKB: 8,
     warning:
       "Set the A/B switch to position A (lockout-defeat OFF) before dumping — leaving it in B can damage the cart or reader.",
+  },
+  {
+    id: 268,
+    name: "Mindkids / CoolBoy",
+    // The SMD172 board family ships up to 32 MiB and the dump walk's
+    // register math covers all of it (the header builder spills sizes
+    // >= 4 MiB into byte 9), but only the sizes listed here have been
+    // validated on hardware — extend the list as bigger boards are.
+    // Listing conservatively also keeps the default (largest = last)
+    // a sane dump length.
+    prgSizesKB: [512, 1024, 2048],
+    chrSizesKB: [0],
+    mirroring: "mapper_controlled",
+    commonlyHasBattery: false,
+    // No battery — so no save opt-in (maxPrgRamKB 0). But multicarts on
+    // this board use volatile PRG-RAM at $6000-$7FFF as the destination
+    // for a runtime-copied bank-switch trampoline; without declaring it
+    // in the header (byte 10 low nibble), emulators reject the copy and
+    // the trampoline-dependent games fail to boot even though the dump
+    // is complete.
+    maxPrgRamKB: 0,
+    prgRamKB: 8,
+    chrRamKB: 256,
+    // No device-agnostic caveat: incompatibility is per-device
+    // (capability.unsupportedMappers greys it out on the INL), and on a
+    // device that can drive this board the dump path is hardware-validated.
   },
 ];
 

--- a/src/lib/systems/nes/nes-header.test.ts
+++ b/src/lib/systems/nes/nes-header.test.ts
@@ -95,4 +95,48 @@ describe("buildNes2Header", () => {
       }),
     ).toThrow();
   });
+
+  it("encodes a mapper-268 multicart: mapper MSBs, volatile work RAM, big CHR-RAM", () => {
+    const h = buildNes2Header({
+      prgBytes: 2048 * 1024,
+      chrBytes: 0,
+      mapper: 268,
+      mirroring: "mapper_controlled",
+      battery: false,
+      chrRamKB: 256,
+      prgRamKB: 8, // unbatteried trampoline RAM — byte 10 LOW nibble
+    });
+    expectNes2Magic(h);
+    expect(h[4]).toBe(128); // 2 MiB = 128 x 16 KiB
+    expect(h[6] >> 4).toBe(268 & 0x0f);
+    expect(h[7] & 0xf0).toBe(268 & 0xf0);
+    expect(h[8] & 0x0f).toBe(268 >> 8);
+    expect(h[10]).toBe(0x07); // volatile 8 KiB, no NVRAM
+    expect(h[11]).toBe(0x0c); // 256 KiB CHR-RAM = 64 << 12
+  });
+
+  it("spills PRG/CHR sizes >= 4 MiB into the byte-9 MSB nibbles", () => {
+    const h = buildNes2Header({
+      prgBytes: 32768 * 1024, // 32 MiB = 0x800 x 16 KiB units
+      chrBytes: 4096 * 1024, // 4 MiB = 0x200 x 8 KiB units
+      mapper: 268,
+      mirroring: "mapper_controlled",
+      battery: false,
+    });
+    expect(h[4]).toBe(0x00);
+    expect(h[5]).toBe(0x00);
+    expect(h[9]).toBe(0x28); // CHR MSB nibble 2 (high), PRG MSB nibble 8 (low)
+  });
+
+  it("rejects sizes past the plain-form ceiling instead of wrapping", () => {
+    expect(() =>
+      buildNes2Header({
+        prgBytes: 0xf00 * 16384, // first unit count that needs exponent form
+        chrBytes: 0,
+        mapper: 268,
+        mirroring: "mapper_controlled",
+        battery: false,
+      }),
+    ).toThrow(/too large/);
+  });
 });

--- a/src/lib/systems/nes/nes-header.ts
+++ b/src/lib/systems/nes/nes-header.ts
@@ -84,11 +84,21 @@ export function buildNes2Header(p: Nes2HeaderInputs): Uint8Array {
   h[2] = 0x53; // S
   h[3] = 0x1a;
 
-  // PRG/CHR size — currently only the low 8 bits; byte 9 high nibble
-  // would carry MSB nibbles for sizes >= 4 MiB which we don't yet
-  // support.
-  h[4] = (p.prgBytes / 16384) & 0xff;
-  h[5] = (p.chrBytes / 8192) & 0xff;
+  // PRG/CHR size: low 8 bits in bytes 4/5, MSB nibbles in byte 9. The
+  // plain (non-exponent) NES 2.0 size form tops out at 0xEFF units —
+  // ~60 MiB PRG / ~30 MiB CHR — which comfortably covers the largest
+  // boards we offer (32 MiB mapper-268 multicarts). An MSB nibble of
+  // 0xF would flip the field into exponent form, so guard loudly
+  // rather than emit a header that silently means something else.
+  const prgUnits = p.prgBytes / 16384;
+  const chrUnits = p.chrBytes / 8192;
+  if (prgUnits > 0xeff || chrUnits > 0xeff) {
+    throw new Error(
+      `ROM too large for NES 2.0 plain size form: ${prgUnits}x16K PRG / ${chrUnits}x8K CHR`,
+    );
+  }
+  h[4] = prgUnits & 0xff;
+  h[5] = chrUnits & 0xff;
 
   // Flags 6: mapper bits 0-3, mirroring, battery, four-screen
   let flags6 = (p.mapper & 0x0f) << 4;
@@ -104,8 +114,8 @@ export function buildNes2Header(p: Nes2HeaderInputs): Uint8Array {
   const submapper = p.submapper ?? 0;
   h[8] = ((submapper & 0x0f) << 4) | ((p.mapper >> 8) & 0x0f);
 
-  // Byte 9: PRG/CHR MSB nibbles — 0 for everything we support today.
-  h[9] = 0;
+  // Byte 9: CHR MSB nibble (high), PRG MSB nibble (low).
+  h[9] = (((chrUnits >> 8) & 0x0f) << 4) | ((prgUnits >> 8) & 0x0f);
 
   // Byte 10: PRG-RAM (low), PRG-NVRAM (high). Battery → NVRAM nibble.
   const prgRamShift = ramShift((p.prgRamKB ?? 0) * 1024);

--- a/src/lib/systems/nes/nes-system-handler.test.ts
+++ b/src/lib/systems/nes/nes-system-handler.test.ts
@@ -29,3 +29,32 @@ describe("NES config sizing", () => {
     expect(handler.estimateDumpSize({ mapper: 0 })).toBe(16 + (32 + 8) * 1024);
   });
 });
+
+describe("NES mapper-option greying", () => {
+  const handler = new NESSystemHandler();
+
+  it("greys out mappers the connected device declares unsupported", () => {
+    const fields = handler.getConfigFields({ mapper: 0 }, undefined, {
+      systemId: "nes",
+      operations: ["dump_rom"],
+      autoDetect: true,
+      unsupportedMappers: [4],
+    });
+    const options = fields.find((f) => f.key === "mapper")?.options ?? [];
+    const disabledOpt = options.find((o) => o.value === 4);
+    expect(disabledOpt?.disabled).toBe(true);
+    // A disabled mapper's hint is only the reason — no PRG/CHR sizes.
+    expect(disabledOpt?.hint).toBe("not dumpable with this device");
+    // Enabled mappers still show their sizes.
+    expect(options.find((o) => o.value === 0)?.hint).toMatch(/PRG:/);
+    // Everything else stays selectable...
+    expect(options.filter((o) => o.disabled)).toHaveLength(1);
+    // ...and with no capability context nothing is greyed at all.
+    const bare = handler.getConfigFields({ mapper: 0 });
+    expect(
+      (bare.find((f) => f.key === "mapper")?.options ?? []).every(
+        (o) => !o.disabled,
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/lib/systems/nes/nes-system-handler.test.ts
+++ b/src/lib/systems/nes/nes-system-handler.test.ts
@@ -30,21 +30,54 @@ describe("NES config sizing", () => {
   });
 });
 
-describe("NES mapper-option greying", () => {
+describe("NES computed-header PRG-RAM declarations (buildOutputFile)", () => {
   const handler = new NESSystemHandler();
+
+  /** Computed 16-byte header for a mapper + save-opt-in combination. */
+  function headerFor(values: Parameters<typeof handler.buildReadConfig>[0]) {
+    const config = handler.buildReadConfig(values);
+    // No verification entry → the computed (not canonical) header path.
+    const out = handler.buildOutputFile(new Uint8Array(16), config);
+    return out.data.subarray(0, 16);
+  }
+
+  it("declares mapper 268's volatile trampoline RAM without any battery", () => {
+    const h = headerFor({ mapper: 268 });
+    expect(h[6] & 0x02).toBe(0); // no battery bit
+    expect(h[10]).toBe(0x07); // 8 KiB volatile work RAM, no NVRAM
+    expect(h[11]).toBe(0x0c); // 256 KiB CHR-RAM
+  });
+
+  it("declares NVRAM only when the save opt-in is set (MMC3)", () => {
+    const withSave = headerFor({ mapper: 4, backupSave: true });
+    expect(withSave[6] & 0x02).toBe(0x02);
+    expect(withSave[10]).toBe(0x70); // 8 KiB NVRAM, no volatile RAM
+
+    const withoutSave = headerFor({ mapper: 4 });
+    expect(withoutSave[6] & 0x02).toBe(0);
+    expect(withoutSave[10]).toBe(0x00); // no PRG-RAM declared at all
+  });
+
+  it("offers no battery-SRAM opt-in for the battery-less mapper 268", () => {
+    const fields = handler.getConfigFields({ mapper: 268 });
+    expect(fields.some((f) => f.key === "backupSave")).toBe(false);
+    // ...while a battery-capable mapper does get the checkbox.
+    const mmc3Fields = handler.getConfigFields({ mapper: 4 });
+    expect(mmc3Fields.some((f) => f.key === "backupSave")).toBe(true);
+  });
 
   it("greys out mappers the connected device declares unsupported", () => {
     const fields = handler.getConfigFields({ mapper: 0 }, undefined, {
       systemId: "nes",
       operations: ["dump_rom"],
       autoDetect: true,
-      unsupportedMappers: [4],
+      unsupportedMappers: [268],
     });
     const options = fields.find((f) => f.key === "mapper")?.options ?? [];
-    const disabledOpt = options.find((o) => o.value === 4);
-    expect(disabledOpt?.disabled).toBe(true);
+    const m268 = options.find((o) => o.value === 268);
+    expect(m268?.disabled).toBe(true);
     // A disabled mapper's hint is only the reason — no PRG/CHR sizes.
-    expect(disabledOpt?.hint).toBe("not dumpable with this device");
+    expect(m268?.hint).toBe("not dumpable with this device");
     // Enabled mappers still show their sizes.
     expect(options.find((o) => o.value === 0)?.hint).toMatch(/PRG:/);
     // Everything else stays selectable...

--- a/src/lib/systems/nes/nes-system-handler.ts
+++ b/src/lib/systems/nes/nes-system-handler.ts
@@ -268,8 +268,14 @@ export class NESSystemHandler implements SystemHandler {
     // CHR-RAM: only present if the cart has no CHR-ROM and the mapper
     // def declares a CHR-RAM size (e.g. mapper 470: 8 KiB).
     const chrRamKB = chrBytes === 0 ? (mapperDef?.chrRamKB ?? 0) : 0;
-    // The SRAM opt-in is battery-backed (NVRAM) when set; we declare no
-    // PRG-RAM when it's unset. A No-Intro match overrides this regardless.
+    // PRG-RAM, two independent declarations mirroring the two DB fields:
+    // volatile work RAM (`prgRamKB`, byte 10 low nibble) is a property of
+    // the board and is declared whether or not a save was read — carts
+    // like the mapper 268 multicarts need it for games to boot in
+    // emulators; battery NVRAM (`maxPrgRamKB`, high nibble) is declared
+    // only when the save opt-in is set. A No-Intro match overrides all of
+    // this regardless.
+    const prgRamKB = mapperDef?.prgRamKB ?? 0;
     const prgNvramKB =
       battery && mapperDef?.maxPrgRamKB ? mapperDef.maxPrgRamKB : 0;
 
@@ -282,7 +288,7 @@ export class NESSystemHandler implements SystemHandler {
           mirroring,
           battery,
           chrRamKB,
-          prgRamKB: 0,
+          prgRamKB,
           prgNvramKB,
         });
 

--- a/src/lib/systems/nes/nes-system-handler.ts
+++ b/src/lib/systems/nes/nes-system-handler.ts
@@ -2,6 +2,7 @@ import type {
   SystemHandler,
   ConfigValues,
   CartridgeInfo,
+  DeviceCapability,
   ResolvedConfigField,
   ValidationResult,
   ValidationError,
@@ -43,6 +44,7 @@ export class NESSystemHandler implements SystemHandler {
   getConfigFields(
     currentValues: ConfigValues,
     autoDetected?: CartridgeInfo,
+    capability?: DeviceCapability,
   ): ResolvedConfigField[] {
     const fields: ResolvedConfigField[] = [];
 
@@ -57,15 +59,25 @@ export class NESSystemHandler implements SystemHandler {
       type: "select",
       value: mapperValue,
       autoDetected: autoDetected?.mapper != null,
-      options: NES_MAPPER_DB.map((m) => ({
-        value: m.id,
-        label: `${m.id}: ${m.name}`,
-        hint:
-          `PRG: ${m.prgSizesKB.join("/")}KB` +
-          (m.chrSizesKB.some((c) => c > 0)
-            ? ` · CHR: ${m.chrSizesKB.filter((c) => c > 0).join("/")}KB`
-            : " · CHR RAM"),
-      })),
+      options: NES_MAPPER_DB.map((m) => {
+        // Greyed out when the connected device declares it can't drive
+        // this mapper (the driver also pre-flight-rejects it at dump time).
+        const disabled =
+          capability?.unsupportedMappers?.includes(m.id) ?? false;
+        return {
+          value: m.id,
+          label: `${m.id}: ${m.name}`,
+          // A disabled mapper can't be dumped here, so its sizes are
+          // irrelevant noise — show only why it's unavailable.
+          hint: disabled
+            ? "not dumpable with this device"
+            : `PRG: ${m.prgSizesKB.join("/")}KB` +
+              (m.chrSizesKB.some((c) => c > 0)
+                ? ` · CHR: ${m.chrSizesKB.filter((c) => c > 0).join("/")}KB`
+                : " · CHR RAM"),
+          disabled,
+        };
+      }),
       group: "cartridge",
       order: 0,
       helpText: autoDetected?.mapper

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -72,6 +72,13 @@ export interface DeviceCapability {
   )[];
   autoDetect: boolean;
   notes?: string;
+  /**
+   * Mapper IDs in the system's shared catalog this device cannot drive
+   * (only meaningful for mapper-based systems, i.e. NES). The driver
+   * still pre-flight-rejects these in `readROM`; declaring them here
+   * additionally greys the options out in the config UI.
+   */
+  unsupportedMappers?: number[];
 }
 
 export interface DeviceDriverEvents {
@@ -181,6 +188,12 @@ export interface SystemHandler {
   getConfigFields(
     currentValues: ConfigValues,
     autoDetected?: CartridgeInfo,
+    /**
+     * The connected device's capability for this system, when known —
+     * lets the handler grey out options the device can't drive (e.g.
+     * `unsupportedMappers`).
+     */
+    capability?: DeviceCapability,
   ): ResolvedConfigField[];
   estimateDumpSize?(values: ConfigValues): number;
   validate(values: ConfigValues): ValidationResult;
@@ -286,6 +299,8 @@ export interface ConfigOption {
   value: string | number;
   label: string;
   hint?: string;
+  /** Greyed out and unselectable (e.g. the connected device can't dump it). */
+  disabled?: boolean;
 }
 
 // ─── Validation ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds two CPLD-based NES "clone multicart" mappers to the shared, device-agnostic mapper catalog, plus the header and config-UI work they need:

- **Mapper 268** — CoolBoy / Mindkids MMC3-clone multicart (GNROM-mode dump walk)
- **Mapper 470** — INX_007T_V01 board (fused latch+read dump walk)

Neither board is dumpable on the INL Retro Programmer: its firmware idles M2 and emits a single pulse per write, and these boards' CPLDs refuse those synthesized bus cycles. Both mappers are implemented, spec-tested, and kept in the catalog for devices whose bus the boards accept — the INL driver pre-flight-rejects them and the config UI greys them out, so a user can't start a dump that would only return a boot-bank mirror.

## What's in each commit

1. **NES 2.0 large-cart header encoding** — fill byte-9's PRG/CHR MSB nibbles for ROMs ≥ 4 MiB instead of silently wrapping bytes 4/5, with a guard against the plain-form ceiling (above which the field flips into exponent form).
2. **Config UI** — keep the mapper dropdown inside its grid cell (it overflowed onto the PRG-size control on long labels), and grey out / disable mappers a connected device declares unsupported via a new `DeviceCapability.unsupportedMappers`. Disabled options are unselectable, exposed as disabled in the accessibility tree, and labelled "not dumpable with this device".
3. **Mapper 268** — GNROM-mode walk (mirroring ClusterM's `famicom-dumper-client` reference recipe), a consensus re-read for this clone's bank-substitution glitch, a per-dump failure-classification pass (writes-not-landing / relocked-mid-dump / unstable-reads / open-bus) fenced so a diagnostics fault can't discard a completed dump, and a per-mapper volatile work-RAM header declaration for the boards' bank-switch trampoline.
4. **Mapper 470** — vendor-cadence walk through a new optional `NesBus.readCpuBankLatched` capability (the board's inner-bank latch doesn't survive bus idle, so the bank write and read must share one transaction), with a split write-then-read fallback for buses that lack the fused primitive.

## Hardware status

- **Mapper 268** — the dump walk is hardware-validated against a known-good reference on a denser-cadence dumper; its INL incompatibility is hardware-classified (writes-not-landing, with the inner-MMC3 discrimination probe also negative — the CPLD refuses *all* synthesized writes, not just the outer registers).
- **Mapper 470** — the recipe is reverse-engineered from the vendor host app plus a firmware bus trace; **not yet hardware-validated on any device here** (the DB entry carries that caveat). The INL rejection is by family inference plus a recalled prior failure of this board on this device class, so it's a conservative default an instrumented attempt could overturn.

## Testing

259 unit/integration tests, build and lint clean. New coverage spans both mappers' banking and byte-exact reconstruction, the classifier's failure modes, the header encoding (including the ≥ 4 MiB spill and the ceiling guard), and the config-UI greying.

## Attribution

Mapper 268's register sequence is derived from ClusterM's `famicom-dumper-client` (GPL-3.0); attribution added to `THIRD-PARTY-LICENSES`.
