### PR TITLE
NES: post-dump header editor + per-section CRC breakdown

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,10 @@ function App() {
     null,
   );
   const [configValues, setConfigValues] = useState<ConfigValues>({});
+  // User edits to the NES 2.0 header on the completion screen, for unverified
+  // dumps only. Keyed by header-field key; empty means "use the defaults the
+  // computed header already carries". Reset on every new dump / teardown.
+  const [headerOverrides, setHeaderOverrides] = useState<ConfigValues>({});
   const [autoDetected, setAutoDetected] = useState<CartridgeInfo | null>(null);
   const [detecting, setDetecting] = useState(false);
   const [unsupportedDetection, setUnsupportedDetection] = useState<{
@@ -232,6 +236,7 @@ function App() {
   const clearSessionState = useCallback(() => {
     setSelectedSystem(null);
     setConfigValues({});
+    setHeaderOverrides({});
     setAutoDetected(null);
     setUnsupportedDetection(null);
     dumpJob.reset();
@@ -276,18 +281,62 @@ function App() {
     return "idle" as const;
   }, [dumpJob.state, connection.driver]);
 
+  // Apply the user's header edits (unverified dumps only) to the produced ROM.
+  // Identity passthrough whenever there's nothing to apply — verified dump, no
+  // edits, or a system without an editable header — so downstream memos (e.g.
+  // the icon-allocating PS1 summary) don't churn on unrelated re-renders.
+  const editedResult = useMemo(() => {
+    const result = dumpJob.result;
+    if (
+      !result?.rom ||
+      result.verification.matched ||
+      !selectedSystem?.applyHeaderOverrides ||
+      Object.keys(headerOverrides).length === 0
+    ) {
+      return result;
+    }
+    const data = selectedSystem.applyHeaderOverrides(
+      result.rom.data,
+      headerOverrides,
+    );
+    return {
+      ...result,
+      rom: {
+        ...result.rom,
+        data,
+        // Refresh the report meta from the edited header so the saved report
+        // matches the saved bytes (e.g. an edited Mirroring / Region).
+        meta: { ...result.rom.meta, ...(selectedSystem.headerMeta?.(data) ?? {}) },
+      },
+    };
+  }, [dumpJob.result, selectedSystem, headerOverrides]);
+
   // Decoding the PS1 dump summary allocates fresh icon arrays per call, which
   // would restart the IconCanvas animation on every unrelated re-render
   // (e.g. log-panel updates). Memoize on the rom data reference.
   const dumpSummary = useMemo(() => {
-    const data = dumpJob.result?.rom?.data;
+    const data = editedResult?.rom?.data;
     if (!data) return null;
     return selectedSystem?.summarizeDump?.(data) ?? null;
-  }, [selectedSystem, dumpJob.result?.rom?.data]);
+  }, [selectedSystem, editedResult?.rom?.data]);
+
+  // Editable NES 2.0 header fields, offered only for an unverified dump (the
+  // verified path uses the canonical DB header). Built from the ORIGINAL ROM
+  // bytes overlaid with the user's edits — never the already-edited file.
+  const headerFields = useMemo(() => {
+    const result = dumpJob.result;
+    if (!result?.rom || result.verification.matched) return null;
+    const fields = selectedSystem?.getHeaderFields?.(
+      result.rom.data,
+      headerOverrides,
+    );
+    return fields && fields.length > 0 ? fields : null;
+  }, [dumpJob.result, selectedSystem, headerOverrides]);
 
   const handleSelectSystem = useCallback(
     async (system: SystemHandler) => {
       dumpJob.reset();
+      setHeaderOverrides({});
 
       // Do auto-detection BEFORE updating state, so the UI renders once
       // with the final values instead of flashing empty then populated.
@@ -348,6 +397,8 @@ function App() {
 
   const handleStartDump = useCallback(async () => {
     if (!connection.driver || !selectedSystem) return;
+    // A fresh dump starts with no header edits carried over from the last one.
+    setHeaderOverrides({});
     // Resolve field defaults for locked/unset keys (e.g. backupSave, battery)
     // so locked checkbox values that the user can't interact with are included.
     const resolved = seedConfigDefaults(
@@ -554,7 +605,7 @@ function App() {
                 )}
                 {dumpJob.state === "complete" && dumpJob.result && (
                   <CompleteStep
-                    result={dumpJob.result}
+                    result={editedResult ?? dumpJob.result}
                     // No placeholder default: CompleteStep owns the fallback
                     // chain (verified name → title → "(Unverified) <CRC32>"),
                     // and a truthy placeholder here would short-circuit it.
@@ -570,6 +621,10 @@ function App() {
                         ?.operations.includes("dump_rom")
                     }
                     summary={dumpSummary}
+                    headerFields={headerFields}
+                    onHeaderFieldChange={(key, value) =>
+                      setHeaderOverrides((prev) => ({ ...prev, [key]: value }))
+                    }
                     log={log}
                   />
                 )}

--- a/src/components/wizard/complete-step.tsx
+++ b/src/components/wizard/complete-step.tsx
@@ -7,7 +7,9 @@ import type {
   CartridgeInfo,
   DumpSummary,
   DumpSummaryCell,
+  ResolvedConfigField,
 } from "@/lib/types";
+import { ConfigField } from "@/components/shared/config-field";
 import { hexStr, formatBytes } from "@/lib/core/hashing";
 import { saveFile } from "@/lib/core/file-save";
 import { generateDumpReport } from "@/lib/core/dump-report";
@@ -72,6 +74,14 @@ interface CompleteStepProps {
   saveOnly: boolean;
   /** Optional system-specific breakdown of the dump's contents. */
   summary?: DumpSummary | null;
+  /**
+   * Editable header fields for an unverified dump (NES 2.0 region/timing,
+   * console, controller, …). Null/empty when none apply (verified dump or a
+   * system with no editable header), in which case no editor is shown.
+   */
+  headerFields?: ResolvedConfigField[] | null;
+  /** Called when the user edits a header field; keyed by field key. */
+  onHeaderFieldChange?: (key: string, value: unknown) => void;
   /** Event-log sink, used to surface a failed save. */
   log: (message: string, level?: "info" | "warn" | "error") => void;
 }
@@ -86,6 +96,8 @@ export function CompleteStep({
   hotSwap,
   saveOnly,
   summary,
+  headerFields,
+  onHeaderFieldChange,
   log,
 }: CompleteStepProps) {
   const verified = result.verification.matched;
@@ -219,7 +231,11 @@ export function CompleteStep({
                     {summary.columns.map((c, i) => (
                       <th
                         key={i}
-                        className="px-3 py-1.5 text-left font-normal"
+                        className={`px-3 py-1.5 font-normal ${
+                          summary.rightAlignColumns?.includes(i)
+                            ? "text-right"
+                            : "text-left"
+                        }`}
                       >
                         {c}
                       </th>
@@ -233,10 +249,12 @@ export function CompleteStep({
                         const mono = summary.monoColumns?.includes(j) ?? false;
                         const muted =
                           summary.mutedColumns?.includes(j) ?? false;
+                        const right =
+                          summary.rightAlignColumns?.includes(j) ?? false;
                         return (
                           <td
                             key={j}
-                            className={`px-3 py-1 ${mono ? "font-mono" : ""} ${muted ? "text-muted-foreground" : ""}`}
+                            className={`px-3 py-1 ${mono ? "font-mono" : ""} ${muted ? "text-muted-foreground" : ""} ${right ? "text-right" : ""}`}
                           >
                             {typeof cell === "string" ? (
                               cell
@@ -258,6 +276,34 @@ export function CompleteStep({
             )}
           </div>
         )}
+
+        {/* Header editor — unverified dumps only (the DB supplies these on a
+            match). Edits rewrite the saved file's header; hashes are unaffected. */}
+        {!verified &&
+          !saveOnly &&
+          headerFields &&
+          headerFields.length > 0 &&
+          onHeaderFieldChange && (
+            <div className="flex flex-col gap-2">
+              <div className="text-[10px] uppercase tracking-widest text-muted-foreground">
+                NES 2.0 Header
+              </div>
+              <p className="text-[11px] text-muted-foreground">
+                No database match — set any fields the cartridge can't report.
+                They're written into the saved file's header and don't change
+                the dump's hashes.
+              </p>
+              <div className="grid grid-cols-2 gap-3">
+                {headerFields.map((field) => (
+                  <ConfigField
+                    key={field.key}
+                    field={field}
+                    onChange={(v) => onHeaderFieldChange(field.key, v)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
 
         {/* Actions */}
         <div className="flex flex-wrap gap-2">

--- a/src/lib/core/dump-job.ts
+++ b/src/lib/core/dump-job.ts
@@ -108,6 +108,11 @@ export class DumpJobImpl {
         readConfig,
         verification,
       );
+      // Surface any build-time warnings (e.g. a verified No-Intro header
+      // whose size/trainer fields don't describe the dump). The file is
+      // still emitted as verified — these only flag a suspect DAT entry.
+      for (const warning of outputFile.warnings ?? [])
+        this.log(warning, "warn");
 
       const result: DumpResult = {
         rom: outputFile,

--- a/src/lib/systems/nes/nes-constants.ts
+++ b/src/lib/systems/nes/nes-constants.ts
@@ -1,3 +1,5 @@
+import type { ConfigOption } from "@/lib/types";
+
 export interface NESMapperDef {
   id: number;
   name: string;
@@ -209,6 +211,53 @@ export const NES_MAPPER_DB: NESMapperDef[] = [
       "The dump recipe for this board is vendor-derived and not yet hardware-validated — verify the result against a known-good reference.",
   },
 ];
+
+// ─── NES 2.0 header-field options ───────────────────────────────────────────
+// Curated choices for the post-dump header editor (unverified dumps only).
+// Values match the encodings the NES header helpers expect: timing/mirroring
+// use the NesTvSystem/NesMirroring string literals; the rest are raw field
+// numbers.
+
+/** CPU/PPU timing (header byte 12) — the closest thing NES 2.0 has to region. */
+export const NES_TIMING_OPTIONS: ConfigOption[] = [
+  { value: "ntsc", label: "NTSC", hint: "North America / Japan (RP2C02)" },
+  { value: "pal", label: "PAL", hint: "Europe / Australia (RP2C07)" },
+  { value: "multi", label: "Multi-region" },
+  { value: "dendy", label: "Dendy", hint: "Famiclone timing" },
+];
+
+/** Console type (header byte 7 bits 0-1). */
+export const NES_CONSOLE_TYPE_OPTIONS: ConfigOption[] = [
+  { value: 0, label: "NES / Famicom" },
+  { value: 1, label: "Vs. System" },
+  { value: 2, label: "PlayChoice-10" },
+];
+
+/** Nametable mirroring (header byte 6). */
+export const NES_MIRRORING_OPTIONS: ConfigOption[] = [
+  { value: "horizontal", label: "Horizontal" },
+  { value: "vertical", label: "Vertical" },
+  { value: "four_screen", label: "Four-screen" },
+];
+
+/**
+ * Default expansion device (header byte 15). The NES 2.0 spec defines ~60;
+ * this is a curated shortlist of the common first-party peripherals. Values
+ * are the spec's device IDs.
+ */
+export const NES_EXPANSION_DEVICE_OPTIONS: ConfigOption[] = [
+  { value: 0, label: "Unspecified" },
+  { value: 1, label: "Standard Controller" },
+  { value: 2, label: "Four Score", hint: "4-player adapter" },
+  { value: 8, label: "Zapper", hint: "Light gun" },
+  { value: 0x0b, label: "Power Pad" },
+];
+
+/** Submapper (header byte 8, high nibble): 0-15. */
+export const NES_SUBMAPPER_OPTIONS: ConfigOption[] = Array.from(
+  { length: 16 },
+  (_, i) => ({ value: i, label: String(i) }),
+);
 
 export function getMapperDef(id: number): NESMapperDef | undefined {
   return NES_MAPPER_DB.find((m) => m.id === id);

--- a/src/lib/systems/nes/nes-header.test.ts
+++ b/src/lib/systems/nes/nes-header.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { buildNes2Header } from "./nes-header";
+import {
+  buildNes2Header,
+  parseEditableHeaderFields,
+  applyEditableHeaderFields,
+} from "./nes-header";
 
 /** Every NES 2.0 header carries the magic and the 2.0 indicator (byte 7 bits 2-3 = 10). */
 function expectNes2Magic(h: Uint8Array) {
@@ -138,5 +142,88 @@ describe("buildNes2Header", () => {
         battery: false,
       }),
     ).toThrow(/too large/);
+  });
+});
+
+describe("editable header fields", () => {
+  // A non-trivial baseline: mapper 4 (MMC3), battery on, vertical mirroring,
+  // submapper bits and a mapper high nibble present so the preserve-checks bite.
+  const baseline = () =>
+    buildNes2Header({
+      prgBytes: 128 * 1024,
+      chrBytes: 128 * 1024,
+      mapper: 4,
+      submapper: 3,
+      mirroring: "vertical",
+      battery: true,
+    });
+
+  it("round-trips through parse → apply → parse", () => {
+    const h = baseline();
+    const fields = parseEditableHeaderFields(h);
+    const rebuilt = applyEditableHeaderFields(h, fields);
+    expect(parseEditableHeaderFields(rebuilt)).toEqual(fields);
+    // Applying the parsed-back fields changes nothing.
+    expect(Array.from(rebuilt)).toEqual(Array.from(h));
+  });
+
+  it("writes each editable field into the right byte", () => {
+    const h = applyEditableHeaderFields(baseline(), {
+      tvSystem: "pal",
+      consoleType: 1,
+      mirroring: "four_screen",
+      expansionDevice: 8,
+      submapper: 5,
+    });
+    expect(h[12] & 0x03).toBe(1); // PAL timing
+    expect(h[7] & 0x03).toBe(1); // Vs. System console type
+    expect(h[6] & 0x08).toBe(0x08); // four-screen
+    expect(h[15] & 0x3f).toBe(8); // Zapper
+    expect((h[8] >> 4) & 0x0f).toBe(5); // submapper
+    expect(parseEditableHeaderFields(h)).toEqual({
+      tvSystem: "pal",
+      consoleType: 1,
+      mirroring: "four_screen",
+      expansionDevice: 8,
+      submapper: 5,
+    });
+  });
+
+  it("preserves the bits each field must not touch", () => {
+    const h = baseline();
+    const before = { b6: h[6], b7: h[7], b8: h[8] };
+    const out = applyEditableHeaderFields(h, {
+      consoleType: 2,
+      mirroring: "horizontal",
+      submapper: 0,
+    });
+    // NES 2.0 indicator (byte 7 bits 2-3) and mapper mid nibble survive.
+    expect(out[7] & 0x0c).toBe(0x08);
+    expect(out[7] & 0xf0).toBe(before.b7 & 0xf0);
+    // Battery (bit 1), trainer (bit 2), mapper low nibble survive byte-6 edit.
+    expect(out[6] & 0x02).toBe(before.b6 & 0x02);
+    expect(out[6] & 0x04).toBe(before.b6 & 0x04);
+    expect(out[6] & 0xf0).toBe(before.b6 & 0xf0);
+    // Mapper high nibble (byte 8 low nibble) survives the submapper edit.
+    expect(out[8] & 0x0f).toBe(before.b8 & 0x0f);
+  });
+
+  it("only writes provided fields and never the content bytes", () => {
+    // A full file: header + PRG + CHR with recognizable content.
+    const header = baseline();
+    const content = new Uint8Array(64).map((_, i) => (i * 7) & 0xff);
+    const file = new Uint8Array(header.length + content.length);
+    file.set(header, 0);
+    file.set(content, header.length);
+
+    const out = applyEditableHeaderFields(file, { tvSystem: "dendy" });
+    // Only byte 12 changed in the header; everything else identical.
+    expect(out[12] & 0x03).toBe(3);
+    expect(Array.from(out.subarray(0, 12))).toEqual(
+      Array.from(file.subarray(0, 12)),
+    );
+    expect(Array.from(out.subarray(13))).toEqual(
+      Array.from(file.subarray(13)),
+    );
   });
 });

--- a/src/lib/systems/nes/nes-header.test.ts
+++ b/src/lib/systems/nes/nes-header.test.ts
@@ -208,6 +208,14 @@ describe("editable header fields", () => {
     expect(out[8] & 0x0f).toBe(before.b8 & 0x0f);
   });
 
+  it("preserves the reserved upper bits of byte 15 when setting the expansion device", () => {
+    const h = baseline();
+    h[15] = 0xc0; // reserved bits 6-7 set
+    const out = applyEditableHeaderFields(h, { expansionDevice: 8 });
+    expect(out[15] & 0x3f).toBe(8); // Zapper written into the low 6 bits
+    expect(out[15] & 0xc0).toBe(0xc0); // reserved bits 6-7 untouched
+  });
+
   it("only writes provided fields and never the content bytes", () => {
     // A full file: header + PRG + CHR with recognizable content.
     const header = baseline();

--- a/src/lib/systems/nes/nes-header.ts
+++ b/src/lib/systems/nes/nes-header.ts
@@ -219,7 +219,8 @@ export function applyEditableHeaderFields(
     h[8] = (h[8] & 0x0f) | ((fields.submapper & 0x0f) << 4);
   }
   if (fields.expansionDevice !== undefined) {
-    h[15] = fields.expansionDevice & 0x3f;
+    // Bits 0-5; preserve the reserved upper two bits (6-7).
+    h[15] = (h[15] & 0xc0) | (fields.expansionDevice & 0x3f);
   }
 
   return h;

--- a/src/lib/systems/nes/nes-header.ts
+++ b/src/lib/systems/nes/nes-header.ts
@@ -144,3 +144,77 @@ export function buildNes2Header(p: Nes2HeaderInputs): Uint8Array {
 
   return h;
 }
+
+/** TV-system bits (byte 12) → name, the inverse of {@link TV_SYSTEM_BITS}. */
+const TV_SYSTEM_BY_BITS: readonly NesTvSystem[] = ["ntsc", "pal", "multi", "dendy"];
+
+/**
+ * The NES 2.0 header fields a finished dump can't pin from its own bytes and
+ * that a user may want to set when there's no DB entry to supply them. These
+ * map to header bytes 6 (mirroring), 7 (console type), 8 (submapper), 12
+ * (CPU/PPU timing) and 15 (default expansion device) — none of which affect
+ * the PRG/CHR content or its hashes.
+ */
+export interface EditableHeaderFields {
+  tvSystem: NesTvSystem;
+  consoleType: number;
+  mirroring: NesMirroring;
+  expansionDevice: number;
+  submapper: number;
+}
+
+/** Read the editable fields back out of a 16-byte iNES / NES 2.0 header. */
+export function parseEditableHeaderFields(
+  header: Uint8Array,
+): EditableHeaderFields {
+  return {
+    tvSystem: TV_SYSTEM_BY_BITS[header[12] & 0x03],
+    consoleType: header[7] & 0x03,
+    mirroring:
+      header[6] & 0x08
+        ? "four_screen"
+        : header[6] & 0x01
+          ? "vertical"
+          : "horizontal",
+    expansionDevice: header[15] & 0x3f,
+    submapper: (header[8] >> 4) & 0x0f,
+  };
+}
+
+/**
+ * Return a copy of `header` (which may be a full `.nes` file — only the first
+ * 16 bytes are touched) with the supplied editable fields written in. Only the
+ * fields present in `fields` are changed; each rewrite preserves the unrelated
+ * bits of its byte (mapper nibbles, the NES 2.0 indicator, battery/trainer
+ * flags). Content bytes (index 16+) are never modified.
+ */
+export function applyEditableHeaderFields(
+  header: Uint8Array,
+  fields: Partial<EditableHeaderFields>,
+): Uint8Array {
+  const h = Uint8Array.from(header);
+
+  if (fields.tvSystem !== undefined) {
+    h[12] = (h[12] & ~0x03) | TV_SYSTEM_BITS[fields.tvSystem];
+  }
+  if (fields.consoleType !== undefined) {
+    // Bits 0-1; preserve the NES 2.0 indicator (bits 2-3) and mapper nibble.
+    h[7] = (h[7] & 0xfc) | (fields.consoleType & 0x03);
+  }
+  if (fields.mirroring !== undefined) {
+    // Bit 0 = vertical, bit 3 = four-screen; preserve battery (1), trainer
+    // (2) and the mapper low nibble (4-7).
+    h[6] =
+      (h[6] & ~0x09) |
+      (fields.mirroring === "vertical" ? 0x01 : 0) |
+      (fields.mirroring === "four_screen" ? 0x08 : 0);
+  }
+  if (fields.submapper !== undefined) {
+    h[8] = (h[8] & 0x0f) | ((fields.submapper & 0x0f) << 4);
+  }
+  if (fields.expansionDevice !== undefined) {
+    h[15] = fields.expansionDevice & 0x3f;
+  }
+
+  return h;
+}

--- a/src/lib/systems/nes/nes-system-handler.test.ts
+++ b/src/lib/systems/nes/nes-system-handler.test.ts
@@ -165,6 +165,22 @@ describe("NES dump summary (per-section hashes)", () => {
     ]);
   });
 
+  it("returns null for a truncated misc-ROM file (declared misc, too few bytes)", () => {
+    const header = buildNes2Header({
+      prgBytes: 256 * 1024,
+      chrBytes: 256 * 1024,
+      mapper: 413,
+      mirroring: "vertical",
+      battery: false,
+      miscRoms: 1,
+    });
+    // Header declares a misc ROM, but the file stops short of even PRG+CHR —
+    // negative trailing must not be treated as a misc payload.
+    const truncated = new Uint8Array(header.length + 256 * 1024); // PRG only
+    truncated.set(header, 0);
+    expect(handler.summarizeDump(truncated)).toBeNull();
+  });
+
   it("returns null for a CHR-RAM cart (no CHR ROM to split out)", () => {
     const { file } = makeNesFile(32 * 1024, 0);
     expect(handler.summarizeDump(file)).toBeNull();
@@ -253,6 +269,29 @@ describe("NES buildOutputFile canonical-header handling", () => {
     expect(out.data[4]).toBe(1); // 16 KB PRG declared — emitted verbatim
     expect(out.meta?.Source).toBe("No-Intro canonical header");
     expect(out.warnings?.some((w) => /PRG\+CHR/.test(w))).toBe(true);
+  });
+
+  it("does not warn when a verified misc-ROM board's dump runs past PRG+CHR (mapper 413)", () => {
+    const canonical = Array.from(
+      buildNes2Header({
+        prgBytes: 256 * 1024,
+        chrBytes: 256 * 1024,
+        mapper: 413,
+        mirroring: "vertical",
+        battery: false,
+        miscRoms: 1,
+      }),
+    );
+    // 256 KiB PRG + 256 KiB CHR + a trailing misc section: the extra bytes
+    // are the misc ROM (header byte 14), not a malformed header.
+    const content = new Uint8Array((256 + 256) * 1024 + 16);
+    const out = handler.buildOutputFile(
+      content,
+      handler.buildReadConfig({ mapper: 413 }),
+      matchedWith(canonical),
+    );
+    expect(out.meta?.Source).toBe("No-Intro canonical header");
+    expect(out.warnings?.some((w) => /PRG\+CHR/.test(w)) ?? false).toBe(false);
   });
 
   it("uses a computed header with no warnings when nothing matched", () => {

--- a/src/lib/systems/nes/nes-system-handler.test.ts
+++ b/src/lib/systems/nes/nes-system-handler.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { NESSystemHandler } from "./nes-system-handler";
 import { NES_MAPPER_DB } from "./nes-constants";
+import { buildNes2Header } from "./nes-header";
+import { crc32, hexStr, formatBytes } from "@/lib/core/hashing";
 
 describe("NES config sizing", () => {
   const handler = new NESSystemHandler();
@@ -89,5 +91,249 @@ describe("NES computed-header PRG-RAM declarations (buildOutputFile)", () => {
         (o) => !o.disabled,
       ),
     ).toBe(true);
+  });
+});
+
+describe("NES dump summary (per-section hashes)", () => {
+  const handler = new NESSystemHandler();
+
+  /** Build a headered `.nes` file with distinct fill bytes per region. */
+  const makeNesFile = (prgBytes: number, chrBytes: number) => {
+    const header = buildNes2Header({
+      prgBytes,
+      chrBytes,
+      mapper: 0,
+      mirroring: "horizontal",
+      battery: false,
+    });
+    const prg = new Uint8Array(prgBytes).fill(0xa5);
+    const chr = new Uint8Array(chrBytes).fill(0x5a);
+    const file = new Uint8Array(header.length + prgBytes + chrBytes);
+    file.set(header, 0);
+    file.set(prg, header.length);
+    file.set(chr, header.length + prgBytes);
+    return { file, prg, chr };
+  };
+
+  it("reports per-section PRG and CHR size + CRC32 from the header", () => {
+    const prgBytes = 32 * 1024;
+    const chrBytes = 8 * 1024;
+    const { file, prg, chr } = makeNesFile(prgBytes, chrBytes);
+
+    const summary = handler.summarizeDump(file);
+    expect(summary).not.toBeNull();
+    expect(summary!.columns).toEqual(["Section", "Size", "CRC32"]);
+    // Size and CRC32 columns are right-aligned.
+    expect(summary!.rightAlignColumns).toEqual([1, 2]);
+    // No "Combined" row — the completion screen's main hash block covers it.
+    expect(summary!.rows).toEqual([
+      ["PRG ROM", formatBytes(prgBytes), hexStr(crc32(prg))],
+      ["CHR ROM", formatBytes(chrBytes), hexStr(crc32(chr))],
+    ]);
+  });
+
+  it("returns null for a CHR-RAM cart (no CHR ROM to split out)", () => {
+    const { file } = makeNesFile(32 * 1024, 0);
+    expect(handler.summarizeDump(file)).toBeNull();
+  });
+
+  it("returns null when the header sizes don't cover the file", () => {
+    const { file } = makeNesFile(32 * 1024, 8 * 1024);
+    // Drop the last CHR byte: declared sizes no longer add up to the file.
+    expect(handler.summarizeDump(file.subarray(0, file.length - 1))).toBeNull();
+  });
+
+  it("returns null for a non-NES header", () => {
+    expect(handler.summarizeDump(new Uint8Array(40))).toBeNull();
+  });
+});
+
+describe("NES buildOutputFile canonical-header handling", () => {
+  const handler = new NESSystemHandler();
+  const config = handler.buildReadConfig({
+    mapper: 0,
+    prgSizeKB: 32,
+    chrSizeKB: 8,
+  });
+  const raw = new Uint8Array(32 * 1024 + 8 * 1024);
+
+  /** A matched verification carrying the given canonical header bytes. */
+  const matchedWith = (header: number[]) => ({
+    matched: true as const,
+    confidence: "exact" as const,
+    entry: { name: "Test Entry", status: "verified" as const, header },
+  });
+
+  it("emits the verified canonical header byte-for-byte, no warnings", () => {
+    // A soft field (PAL TV system → byte 12 = 1) the cart can't self-report:
+    // its survival proves the canonical header was used verbatim.
+    const canonical = Array.from(
+      buildNes2Header({
+        prgBytes: 32 * 1024,
+        chrBytes: 8 * 1024,
+        mapper: 0,
+        mirroring: "horizontal",
+        battery: false,
+        tvSystem: "pal",
+      }),
+    );
+
+    const out = handler.buildOutputFile(raw, config, matchedWith(canonical));
+    expect(Array.from(out.data.subarray(0, 16))).toEqual(canonical);
+    expect(out.data[12]).toBe(1);
+    expect(out.meta?.Source).toBe("No-Intro canonical header");
+    expect(out.warnings ?? []).toEqual([]);
+  });
+
+  it("warns but still emits a canonical header that sets the trainer flag", () => {
+    const canonical = Array.from(
+      buildNes2Header({
+        prgBytes: 32 * 1024,
+        chrBytes: 8 * 1024,
+        mapper: 0,
+        mirroring: "horizontal",
+        battery: false,
+      }),
+    );
+    canonical[6] |= 0x04; // spurious trainer flag
+
+    const out = handler.buildOutputFile(raw, config, matchedWith(canonical));
+    // Trainer bit preserved verbatim — we never rewrite verified bytes.
+    expect(out.data[6] & 0x04).toBe(0x04);
+    expect(out.meta?.Source).toBe("No-Intro canonical header");
+    expect(out.warnings?.some((w) => /trainer/i.test(w))).toBe(true);
+  });
+
+  it("warns but still emits a canonical header whose sizes don't fit the dump", () => {
+    // Declares 16 KB PRG + 16 KB CHR = 32 KB, but the dump is 40 KB.
+    const canonical = Array.from(
+      buildNes2Header({
+        prgBytes: 16 * 1024,
+        chrBytes: 16 * 1024,
+        mapper: 0,
+        mirroring: "horizontal",
+        battery: false,
+      }),
+    );
+
+    const out = handler.buildOutputFile(raw, config, matchedWith(canonical));
+    expect(out.data[4]).toBe(1); // 16 KB PRG declared — emitted verbatim
+    expect(out.meta?.Source).toBe("No-Intro canonical header");
+    expect(out.warnings?.some((w) => /PRG\+CHR/.test(w))).toBe(true);
+  });
+
+  it("uses a computed header with no warnings when nothing matched", () => {
+    const out = handler.buildOutputFile(raw, config, {
+      matched: false,
+      confidence: "none",
+    });
+    expect(out.meta?.Source).toBe("computed");
+    expect(out.warnings ?? []).toEqual([]);
+  });
+
+  it("report meta carries the editable header fields, labelled", () => {
+    const meta = handler.buildOutputFile(raw, config).meta;
+    expect(meta?.["Region/Timing"]).toBe("NTSC");
+    expect(meta?.["Console type"]).toBe("NES / Famicom");
+    expect(meta?.Mirroring).toBe("Horizontal");
+    expect(meta?.Expansion).toBe("Unspecified");
+    expect(meta?.Submapper).toBe("0");
+  });
+});
+
+describe("NES header editor (getHeaderFields / applyHeaderOverrides)", () => {
+  const handler = new NESSystemHandler();
+
+  /** A computed-header NROM file (32 KB PRG + 8 KB CHR), patterned content. */
+  const nromFile = () => {
+    const config = handler.buildReadConfig({
+      mapper: 0,
+      prgSizeKB: 32,
+      chrSizeKB: 8,
+    });
+    const raw = new Uint8Array(32 * 1024 + 8 * 1024).map((_, i) => (i * 3) & 0xff);
+    return handler.buildOutputFile(raw, config).data;
+  };
+
+  const byKey = (fields: ReturnType<typeof handler.getHeaderFields>) =>
+    Object.fromEntries(fields.map((f) => [f.key, f]));
+
+  it("getHeaderFields reflects the header's defaults", () => {
+    const f = byKey(handler.getHeaderFields(nromFile(), {}));
+    expect(f.tvSystem.value).toBe("ntsc");
+    expect(f.consoleType.value).toBe(0);
+    expect(f.mirroring.value).toBe("horizontal");
+    expect(f.expansionDevice.value).toBe(0);
+    expect(f.submapper.value).toBe(0);
+  });
+
+  it("getHeaderFields lets overrides win over the parsed defaults", () => {
+    const f = byKey(
+      handler.getHeaderFields(nromFile(), { tvSystem: "pal", submapper: 7 }),
+    );
+    expect(f.tvSystem.value).toBe("pal");
+    expect(f.submapper.value).toBe(7);
+    expect(f.mirroring.value).toBe("horizontal"); // untouched default
+  });
+
+  it("notes mapper-controlled mirroring in the field help text", () => {
+    // MMC1 (mapper 1) controls mirroring at runtime.
+    const config = handler.buildReadConfig({
+      mapper: 1,
+      prgSizeKB: 32,
+      chrSizeKB: 8,
+    });
+    const raw = new Uint8Array(32 * 1024 + 8 * 1024);
+    const file = handler.buildOutputFile(raw, config).data;
+    const f = byKey(handler.getHeaderFields(file, {}));
+    expect(f.mirroring.helpText).toMatch(/runtime/i);
+  });
+
+  it("applyHeaderOverrides rewrites the header, leaving content and section hashes intact", () => {
+    const file = nromFile();
+    const before = handler.summarizeDump(file);
+
+    const edited = handler.applyHeaderOverrides(file, {
+      tvSystem: "pal",
+      mirroring: "vertical",
+      expansionDevice: 8,
+    });
+
+    // Header reflects the edits.
+    expect(edited[12] & 0x03).toBe(1);
+    expect(edited[6] & 0x01).toBe(1);
+    expect(edited[15] & 0x3f).toBe(8);
+    // Content (bytes 16+) is byte-identical, so the section breakdown is too.
+    expect(Array.from(edited.subarray(16))).toEqual(
+      Array.from(file.subarray(16)),
+    );
+    expect(handler.summarizeDump(edited)).toEqual(before);
+  });
+
+  it("applies cleanly to a CHR-RAM cart (no CHR ROM)", () => {
+    const config = handler.buildReadConfig({
+      mapper: 2,
+      prgSizeKB: 64,
+      chrSizeKB: 0,
+    });
+    const raw = new Uint8Array(64 * 1024);
+    const file = handler.buildOutputFile(raw, config).data;
+
+    const edited = handler.applyHeaderOverrides(file, { mirroring: "vertical" });
+    expect(edited[6] & 0x01).toBe(1);
+    expect(edited.length).toBe(file.length);
+    expect(handler.getHeaderFields(file, {})).toHaveLength(5);
+  });
+
+  it("headerMeta reflects an edited header (so the report matches the file)", () => {
+    const edited = handler.applyHeaderOverrides(nromFile(), {
+      tvSystem: "pal",
+      mirroring: "vertical",
+      expansionDevice: 8,
+    });
+    const meta = handler.headerMeta(edited);
+    expect(meta["Region/Timing"]).toBe("PAL");
+    expect(meta.Mirroring).toBe("Vertical");
+    expect(meta.Expansion).toBe("Zapper");
   });
 });

--- a/src/lib/systems/nes/nes-system-handler.test.ts
+++ b/src/lib/systems/nes/nes-system-handler.test.ts
@@ -133,6 +133,38 @@ describe("NES dump summary (per-section hashes)", () => {
     ]);
   });
 
+  it("adds a Misc ROM row for a NES 2.0 board with a misc-ROM section", () => {
+    const prgBytes = 256 * 1024;
+    const chrBytes = 256 * 1024;
+    const miscBytes = 64 * 1024; // small stand-in for the 8 MiB sample flash
+    const header = buildNes2Header({
+      prgBytes,
+      chrBytes,
+      mapper: 413,
+      mirroring: "vertical",
+      battery: false,
+      miscRoms: 1,
+    });
+    const prg = new Uint8Array(prgBytes).fill(0xa5);
+    const chr = new Uint8Array(chrBytes).fill(0x5a);
+    const misc = new Uint8Array(miscBytes).fill(0x3c);
+    const file = new Uint8Array(
+      header.length + prgBytes + chrBytes + miscBytes,
+    );
+    file.set(header, 0);
+    file.set(prg, header.length);
+    file.set(chr, header.length + prgBytes);
+    file.set(misc, header.length + prgBytes + chrBytes);
+
+    const summary = handler.summarizeDump(file);
+    expect(summary).not.toBeNull();
+    expect(summary!.rows).toEqual([
+      ["PRG ROM", formatBytes(prgBytes), hexStr(crc32(prg))],
+      ["CHR ROM", formatBytes(chrBytes), hexStr(crc32(chr))],
+      ["Misc ROM", formatBytes(miscBytes), hexStr(crc32(misc))],
+    ]);
+  });
+
   it("returns null for a CHR-RAM cart (no CHR ROM to split out)", () => {
     const { file } = makeNesFile(32 * 1024, 0);
     expect(handler.summarizeDump(file)).toBeNull();

--- a/src/lib/systems/nes/nes-system-handler.ts
+++ b/src/lib/systems/nes/nes-system-handler.ts
@@ -531,11 +531,12 @@ export class NESSystemHandler implements SystemHandler {
   }
 
   /**
-   * Per-section breakdown of a finished dump: the PRG ROM and the CHR ROM,
-   * each with its size and CRC32 — the chip-level view NESCartDB / No-Intro
-   * list. The combined size + hashes already appear in the completion
-   * screen's main hash block, so they aren't repeated here. `rawData` is the
-   * output `.nes` file (16-byte header + PRG + CHR), so its iNES header is
+   * Per-section breakdown of a finished dump: the PRG ROM, the CHR ROM, and
+   * (for NES 2.0 boards that carry one) the miscellaneous-ROM section, each
+   * with its size and CRC32 — the chip-level view NESCartDB / No-Intro list.
+   * The combined size + hashes already appear in the completion screen's main
+   * hash block, so they aren't repeated here. `rawData` is the output `.nes`
+   * file (16-byte header + PRG + CHR [+ misc]), so its iNES header is
    * authoritative for where each region starts.
    *
    * Returns null when there's nothing to break down: a malformed header, a
@@ -553,9 +554,19 @@ export class NESSystemHandler implements SystemHandler {
     // shown above. Nothing to add.
     if (chrBytes <= 0) return null;
 
-    // The declared regions must exactly cover the file; if they don't, the
-    // header disagrees with the dumped bytes and any split would mislead.
-    if (dataStart + prgBytes + chrBytes !== rawData.length) return null;
+    // A NES 2.0 board may append a miscellaneous-ROM section after CHR
+    // (header byte 14 counts it; mapper 413's 8 MiB sample flash is the one
+    // such board) — whatever trails PRG+CHR is that section.
+    const isNes2 = (rawData[7] & 0x0c) === 0x08;
+    const trailing = rawData.length - (dataStart + prgBytes + chrBytes);
+    const miscBytes = isNes2 && (rawData[14] & 0x03) > 0 ? trailing : 0;
+
+    // The declared regions must exactly cover the file (after accounting for
+    // any misc section); if they don't, the header disagrees with the dumped
+    // bytes and any split would mislead.
+    if (dataStart + prgBytes + chrBytes + miscBytes !== rawData.length) {
+      return null;
+    }
 
     const prg = rawData.subarray(dataStart, dataStart + prgBytes);
     const chr = rawData.subarray(
@@ -572,12 +583,19 @@ export class NESSystemHandler implements SystemHandler {
       hexStr(crc32(bytes)),
     ];
 
+    const rows = [sectionRow("PRG ROM", prg), sectionRow("CHR ROM", chr)];
+    if (miscBytes > 0) {
+      rows.push(
+        sectionRow("Misc ROM", rawData.subarray(dataStart + prgBytes + chrBytes)),
+      );
+    }
+
     return {
       title: "ROM sections",
       columns: ["Section", "Size", "CRC32"],
       monoColumns: [1, 2],
       rightAlignColumns: [1, 2],
-      rows: [sectionRow("PRG ROM", prg), sectionRow("CHR ROM", chr)],
+      rows,
     };
   }
 

--- a/src/lib/systems/nes/nes-system-handler.ts
+++ b/src/lib/systems/nes/nes-system-handler.ts
@@ -11,10 +11,34 @@ import type {
   VerificationHashes,
   VerificationDB,
   VerificationResult,
+  DumpSummary,
+  DumpSummaryCell,
+  ConfigOption,
 } from "@/lib/types";
-import { crc32, sha1Hex, sha256Hex } from "@/lib/core/hashing";
-import { NES_MAPPER_DB, getMapperDef, coerceToNearest } from "./nes-constants";
-import { buildNes2Header, type NesMirroring } from "./nes-header";
+import {
+  crc32,
+  sha1Hex,
+  sha256Hex,
+  hexStr,
+  formatBytes,
+} from "@/lib/core/hashing";
+import {
+  NES_MAPPER_DB,
+  getMapperDef,
+  coerceToNearest,
+  NES_TIMING_OPTIONS,
+  NES_CONSOLE_TYPE_OPTIONS,
+  NES_MIRRORING_OPTIONS,
+  NES_EXPANSION_DEVICE_OPTIONS,
+  NES_SUBMAPPER_OPTIONS,
+} from "./nes-constants";
+import {
+  buildNes2Header,
+  parseEditableHeaderFields,
+  applyEditableHeaderFields,
+  type NesMirroring,
+  type EditableHeaderFields,
+} from "./nes-header";
 import { bytesEqual, isUniformFill } from "./mappers/bank-reliability";
 
 /**
@@ -33,6 +57,105 @@ function resolveSizesKB(
   return {
     prgKB: (values.prgSizeKB as number) ?? prgSizes[prgSizes.length - 1],
     chrKB: (values.chrSizeKB as number) ?? chrSizes[chrSizes.length - 1],
+  };
+}
+
+/**
+ * Read the PRG/CHR ROM region sizes (in bytes) from a 16-byte iNES / NES 2.0
+ * header, plus the offset at which ROM data begins. Returns null for a
+ * non-NES header or the NES 2.0 exponent-multiplier size form — our dumps
+ * never emit the latter, and decoding it here would add untested complexity
+ * for no cartridge in scope.
+ */
+function parseNesRomLayout(
+  data: Uint8Array,
+): { dataStart: number; prgBytes: number; chrBytes: number } | null {
+  // Magic "NES\x1A".
+  if (
+    data.length < 16 ||
+    data[0] !== 0x4e ||
+    data[1] !== 0x45 ||
+    data[2] !== 0x53 ||
+    data[3] !== 0x1a
+  )
+    return null;
+
+  const isNes2 = (data[7] & 0x0c) === 0x08;
+  const prgMsb = isNes2 ? data[9] & 0x0f : 0;
+  const chrMsb = isNes2 ? (data[9] >> 4) & 0x0f : 0;
+  // A 0xF MSB nibble selects the NES 2.0 exponent-multiplier size form — a
+  // valid encoding we don't implement (no cart in scope reaches the sizes
+  // that need it). Bail rather than mis-read the bytes as a linear size.
+  if (prgMsb === 0x0f || chrMsb === 0x0f) return null;
+
+  // A trainer (flags6 bit 2) inserts 512 bytes between header and PRG.
+  const trainer = (data[6] & 0x04) !== 0 ? 512 : 0;
+  return {
+    dataStart: 16 + trainer,
+    prgBytes: ((prgMsb << 8) | data[4]) * 16384,
+    chrBytes: ((chrMsb << 8) | data[5]) * 8192,
+  };
+}
+
+/**
+ * Sanity-check a verified No-Intro canonical header we're about to emit
+ * verbatim against the dump it will wrap. The match was verified by SHA-1
+ * over `header || content`, so the header IS the verified canonical form —
+ * we emit it as-is regardless. But a header that can't describe the bytes
+ * we're attaching (a trainer flag a cart dump can never satisfy, or PRG/CHR
+ * sizes that don't sum to the content) is a malformed DAT entry worth
+ * flagging. Returns human-readable warnings; an empty array means it checks
+ * out. These can only fire on a genuinely corrupt entry — a well-formed
+ * canonical header always describes the content that verified against it.
+ */
+function canonicalHeaderWarnings(
+  header: Uint8Array,
+  contentLength: number,
+): string[] {
+  const warnings: string[] = [];
+
+  if ((header[6] & 0x04) !== 0) {
+    warnings.push(
+      "Verified No-Intro header sets the trainer flag, but a cartridge dump never contains a trainer. " +
+        "Emitting it as verified — the DAT entry's header looks malformed.",
+    );
+  }
+
+  const layout = parseNesRomLayout(header);
+  if (!layout) {
+    warnings.push(
+      "Verified No-Intro header's PRG/CHR size fields couldn't be parsed. " +
+        "Emitting it as verified — the DAT entry's header looks malformed.",
+    );
+  } else if (layout.prgBytes + layout.chrBytes !== contentLength) {
+    warnings.push(
+      `Verified No-Intro header declares ${formatBytes(layout.prgBytes + layout.chrBytes)} of PRG+CHR, ` +
+        `but the dump is ${formatBytes(contentLength)}. Emitting it as verified — the DAT entry's header looks malformed.`,
+    );
+  }
+
+  return warnings;
+}
+
+/**
+ * Human-readable display values for the editable NES 2.0 header fields, read
+ * back from a header's bytes and labelled via the curated option lists. Shared
+ * by buildOutputFile (initial dump) and the post-dump header editor (after an
+ * edit) so the dump report always documents the header that was actually
+ * emitted — not a value baked in from the original config. Unknown raw values
+ * (e.g. an expansion device outside the curated shortlist) fall back to their
+ * number.
+ */
+function nesHeaderMeta(header: Uint8Array): Record<string, string> {
+  const f = parseEditableHeaderFields(header);
+  const labelFor = (options: ConfigOption[], value: string | number) =>
+    options.find((o) => o.value === value)?.label ?? String(value);
+  return {
+    "Region/Timing": labelFor(NES_TIMING_OPTIONS, f.tvSystem),
+    "Console type": labelFor(NES_CONSOLE_TYPE_OPTIONS, f.consoleType),
+    Mirroring: labelFor(NES_MIRRORING_OPTIONS, f.mirroring),
+    Expansion: labelFor(NES_EXPANSION_DEVICE_OPTIONS, f.expansionDevice),
+    Submapper: labelFor(NES_SUBMAPPER_OPTIONS, f.submapper),
   };
 }
 
@@ -256,9 +379,12 @@ export class NESSystemHandler implements SystemHandler {
 
     // Prefer the canonical No-Intro header byte-for-byte when the dump
     // matched a DAT entry: anything the cart can't self-report (TV
-    // system, default expansion device, submapper, etc.) lives in
-    // those bytes, and copying them keeps the output bit-identical to
-    // the DAT entry. Falls back to a computed header when there's no
+    // system, default expansion device, submapper, etc.) lives in those
+    // bytes, and the match is verified by SHA-1 over `header || content`
+    // (see verify()), so emitting it keeps the output bit-identical to the
+    // verified entry. We emit it as-is even if the header looks unusual —
+    // an inconsistent header is flagged via canonicalHeaderWarnings below,
+    // never rewritten. Falls back to a computed header when there's no
     // match.
     const canonicalHeader =
       verification?.matched && verification.entry?.header
@@ -300,6 +426,12 @@ export class NESSystemHandler implements SystemHandler {
     // set; iNES 1.0 files leave it clear.
     const isNes2 = (header[7] & 0x0c) === 0x08;
 
+    // Emitted the verified canonical header? Flag it if it can't describe
+    // the bytes we just attached (corrupt DAT entry) — without rewriting it.
+    const warnings = canonicalHeader
+      ? canonicalHeaderWarnings(header, rawData.length)
+      : [];
+
     return {
       data: output,
       filename: `dump_mapper${mapper}.nes`,
@@ -315,9 +447,13 @@ export class NESSystemHandler implements SystemHandler {
             : chrRamKB > 0
               ? `None (${chrRamKB} KB CHR-RAM)`
               : "None",
-        Mirroring: mirroring,
+        // Region/timing, console, mirroring, expansion device and submapper —
+        // read from the header we actually emit, so the report stays truthful
+        // even after the user edits them on the completion screen.
+        ...nesHeaderMeta(header),
         Battery: battery ? "Yes" : "No",
       },
+      ...(warnings.length > 0 ? { warnings } : {}),
     };
   }
 
@@ -382,6 +518,159 @@ export class NESSystemHandler implements SystemHandler {
     // No header on the entry (e.g. non-headered system), or no content
     // passed in. The CRC32 match alone is treated as exact.
     return { matched: true, entry, confidence: "exact" };
+  }
+
+  /**
+   * Per-section breakdown of a finished dump: the PRG ROM and the CHR ROM,
+   * each with its size and CRC32 — the chip-level view NESCartDB / No-Intro
+   * list. The combined size + hashes already appear in the completion
+   * screen's main hash block, so they aren't repeated here. `rawData` is the
+   * output `.nes` file (16-byte header + PRG + CHR), so its iNES header is
+   * authoritative for where each region starts.
+   *
+   * Returns null when there's nothing to break down: a malformed header, a
+   * CHR-RAM cart with no CHR ROM (PRG would just equal the whole ROM), or a
+   * header whose declared sizes don't add up to the file — in which case any
+   * split would be a guess.
+   */
+  summarizeDump(rawData: Uint8Array): DumpSummary | null {
+    const layout = parseNesRomLayout(rawData);
+    if (!layout) return null;
+    const { dataStart, prgBytes, chrBytes } = layout;
+
+    // No CHR ROM means the cart uses CHR-RAM (which we don't dump), so the
+    // file is PRG only — a single PRG row would just restate the combined ROM
+    // shown above. Nothing to add.
+    if (chrBytes <= 0) return null;
+
+    // The declared regions must exactly cover the file; if they don't, the
+    // header disagrees with the dumped bytes and any split would mislead.
+    if (dataStart + prgBytes + chrBytes !== rawData.length) return null;
+
+    const prg = rawData.subarray(dataStart, dataStart + prgBytes);
+    const chr = rawData.subarray(
+      dataStart + prgBytes,
+      dataStart + prgBytes + chrBytes,
+    );
+
+    const sectionRow = (
+      label: string,
+      bytes: Uint8Array,
+    ): DumpSummaryCell[] => [
+      label,
+      formatBytes(bytes.length),
+      hexStr(crc32(bytes)),
+    ];
+
+    return {
+      title: "ROM sections",
+      columns: ["Section", "Size", "CRC32"],
+      monoColumns: [1, 2],
+      rightAlignColumns: [1, 2],
+      rows: [sectionRow("PRG ROM", prg), sectionRow("CHR ROM", chr)],
+    };
+  }
+
+  /**
+   * Editable NES 2.0 header fields for an unverified dump — region/timing,
+   * console type, mirroring, default expansion device, submapper. Each value
+   * defaults to whatever the produced header already carries (the sensible
+   * defaults `buildOutputFile` baked in), overlaid with the user's edits.
+   * `file` is the output `.nes` bytes; only its 16-byte header is read.
+   */
+  getHeaderFields(file: Uint8Array, overrides: ConfigValues): ResolvedConfigField[] {
+    if (file.length < 16) return [];
+    const parsed = parseEditableHeaderFields(file);
+
+    // Mapper number from the header — only to note runtime-controlled mirroring.
+    const mapper = (file[6] >> 4) | (file[7] & 0xf0) | ((file[8] & 0x0f) << 8);
+    const mapperControlsMirroring =
+      getMapperDef(mapper)?.mirroring === "mapper_controlled";
+
+    const value = (key: string, fallback: string | number) =>
+      overrides[key] ?? fallback;
+
+    return [
+      {
+        key: "tvSystem",
+        label: "Region / Timing",
+        type: "select",
+        value: value("tvSystem", parsed.tvSystem),
+        options: NES_TIMING_OPTIONS,
+        group: "header",
+        order: 0,
+      },
+      {
+        key: "consoleType",
+        label: "Console type",
+        type: "select",
+        value: value("consoleType", parsed.consoleType),
+        options: NES_CONSOLE_TYPE_OPTIONS,
+        group: "header",
+        order: 1,
+      },
+      {
+        key: "mirroring",
+        label: "Mirroring",
+        type: "select",
+        value: value("mirroring", parsed.mirroring),
+        options: NES_MIRRORING_OPTIONS,
+        group: "header",
+        order: 2,
+        helpText: mapperControlsMirroring
+          ? "This mapper sets mirroring at runtime; the header value is informational."
+          : undefined,
+      },
+      {
+        key: "expansionDevice",
+        label: "Default expansion device",
+        type: "select",
+        value: value("expansionDevice", parsed.expansionDevice),
+        options: NES_EXPANSION_DEVICE_OPTIONS,
+        group: "header",
+        order: 3,
+      },
+      {
+        key: "submapper",
+        label: "Submapper",
+        type: "select",
+        value: value("submapper", parsed.submapper),
+        options: NES_SUBMAPPER_OPTIONS,
+        group: "header",
+        order: 4,
+      },
+    ];
+  }
+
+  /**
+   * Apply header-field overrides to a finished dump, rewriting only the header
+   * bytes the editor exposes and leaving the PRG/CHR content (and its hashes)
+   * untouched. Unset fields keep the file's current values.
+   */
+  applyHeaderOverrides(file: Uint8Array, overrides: ConfigValues): Uint8Array {
+    const fields: Partial<EditableHeaderFields> = {};
+    if (overrides.tvSystem !== undefined)
+      fields.tvSystem = overrides.tvSystem as EditableHeaderFields["tvSystem"];
+    if (overrides.consoleType !== undefined)
+      fields.consoleType = overrides.consoleType as number;
+    if (overrides.mirroring !== undefined)
+      fields.mirroring = overrides.mirroring as NesMirroring;
+    if (overrides.expansionDevice !== undefined)
+      fields.expansionDevice = overrides.expansionDevice as number;
+    if (overrides.submapper !== undefined)
+      fields.submapper = overrides.submapper as number;
+    return applyEditableHeaderFields(file, fields);
+  }
+
+  /**
+   * Human-readable display values for the editable header fields of a finished
+   * dump, keyed for the report's "Dumping Settings" section. The wizard merges
+   * this over the output's original meta after a header edit so the saved
+   * report matches the saved bytes.
+   */
+  headerMeta(file: Uint8Array): Record<string, string> {
+    if (file.length < 16) return {};
+    return nesHeaderMeta(file);
   }
 
   /**

--- a/src/lib/systems/nes/nes-system-handler.ts
+++ b/src/lib/systems/nes/nes-system-handler.ts
@@ -127,11 +127,23 @@ function canonicalHeaderWarnings(
       "Verified No-Intro header's PRG/CHR size fields couldn't be parsed. " +
         "Emitting it as verified — the DAT entry's header looks malformed.",
     );
-  } else if (layout.prgBytes + layout.chrBytes !== contentLength) {
-    warnings.push(
-      `Verified No-Intro header declares ${formatBytes(layout.prgBytes + layout.chrBytes)} of PRG+CHR, ` +
-        `but the dump is ${formatBytes(contentLength)}. Emitting it as verified — the DAT entry's header looks malformed.`,
-    );
+  } else {
+    // A NES 2.0 board may append a miscellaneous-ROM section after CHR
+    // (header byte 14 counts it; mapper 413), so trailing bytes beyond
+    // PRG+CHR are legitimate. Warn only when the dump is too small, or when
+    // no misc section is declared and the sizes still differ.
+    const declared = layout.prgBytes + layout.chrBytes;
+    const isNes2 = (header[7] & 0x0c) === 0x08;
+    const miscCount = isNes2 ? header[14] & 0x03 : 0;
+    if (
+      contentLength < declared ||
+      (miscCount === 0 && contentLength !== declared)
+    ) {
+      warnings.push(
+        `Verified No-Intro header declares ${formatBytes(declared)} of PRG+CHR, ` +
+          `but the dump is ${formatBytes(contentLength)}. Emitting it as verified — the DAT entry's header looks malformed.`,
+      );
+    }
   }
 
   return warnings;
@@ -558,15 +570,17 @@ export class NESSystemHandler implements SystemHandler {
     // (header byte 14 counts it; mapper 413's 8 MiB sample flash is the one
     // such board) — whatever trails PRG+CHR is that section.
     const isNes2 = (rawData[7] & 0x0c) === 0x08;
+    const miscCount = isNes2 ? rawData[14] & 0x03 : 0;
     const trailing = rawData.length - (dataStart + prgBytes + chrBytes);
-    const miscBytes = isNes2 && (rawData[14] & 0x03) > 0 ? trailing : 0;
 
-    // The declared regions must exactly cover the file (after accounting for
-    // any misc section); if they don't, the header disagrees with the dumped
-    // bytes and any split would mislead.
-    if (dataStart + prgBytes + chrBytes + miscBytes !== rawData.length) {
-      return null;
-    }
+    // The declared regions must exactly cover the file: without a misc
+    // section PRG+CHR must land on the end; with one (byte-14 count > 0)
+    // there must be at least one trailing byte for it. Negative trailing is
+    // a truncated file. Either way, don't guess a split.
+    if (trailing < 0) return null;
+    if (miscCount === 0 ? trailing !== 0 : trailing === 0) return null;
+
+    const miscBytes = miscCount > 0 ? trailing : 0;
 
     const prg = rawData.subarray(dataStart, dataStart + prgBytes);
     const chr = rawData.subarray(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -204,7 +204,13 @@ export interface SystemHandler {
    * byte-for-byte over their own computed header — keeping the output
    * bit-identical to the No-Intro DAT entry rather than relying on our
    * defaults for the bits the cart can't self-report (TV system,
-   * expansion device, submapper, etc.).
+   * expansion device, submapper, etc.). The match is verified by
+   * re-hashing `header || content`, so the emitted file equals the
+   * verified entry byte-for-byte — emit the canonical header as-is even
+   * if it looks unusual. A header that can't describe the attached bytes
+   * (e.g. a trainer flag the dump can't satisfy, or size fields that
+   * don't sum to the content) is surfaced via {@link OutputFile.warnings}
+   * rather than rewritten — we never second-guess the verified bytes.
    */
   buildOutputFile(
     rawData: Uint8Array,
@@ -225,6 +231,32 @@ export interface SystemHandler {
   ): VerificationResult | Promise<VerificationResult>;
   /** Optional: extract a human-readable summary of a completed dump's contents. */
   summarizeDump?(rawData: Uint8Array): DumpSummary | null;
+  /**
+   * Optional: editable header fields offered for an UNVERIFIED dump, so the
+   * user can complete the header the verification DB would otherwise supply
+   * (e.g. NES 2.0 region/timing, console type, default controller). `file` is
+   * the produced output bytes; `overrides` is the user's edits so far, keyed
+   * by field key. Returns [] when the system has no editable header. Pair with
+   * {@link applyHeaderOverrides}; only headered systems implement these.
+   */
+  getHeaderFields?(
+    file: Uint8Array,
+    overrides: ConfigValues,
+  ): ResolvedConfigField[];
+  /**
+   * Optional: apply header-field overrides to a finished dump, returning new
+   * output bytes with the header rewritten and the content left untouched.
+   * Operates on the original `file` plus `overrides` (never a previously
+   * edited file). No-op fields fall back to the file's current values.
+   */
+  applyHeaderOverrides?(file: Uint8Array, overrides: ConfigValues): Uint8Array;
+  /**
+   * Optional: human-readable display values for the editable header fields of
+   * a finished dump, keyed for the report's "Dumping Settings" section. Lets
+   * the wizard refresh the report meta after a header edit so the saved report
+   * matches the saved bytes. Pairs with {@link getHeaderFields}/{@link applyHeaderOverrides}.
+   */
+  headerMeta?(file: Uint8Array): Record<string, string>;
   /**
    * Optional: post-dump heuristic checks over the unheadered raw bytes
    * that apply regardless of which device or mapper produced them — e.g.
@@ -261,6 +293,8 @@ export interface DumpSummary {
   monoColumns?: number[];
   /** Column indices to render with muted/secondary text color (e.g., row IDs). */
   mutedColumns?: number[];
+  /** Column indices to right-align (e.g., sizes, hashes, counts). */
+  rightAlignColumns?: number[];
   /** Rows of cells; each row's length should equal `columns.length`. */
   rows: DumpSummaryCell[][];
   /** Optional summary line below the table (e.g., counts). */
@@ -335,6 +369,13 @@ export interface OutputFile {
    * based on whether the dump is save-only or a ROM.
    */
   actionLabel?: string;
+  /**
+   * Build-time warnings about the produced file that should be surfaced
+   * loudly in the event log — e.g. a matched No-Intro header whose
+   * size/trainer fields disagreed with the dump (a should-never-happen
+   * integrity signal). Empty/omitted means none.
+   */
+  warnings?: string[];
 }
 
 export interface VerificationHashes {


### PR DESCRIPTION
## Summary

- **Post-dump header editor (unverified dumps only):** the completion screen now shows an editable NES 2.0 header section — Region/Timing, Console type, Mirroring, Default expansion device, and Submapper. Edits rewrite the saved file's header without touching PRG/CHR content or its hashes; the dump report refreshes to match the file that was actually saved. Verified dumps are unchanged — the canonical No-Intro header supplies those fields.
- **Per-section CRC32 breakdown:** headered carts with CHR ROM now show a "ROM sections" table (PRG / CHR, each with size and CRC32) below the main hash block — the chip-level view that NESCartDB and No-Intro use.
- **Right-aligned size/hash columns:** `DumpSummary` gains a `rightAlignColumns` field; NES and any future summary tables can right-align numeric columns.
- **Canonical-header sanity warnings:** if a matched No-Intro canonical header can't describe the attached bytes (trainer flag on a cart dump, or declared PRG+CHR ≠ content length), a warning is emitted to the event log. The verified bytes are still emitted as-is — this is a should-never-fire integrity signal for a malformed DAT entry.
- **INL wire-protocol cleanup** (earlier commits): `SET_RELOAD_PAGENUM` opcode constants declared, `payloadIn` capped at 254 bytes, driver/integration test coverage added.

## Test plan

- [ ] Build passes (`npm run build`), lint clean (`npm run lint`), all 238 tests pass (`npm test`)
- [ ] Dump a NES cart that doesn't match the DB — header editor section appears with correct defaults (NTSC, NES/Famicom, mapper-appropriate mirroring, Unspecified expansion, submapper 0)
- [ ] Change Region to PAL, save the dump — byte 12 of the `.nes` file is 0x01; dump report shows "PAL"
- [ ] Change Mirroring, save — byte 6 bits 0/3 correct; PRG/CHR content bytes unchanged; section CRC32 table matches pre-edit values
- [ ] Dump a verified cart — no header editor section appears
- [ ] Dump a CHR-RAM cart (e.g. UxROM) — no "ROM sections" table; header editor still works
- [ ] Dump a CHR-ROM cart (e.g. NROM) — "ROM sections" table shows PRG + CHR rows with right-aligned size/CRC columns