### PR TITLE
NES: add Mapper 413 (BATMAP) with NES 2.0 miscellaneous-ROM dumping

### DIFF
--- a/src/lib/drivers/inl/inl-driver.ts
+++ b/src/lib/drivers/inl/inl-driver.ts
@@ -122,6 +122,7 @@ export class INLDriver implements DeviceDriver {
     const mapperId = (config.params.mapper as number) ?? 0;
     const prgKB = ((config.params.prgSizeBytes as number) ?? 32768) / 1024;
     const chrKB = ((config.params.chrSizeBytes as number) ?? 8192) / 1024;
+    const miscKB = ((config.params.miscSizeBytes as number) ?? 0) / 1024;
 
     const mapper = getNesMapper(mapperId);
     if (!mapper) throw new Error(`Unsupported mapper: ${mapperId}`);
@@ -139,10 +140,11 @@ export class INLDriver implements DeviceDriver {
     // signal rides along so an abort interrupts per chunk, not per region.
     const bus = new InlNesBus(this.inlDevice, signal);
     const startTime = Date.now();
-    const totalBytes = (prgKB + chrKB) * 1024;
+    const totalBytes = (prgKB + chrKB + miscKB) * 1024;
 
     let prgData: Uint8Array;
     let chrData: Uint8Array = new Uint8Array(0);
+    let miscData: Uint8Array = new Uint8Array(0);
     try {
       // Dump PRG-ROM
       this.log(`Reading ${prgKB}KB PRG-ROM...`);
@@ -176,6 +178,30 @@ export class INLDriver implements DeviceDriver {
           });
         });
       }
+
+      // Dump the miscellaneous-ROM area (mapper 413's sample flash) —
+      // the NES 2.0 file section appended after CHR.
+      if (miscKB > 0) {
+        if (!mapper.dumpMiscRom) {
+          throw new Error(
+            `Mapper ${mapperId} (${mapper.name}) declares a miscellaneous ROM but supplies no dump path for it`,
+          );
+        }
+        this.log(`Reading ${miscKB}KB miscellaneous ROM...`);
+        signal?.throwIfAborted();
+
+        miscData = await mapper.dumpMiscRom(bus, miscKB, (bytesRead) => {
+          const elapsed = (Date.now() - startTime) / 1000;
+          const totalRead = (prgKB + chrKB) * 1024 + bytesRead;
+          this.progress({
+            phase: "rom",
+            bytesRead: totalRead,
+            totalBytes,
+            fraction: totalRead / totalBytes,
+            speed: elapsed > 0 ? totalRead / elapsed : undefined,
+          });
+        });
+      }
     } finally {
       // Always reset the device, including when an abort or error unwinds the
       // dump. dumpRegion already resets the operation engine on its way out;
@@ -191,13 +217,17 @@ export class INLDriver implements DeviceDriver {
 
     const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
     this.log(
-      `ROM read complete (${prgData.length + chrData.length} bytes in ${elapsed}s)`,
+      `ROM read complete (${prgData.length + chrData.length + miscData.length} bytes in ${elapsed}s)`,
     );
 
-    // Return PRG + CHR concatenated (system handler adds the iNES header)
-    const result = new Uint8Array(prgData.length + chrData.length);
+    // Return PRG + CHR + misc concatenated in NES 2.0 file order (the
+    // system handler adds the header).
+    const result = new Uint8Array(
+      prgData.length + chrData.length + miscData.length,
+    );
     result.set(prgData, 0);
     result.set(chrData, prgData.length);
+    result.set(miscData, prgData.length + chrData.length);
     return result;
   }
 

--- a/src/lib/drivers/inl/inl-nes-bus.ts
+++ b/src/lib/drivers/inl/inl-nes-bus.ts
@@ -83,6 +83,37 @@ export class InlNesBus implements NesBus {
     });
   }
 
+  // Optional `NesBus.readCpuByte` capability: the one-byte escape hatch
+  // around dumpRegion's 1 KiB granularity, via the NES_CPU_RD dictionary
+  // opcode. Mapper 413 uses it for the SPI frame's arming read.
+  async readCpuByte(addr: number): Promise<number> {
+    return this.device.nes(NES.NES_CPU_RD, addr);
+  }
+
+  // Optional `NesBus.readSpiDataPort` capability for mapper 413: the
+  // firmware's NESCPU_SPI413 memtype paces each byte as eight cart-ROM
+  // read cycles (the CPLD's SPI clocks) plus one $C000 port read. The
+  // mapper opens the SPI frame before calling.
+  async readSpiDataPort(
+    length: number,
+    onProgress?: BusProgressCb,
+  ): Promise<Uint8Array> {
+    if (length === 0) return new Uint8Array(0);
+    if (length % 1024 !== 0) {
+      throw new Error(
+        `InlNesBus.readSpiDataPort requires multiple-of-1KB length; got ${length}`,
+      );
+    }
+    return dumpRegion(this.device, {
+      sizeKB: length / 1024,
+      memType: MEM.NESCPU_SPI413,
+      mapper: 0,
+      mapVar: MAPVAR.NOVAR,
+      onProgress,
+      signal: this.signal,
+    });
+  }
+
   async readPpu(
     addr: number,
     length: number,

--- a/src/lib/drivers/inl/inl-opcodes.ts
+++ b/src/lib/drivers/inl/inl-opcodes.ts
@@ -22,11 +22,11 @@ export const DICT = {
 // ─── PINPORT Dictionary ─────────────────────────────────────────────────────
 
 export const PINPORT = {
-  CTL_RD: 6,      // RL=4 — read a control pin
-  ADDR_SET: 17,   // set address bus value
+  CTL_RD: 6, // RL=4 — read a control pin
+  ADDR_SET: 17, // set address bus value
   // Control pin operand IDs for CTL_RD
-  CIA10: 11,       // CIRAM A10 (nametable mirroring)
-  CICE: 6,         // CIRAM /CE
+  CIA10: 11, // CIRAM A10 (nametable mirroring)
+  CICE: 6, // CIRAM /CE
 } as const;
 
 // ─── IO Dictionary ──────────────────────────────────────────────────────────
@@ -120,6 +120,10 @@ export const MEM = {
   NESCPU_PAGE: 0x22,
   NESPPU_PAGE: 0x23,
   NESCPU_4KB_TOGGLE: 0x32,
+  // Mapper 413 (BATMAP) serial-flash data port: firmware reads each
+  // byte as 8 dummy cart-ROM reads (SPI clocks) + one $C000 port read.
+  // The host opens the SPI frame first — see InlNesBus.readSpiDataPort.
+  NESCPU_SPI413: 0x33,
 } as const;
 
 // ─── Part numbers ───────────────────────────────────────────────────────────

--- a/src/lib/drivers/inl/unsupported-mappers.ts
+++ b/src/lib/drivers/inl/unsupported-mappers.ts
@@ -66,6 +66,19 @@
  * was matched (see `inx007t.ts`). Given the formal mapper-268 classification
  * of this family on this device, pre-flight-rejecting 470 is the honest
  * default; an instrumented attempt could overturn it.
+ *
+ * ── Mapper 413 (BATMAP) ──
+ *
+ * A different reason from the boards above: the INL drives this mapper's
+ * registers fine and its PRG/CHR dump correctly. The block is the 8 MiB
+ * serial sample flash, which the CPLD clocks from M2 — reading it needs
+ * the firmware's NESCPU_SPI413 memtype to pace eight cart-ROM clock reads
+ * per byte (see InlNesBus.readSpiDataPort). That memtype is not in a
+ * released INL firmware yet, so the flash reads as solid 0xFF and the cart
+ * cannot be fully dumped. The read path is implemented and left dormant
+ * behind this entry — delete the 413 row below to re-enable it once the
+ * upstream firmware lands:
+ *   https://gitlab.com/InfiniteNesLives/INL-retro-progdump/-/merge_requests/45
  */
 
 /** INL-unsupported mapper id → reason shown in the driver's pre-flight error. */
@@ -80,5 +93,11 @@ export const UNSUPPORTED_MAPPERS = new Map<number, string>([
     "the board family refuses this device's synthesized writes (same CPLD " +
       "family as mapper 268, plus a recorded failure of this exact cart on " +
       "this device class)",
+  ],
+  [
+    413,
+    "its 8 MiB serial sample flash needs the NESCPU_SPI413 firmware memtype " +
+      "to pace the read, which is not in a released INL firmware yet (the " +
+      "flash reads as 0xFF until then)",
   ],
 ]);

--- a/src/lib/systems/nes/bus.ts
+++ b/src/lib/systems/nes/bus.ts
@@ -87,6 +87,30 @@ export interface NesBus {
   writeSerialRegister?(addr: number, value: number): Promise<void>;
 
   /**
+   * Read a single byte from CPU-bus address `addr`. Optional — drivers
+   * whose read primitives have block-size minimums (e.g. the INL's
+   * 1 KiB-granular dump engine) supply this as the one-byte escape
+   * hatch. Mapper 413 requires it for the SPI frame's arming read.
+   */
+  readCpuByte?(addr: number): Promise<number>;
+
+  /**
+   * Stream `length` bytes from mapper 413's serial-flash data port,
+   * paced by the device: one byte = eight cart-ROM read cycles (the
+   * CPLD's SPI clocks) followed by a $C000 port read. The mapper opens
+   * the SPI frame (CS pulse, command bits, data mode, arming read) via
+   * `writeCpu`/`readCpuByte` before calling; the device only supplies
+   * the paced transport. Optional — devices without a paced read path
+   * cannot dump this board's miscellaneous ROM at all (a generic
+   * `readCpu` cannot express the per-byte clocking), so the mapper
+   * throws a clear capability error when it is absent.
+   */
+  readSpiDataPort?(
+    length: number,
+    onProgress?: BusProgressCb,
+  ): Promise<Uint8Array>;
+
+  /**
    * Write `latchValue` to the CPU-bus register at `latchAddr` and read
    * `length` bytes from `addr`, as ONE fused device operation with no bus
    * idle between the write and the read. Optional — a driver supplies this

--- a/src/lib/systems/nes/mappers/batmap.ts
+++ b/src/lib/systems/nes/mappers/batmap.ts
@@ -1,0 +1,224 @@
+/**
+ * NES 2.0 Mapper 413 — BATMAP board (a single-title board with an
+ * 8 MiB speech ROM).
+ *
+ * Geometry (the board exists in exactly one configuration):
+ *   256 KiB PRG flash  — 8 KiB banks, all reachable through one window.
+ *   256 KiB CHR flash  — 4 KiB banks, all reachable through one window.
+ *   8 MiB serial flash — speech samples, dumped as the NES 2.0
+ *       miscellaneous-ROM file section (header byte 14 = 1).
+ *
+ * Banking registers (write-only; a CPLD implements the whole mapper):
+ *   $8000-$BFFF  scanline-IRQ block — never touched by the dump.
+ *   $E000-$FFFF  bank port: reg[D7-D6] = D5-D0. reg1 = 8 KiB PRG at
+ *                $8000, reg3 = 4 KiB CHR at PPU $0000 (reg0/reg2 map
+ *                more PRG windows the dump doesn't need).
+ *   PRG fixed banks (#1 at $5000, #7 at $D000, #4 at $E000) and CHR
+ *   fixed bank $3D at $1000 are reachable through the switchable
+ *   windows, so the walks below cover every byte. Power-on state:
+ *   all regs 0 (never relied on — every access selects state first).
+ *
+ * ── The serial-flash port: a bit-banged SPI bridge ──
+ *
+ * Hardware-validated 2026-06-13 by replaying the protocol extracted
+ * from the game's own driver code (in our canonical-verified PRG dump).
+ * The emulator model — a 23-bit auto-increment pointer register — is a
+ * behavioral approximation; the CPLD actually bridges the CPU bus
+ * straight to the flash's SPI interface:
+ *
+ *   $D000 bit 0    SPI /CS framing. An ARM PULSE (write $01 then $00)
+ *                  must precede every frame — modeled by NO emulator;
+ *                  without it the port never leaves 0xFF.
+ *   $C000 writes   shift one command bit each (D7), self-clocked by
+ *                  the write cycle. A frame is the flash's raw 32-bit
+ *                  READ command: 0x03 + 24-bit byte address, MSB first.
+ *   $D000 = $02    data phase: the CPLD shifts one SPI bit per
+ *                  cart-addressed READ cycle (any /ROMSEL read — on a
+ *                  console, instruction fetches supply these for free),
+ *                  halting at 8 bits; a $C000 read latches the
+ *                  assembled byte and re-arms the bit counter. The
+ *                  first $C000 read after a frame arms the engine and
+ *                  returns pipeline garbage — issue and discard it.
+ *                  Sequential addresses come from the flash's own
+ *                  streaming read; there is no mapper-side pointer.
+ *
+ * The $4800-$4FFF mirror in FCEUX/MiSTer/puNES does NOT exist on
+ * hardware (reads there are open bus); the emulators' 4-6 cycle
+ * "increment cooldown" is their approximation of the 8-clocks-per-byte
+ * reality. Dumping needs a device-paced read path (8 cart-ROM reads
+ * then a port read, per byte) — the optional `bus.readSpiDataPort`
+ * capability; a generic block `readCpu` cannot express it. Frames are
+ * re-opened per 1 MiB block, so a glitch can corrupt at most one block
+ * and every block is independently retryable.
+ *
+ * The pre-flight probe reads the first KiB twice (the stream must be
+ * deterministic) and from address 4 once (the streams must overlap
+ * shifted by 4) — catching a dead port, frame/clock misalignment, and
+ * non-landing register writes in seconds instead of after the full
+ * dump. Uniform data satisfies the overlap by construction, so erased
+ * fill can't false-positive; post-dump hash verification and the
+ * uniform-misc advisory in the system handler backstop that blind spot.
+ *
+ * PRG/CHR walks were verified byte-exact against the canonical
+ * per-section hashes on INL hardware (2026-06-13); the serial-flash
+ * recipe was validated over 96-byte windows at both ends of the flash,
+ * with the full-dump hash check pending. The board wires the PRG
+ * flash's /WE straight to CPU R/W: stick to the documented register
+ * writes above, nothing else.
+ */
+
+import type { NesBus } from "../bus";
+import type { NesMapper } from "./types";
+import { walkBanks } from "./bank-walk";
+import { bytesEqual } from "./bank-reliability";
+
+const DATA_PORT = 0xc000; // reads: latch SPI byte; writes: shift command bit
+const CONTROL_REG = 0xd000;
+const CS_ASSERT = 0x01; // control bit 0 — the arm pulse
+const CS_RELEASE = 0x00;
+const DATA_PHASE = 0x02; // control bit 1
+const SPI_READ_CMD = 0x03; // the flash's READ opcode, first byte of a frame
+
+const PRG_WINDOW = 0x8000;
+const PRG_BANK = 8 * 1024;
+const REG1_SELECT = 0x40; // bank-port value D7-D6 = 01 → reg1 (PRG $8000)
+const CHR_BANK = 4 * 1024;
+const REG3_SELECT = 0xc0; // bank-port value D7-D6 = 11 → reg3 (CHR $0000)
+
+/** Re-open the SPI frame per block: bounded blast radius, retryable. */
+const MISC_BLOCK = 1024 * 1024;
+const PROBE_BYTES = 1024;
+
+const EXPECTED_PRG_KB = 256;
+const EXPECTED_CHR_KB = 256;
+const EXPECTED_MISC_KB = 8192;
+
+type SpiBus = NesBus &
+  Required<Pick<NesBus, "readSpiDataPort" | "readCpuByte">>;
+
+/**
+ * Open an SPI READ frame at `address`: arm pulse, 32 command bits,
+ * data phase, and the arming read (discarded — pipeline garbage).
+ */
+async function openFrame(bus: SpiBus, address: number): Promise<void> {
+  await bus.writeCpu(CONTROL_REG, CS_ASSERT);
+  await bus.writeCpu(CONTROL_REG, CS_RELEASE);
+  // 0x03 + 24-bit address, MSB first, one bit per write in D7.
+  const frame = (SPI_READ_CMD << 24) | (address & 0xffffff);
+  for (let bit = 31; bit >= 0; bit--) {
+    await bus.writeCpu(DATA_PORT, ((frame >>> bit) & 1) << 7);
+  }
+  await bus.writeCpu(CONTROL_REG, DATA_PHASE);
+  await bus.readCpuByte(DATA_PORT);
+}
+
+async function readMiscBlock(
+  bus: SpiBus,
+  address: number,
+  length: number,
+  onProgress?: (bytesRead: number) => void,
+): Promise<Uint8Array> {
+  await openFrame(bus, address);
+  return bus.readSpiDataPort(length, onProgress);
+}
+
+export const mapper413: NesMapper = {
+  id: 413,
+  name: "BATMAP",
+
+  async dumpPrgRom(bus, sizeKB, onProgress) {
+    if (sizeKB !== EXPECTED_PRG_KB) {
+      throw new Error(
+        `Mapper 413 boards carry exactly ${EXPECTED_PRG_KB} KiB PRG; got ${sizeKB} KiB`,
+      );
+    }
+    await bus.setup();
+    return walkBanks(
+      {
+        label: "BATMAP PRG",
+        bankBytes: PRG_BANK,
+        numBanks: (sizeKB * 1024) / PRG_BANK,
+        readBank: async (bank) => {
+          await bus.writeCpu(0xe000, REG1_SELECT | bank);
+          return bus.readCpu(PRG_WINDOW, PRG_BANK);
+        },
+      },
+      onProgress,
+    );
+  },
+
+  async dumpChrRom(bus, sizeKB, onProgress) {
+    if (sizeKB !== EXPECTED_CHR_KB) {
+      throw new Error(
+        `Mapper 413 boards carry exactly ${EXPECTED_CHR_KB} KiB CHR; got ${sizeKB} KiB`,
+      );
+    }
+    if (!bus.readPpu) {
+      throw new Error(
+        "BATMAP CHR-ROM dump requires a PPU-bus read primitive, which this driver does not expose. Provide a driver-specific `dumpChrRom` override for mapper 413.",
+      );
+    }
+    const readPpu = bus.readPpu.bind(bus);
+
+    await bus.setup();
+    return walkBanks(
+      {
+        label: "BATMAP CHR",
+        bankBytes: CHR_BANK,
+        numBanks: (sizeKB * 1024) / CHR_BANK,
+        readBank: async (bank) => {
+          await bus.writeCpu(0xe000, REG3_SELECT | bank);
+          return readPpu(0x0000, CHR_BANK);
+        },
+      },
+      onProgress,
+    );
+  },
+
+  async dumpMiscRom(bus, sizeKB, onProgress) {
+    if (sizeKB !== EXPECTED_MISC_KB) {
+      throw new Error(
+        `Mapper 413 boards carry exactly ${EXPECTED_MISC_KB} KiB of miscellaneous ROM; got ${sizeKB} KiB`,
+      );
+    }
+    if (!bus.readSpiDataPort || !bus.readCpuByte) {
+      throw new Error(
+        "BATMAP's serial sample flash needs a device-paced SPI read path (8 cart-ROM clock reads per byte), which this driver does not expose. The miscellaneous ROM cannot be dumped on this device.",
+      );
+    }
+    const spiBus = bus as SpiBus;
+
+    await bus.setup();
+
+    // Pre-flight probe (see header): the stream must repeat exactly on
+    // a re-opened frame, and a frame at address 4 must overlap the
+    // address-0 stream shifted by 4.
+    const first = await readMiscBlock(spiBus, 0, PROBE_BYTES);
+    const again = await readMiscBlock(spiBus, 0, PROBE_BYTES);
+    if (!bytesEqual(first, again)) {
+      throw new Error(
+        "Mapper 413 serial-flash probe failed: two reads of the same address " +
+          "differ, so the SPI stream is not deterministic on this device. " +
+          "Aborting before the full dump.",
+      );
+    }
+    const shifted = await readMiscBlock(spiBus, 4, PROBE_BYTES);
+    if (!bytesEqual(shifted.subarray(0, PROBE_BYTES - 4), first.subarray(4))) {
+      throw new Error(
+        "Mapper 413 serial-flash probe failed: streams from address 0 and " +
+          "address 4 do not overlap, so frame addressing or per-byte clocking " +
+          "is misaligned on this device. Aborting before the full dump.",
+      );
+    }
+
+    const totalBytes = sizeKB * 1024;
+    const out = new Uint8Array(totalBytes);
+    for (let off = 0; off < totalBytes; off += MISC_BLOCK) {
+      const block = await readMiscBlock(spiBus, off, MISC_BLOCK, (bytesRead) =>
+        onProgress?.(off + bytesRead, totalBytes),
+      );
+      out.set(block, off);
+    }
+    return out;
+  },
+};

--- a/src/lib/systems/nes/mappers/index.ts
+++ b/src/lib/systems/nes/mappers/index.ts
@@ -29,6 +29,7 @@ import { bf909x } from "./bf909x";
 import { dxrom } from "./dxrom";
 import { quattro } from "./quattro";
 import { mapper268Mindkids } from "./coolboy";
+import { mapper413 } from "./batmap";
 import { mapper470 } from "./inx007t";
 import type { NesMapper } from "./types";
 
@@ -55,6 +56,10 @@ export const NES_MAPPERS: Record<number, NesMapper> = {
   // that device's synthesized writes; see UNSUPPORTED_MAPPERS in
   // drivers/inl/unsupported-mappers for the hardware-classified account.
   268: mapper268Mindkids,
+  // Spec-derived implementation (emulator/FPGA consensus), not yet
+  // hardware-validated; the only mapper with a miscellaneous-ROM
+  // section. See the data-port probe in batmap.ts.
+  413: mapper413,
   // Vendor-recipe implementation, not yet hardware-validated on a nabu
   // driver (see the cadence lesson in inx007t.ts); INL pre-flight-
   // rejects this id too — same CPLD-refusal family as 268.

--- a/src/lib/systems/nes/mappers/mappers.test.ts
+++ b/src/lib/systems/nes/mappers/mappers.test.ts
@@ -16,6 +16,7 @@ import { bf909x } from "./bf909x";
 import { dxrom } from "./dxrom";
 import { quattro } from "./quattro";
 import { mapper268Mindkids, mapper268Coolboy } from "./coolboy";
+import { mapper413 } from "./batmap";
 import { mapper470 } from "./inx007t";
 
 /**
@@ -816,7 +817,8 @@ describe("RAMBO-1 (mapper 64)", () => {
           "RAMBO-1 has no $A001 PRG-RAM register — the dumper must not write it",
         );
       }
-      if (addr === 0x8000) this.select = value & 0x0f; // 4-bit command
+      if (addr === 0x8000)
+        this.select = value & 0x0f; // 4-bit command
       else if (addr === 0x8001) this.r[this.select] = value;
       // $A000 (mirroring) is a no-op for content reads.
     }
@@ -1454,5 +1456,241 @@ describe("Mapper 470 (INX_007T_V01)", () => {
   it("returns an empty CHR dump (CHR-RAM board)", async () => {
     const out = await mapper470.dumpChrRom({} as NesBus, 0);
     expect(out.length).toBe(0);
+  });
+});
+
+describe("Mapper 413 (BATMAP)", () => {
+  const PRG = 256 * 1024;
+  const CHR = 256 * 1024;
+  const MISC = 8 * 1024 * 1024;
+
+  /**
+   * Faithful model of the board's CPLD-SPI bridge (hardware-validated
+   * protocol, 2026-06-13): $D000 bit 0 = /CS (an $01,$00 arm pulse
+   * begins frame capture); $C000 writes shift one command bit each; a
+   * 32-bit 0x03+addr24 frame opens the flash's streaming read; in data
+   * phase ($D000=$02) every cart-addressed READ clocks one SPI bit
+   * (halting at 8), and a $C000 read latches the byte, re-arms the
+   * counter, and — like the real CPLD — itself contributes a clock.
+   * The first port read after a frame returns pipeline junk (0xff).
+   * `clocksPerByte` lets a test model an under-clocking device. Any
+   * write to the $8000-$BFFF IRQ block throws: the dump must never
+   * touch it.
+   */
+  class SrrSpiBus implements NesBus {
+    private readonly regs = [0, 0, 0, 0];
+    private control = 0;
+    private csPulsed = false;
+    private capturing = false;
+    private frameBits: number[] = [];
+    private framed = false;
+    private flashBitPos = 0;
+    private bitsClocked = 0;
+    private latch = 0;
+    private armed = false;
+    readonly framesOpened: number[] = [];
+    private readonly clocksPerByte: number;
+    private readonly prg: Uint8Array;
+    private readonly chr: Uint8Array;
+    private readonly flash: Uint8Array;
+    constructor(
+      prg: Uint8Array,
+      chr: Uint8Array,
+      flash: Uint8Array,
+      opts: { clocksPerByte?: number } = {},
+    ) {
+      this.prg = prg;
+      this.chr = chr;
+      this.flash = flash;
+      this.clocksPerByte = opts.clocksPerByte ?? 8;
+    }
+    async setup() {}
+
+    async writeCpu(addr: number, value: number) {
+      const page = addr & 0xf000;
+      if (page === 0xe000 || page === 0xf000) {
+        this.regs[value >> 6] = value & 0x3f;
+      } else if (page === 0xd000) {
+        if (value & 0x01) {
+          this.csPulsed = true;
+        } else if (this.csPulsed && !(value & 0x02)) {
+          // $01 then $00: begin a fresh frame capture
+          this.capturing = true;
+          this.frameBits = [];
+          this.framed = false;
+          this.armed = false;
+          this.csPulsed = false;
+        }
+        this.control = value;
+      } else if (page === 0xc000) {
+        if (this.capturing) {
+          this.frameBits.push(value >> 7);
+          if (this.frameBits.length === 32) {
+            const word = this.frameBits.reduce((acc, b) => (acc << 1) | b, 0);
+            const cmd = (word >>> 24) & 0xff;
+            expect(cmd).toBe(0x03); // only the flash READ command is valid
+            const flashAddr = word & 0xffffff;
+            this.flashBitPos = flashAddr * 8;
+            this.framed = true;
+            this.capturing = false;
+            this.framesOpened.push(flashAddr);
+          }
+        }
+      } else {
+        // $8000-$BFFF is the scanline-IRQ block (or below: not a register).
+        throw new Error(`unexpected write $${addr.toString(16)}`);
+      }
+    }
+
+    /** One SPI clock, fired by any cart-addressed read in data phase. */
+    private clock() {
+      if (!(this.control & 0x02) || !this.framed || !this.armed) return;
+      if (this.bitsClocked >= this.clocksPerByte || this.bitsClocked >= 8)
+        return; // the CPLD's counter halts at a byte
+      const bit =
+        (this.flash[this.flashBitPos >> 3] >> (7 - (this.flashBitPos & 7))) & 1;
+      this.latch = ((this.latch << 1) | bit) & 0xff;
+      this.flashBitPos++;
+      this.bitsClocked++;
+    }
+
+    /**
+     * A port read returns the CURRENT shift-register window — like the
+     * real CPLD, not a completeness-gated value. A well-clocked cadence
+     * sees exactly the assembled byte; an under-clocked one sees stale
+     * bits sheared into each byte (non-uniform garbage), which is what
+     * the pre-flight overlap probe catches on hardware.
+     */
+    private portRead(): number {
+      this.clock(); // the port read itself contributes a clock
+      const out = this.armed ? this.latch : 0xff; // pre-arm read: MISO idle
+      this.armed = true;
+      this.bitsClocked = 0;
+      return out;
+    }
+
+    // Synchronous core shared by the async bus method and the paced
+    // page-read simulation — an 8 MiB dump is ~75 million bus cycles,
+    // which must not each be an awaited promise (worker OOM/timeout on
+    // modest hardware).
+    private readByteSync(addr: number): number {
+      if (addr === 0xc000 && this.control & 0x02) {
+        return this.portRead();
+      }
+      if (addr >= 0x8000) {
+        this.clock(); // cart-ROM read = one SPI clock
+        return 0xa5; // arbitrary ROM byte; dummies ignore it
+      }
+      return 0x48; // open bus below $4800-style echo
+    }
+
+    async readCpuByte(addr: number) {
+      return this.readByteSync(addr);
+    }
+
+    /** Simulates the firmware's NESCPU_SPI413 paced page read. */
+    async readSpiDataPort(length: number) {
+      const out = new Uint8Array(length);
+      for (let i = 0; i < length; i++) {
+        for (let j = 0; j < 8; j++) this.readByteSync(0xd000);
+        out[i] = this.readByteSync(0xc000);
+      }
+      return out;
+    }
+
+    async readCpu(addr: number, length: number) {
+      expect(addr).toBe(0x8000); // reg1's PRG window — the only block read
+      expect(length).toBe(0x2000);
+      const off = this.regs[1] * 0x2000;
+      return this.prg.slice(off, off + length);
+    }
+
+    async readPpu(addr: number, length: number) {
+      expect(addr).toBe(0x0000);
+      expect(length).toBe(0x1000);
+      const off = this.regs[3] * 0x1000;
+      return this.chr.slice(off, off + length);
+    }
+  }
+
+  function makeBus(opts?: { clocksPerByte?: number; flash?: Uint8Array }) {
+    return new SrrSpiBus(
+      makeImage(PRG),
+      makeImage(CHR, 1),
+      opts?.flash ?? makeImage(MISC, 2),
+      opts,
+    );
+  }
+
+  it("dumps PRG byte-exact through the reg1 window walk", async () => {
+    const prg = makeImage(PRG);
+    const bus = new SrrSpiBus(prg, new Uint8Array(0), new Uint8Array(0));
+    const out = await mapper413.dumpPrgRom(bus, 256);
+    expectSameBytes(out, prg);
+  });
+
+  it("dumps CHR byte-exact through the reg3 window walk", async () => {
+    const chr = makeImage(CHR, 1);
+    const bus = new SrrSpiBus(new Uint8Array(0), chr, new Uint8Array(0));
+    const out = await mapper413.dumpChrRom(bus, 256);
+    expectSameBytes(out, chr);
+  });
+
+  it("dumps the 8 MiB serial flash byte-exact through the SPI frame protocol", async () => {
+    const flash = makeImage(MISC, 2);
+    const bus = makeBus({ flash });
+    const out = await mapper413.dumpMiscRom!(bus, 8192);
+    expectSameBytes(out, flash);
+  });
+
+  it("re-opens the frame per 1 MiB block, after a 3-frame probe", async () => {
+    const bus = makeBus();
+    await mapper413.dumpMiscRom!(bus, 8192);
+    // probe: 0, 0, 4 — then one frame per 1 MiB block
+    expect(bus.framesOpened).toEqual([
+      0,
+      0,
+      4,
+      ...Array.from({ length: 8 }, (_, i) => i * 1024 * 1024),
+    ]);
+  });
+
+  it("probe rejects an under-clocking device within three probe frames", async () => {
+    // 7 clocks per byte (6 dummies' worth + the port read) shears one
+    // stale bit into every byte. The shear isn't reproducible across
+    // re-opened frames (the shift register carries over), so either
+    // pre-flight check — determinism or shifted-overlap — fires; what
+    // matters is rejecting before the multi-minute full dump.
+    const bus = makeBus({ clocksPerByte: 7 });
+    await expect(mapper413.dumpMiscRom!(bus, 8192)).rejects.toThrow(
+      /probe failed/,
+    );
+    expect(bus.framesOpened.length).toBeLessThanOrEqual(3);
+  });
+
+  it("throws a clear capability error when the bus lacks the paced SPI read", async () => {
+    const bus = makeBus();
+    (bus as { readSpiDataPort?: unknown }).readSpiDataPort = undefined;
+    await expect(mapper413.dumpMiscRom!(bus, 8192)).rejects.toThrow(
+      /paced SPI read path/,
+    );
+  });
+
+  it("rejects any geometry but the board's 256/256/8192 KiB", async () => {
+    await expect(mapper413.dumpPrgRom(makeBus(), 128)).rejects.toThrow(
+      /256 KiB/,
+    );
+    await expect(mapper413.dumpChrRom(makeBus(), 128)).rejects.toThrow(
+      /256 KiB/,
+    );
+    await expect(mapper413.dumpMiscRom!(makeBus(), 4096)).rejects.toThrow(
+      /8192 KiB/,
+    );
+  });
+
+  it("throws a clear error when the bus has no PPU read", async () => {
+    const bus = makeBus();
+    (bus as { readPpu?: unknown }).readPpu = undefined;
+    await expect(mapper413.dumpChrRom(bus, 256)).rejects.toThrow(/PPU-bus/);
   });
 });

--- a/src/lib/systems/nes/mappers/types.ts
+++ b/src/lib/systems/nes/mappers/types.ts
@@ -29,6 +29,18 @@ export interface NesMapper {
     onProgress?: ProgressCb,
   ): Promise<Uint8Array>;
 
+  /**
+   * Dump the NES 2.0 miscellaneous-ROM area — the file section appended
+   * after CHR (header byte 14 counts it). Only boards that carry one
+   * declare this (mapper 413's 8 MiB sample flash); `sizeKB` comes from
+   * the mapper def's fixed `miscRomKB`.
+   */
+  dumpMiscRom?(
+    bus: NesBus,
+    sizeKB: number,
+    onProgress?: ProgressCb,
+  ): Promise<Uint8Array>;
+
   /** Engage SRAM access before a save-RAM dump (where required by the mapper). */
   enableSram?(bus: NesBus): Promise<void>;
 

--- a/src/lib/systems/nes/nes-constants.ts
+++ b/src/lib/systems/nes/nes-constants.ts
@@ -32,6 +32,13 @@ export interface NESMapperDef {
    */
   chrRamKB?: number;
   /**
+   * NES 2.0 miscellaneous-ROM size in KiB — a fixed extra ROM section
+   * appended after CHR in the output file (header byte 14 counts it).
+   * Only boards that carry one declare it (mapper 413: 8 MiB of sample
+   * flash); it is never user-selectable.
+   */
+  miscRomKB?: number;
+  /**
    * Optional per-mapper warning, surfaced as a prominent amber alert in
    * the config UI when the mapper is selected. Must be DEVICE-AGNOSTIC —
    * a cart-handling caveat (e.g. Quattro's A/B switch) or an
@@ -212,6 +219,23 @@ export const NES_MAPPER_DB: NESMapperDef[] = [
     // No device-agnostic caveat: incompatibility is per-device
     // (capability.unsupportedMappers greys it out on the INL), and on a
     // device that can drive this board the dump path is hardware-validated.
+  },
+  {
+    id: 413,
+    name: "BATMAP",
+    // One board, one configuration: 256 KiB PRG + 256 KiB CHR + an
+    // 8 MiB sample flash dumped as the NES 2.0 miscellaneous-ROM area.
+    prgSizesKB: [256],
+    chrSizesKB: [256],
+    mirroring: "vertical",
+    commonlyHasBattery: false,
+    maxPrgRamKB: 0,
+    miscRomKB: 8192,
+    // Device-agnostic maturity caveat, same shape as mapper 470's.
+    warning:
+      "The dump recipe for this board is derived from emulator and FPGA " +
+      "sources and not yet hardware-validated — verify the result against " +
+      "a known-good reference. The 8 MB sample ROM makes this a long dump.",
   },
   {
     id: 470,

--- a/src/lib/systems/nes/nes-header.test.ts
+++ b/src/lib/systems/nes/nes-header.test.ts
@@ -140,3 +140,34 @@ describe("buildNes2Header", () => {
     ).toThrow(/too large/);
   });
 });
+
+describe("buildNes2Header miscellaneous-ROM count (mapper 413)", () => {
+  it("encodes the mapper-413 board: split mapper nibbles and byte-14 misc count", () => {
+    const h = buildNes2Header({
+      prgBytes: 262144, // 256 KiB
+      chrBytes: 262144, // 256 KiB
+      mapper: 413,
+      mirroring: "vertical",
+      battery: false,
+      miscRoms: 1,
+    });
+    expectNes2Magic(h);
+    expect(h[4]).toBe(16); // 256 KiB PRG in 16 KiB units
+    expect(h[5]).toBe(32); // 256 KiB CHR in 8 KiB units
+    expect(h[6]).toBe(0xd1); // mapper low nibble 0xD, vertical mirroring
+    expect(h[7]).toBe(0x98); // mapper mid nibble 9, NES 2.0 indicator
+    expect(h[8]).toBe(0x01); // mapper high bits 1, submapper 0
+    expect(h[14]).toBe(0x01); // one miscellaneous ROM follows CHR
+  });
+
+  it("defaults the misc-ROM count to zero", () => {
+    const h = buildNes2Header({
+      prgBytes: 32768,
+      chrBytes: 8192,
+      mapper: 0,
+      mirroring: "horizontal",
+      battery: false,
+    });
+    expect(h[14]).toBe(0x00);
+  });
+});

--- a/src/lib/systems/nes/nes-header.ts
+++ b/src/lib/systems/nes/nes-header.ts
@@ -38,6 +38,11 @@ export interface Nes2HeaderInputs {
    * (e.g. PAL-only carts).
    */
   tvSystem?: NesTvSystem;
+  /**
+   * Number of miscellaneous ROMs appended after CHR (byte 14, bits 0-1).
+   * Default 0; mapper 413's sample flash is the one case we emit.
+   */
+  miscRoms?: number;
 }
 
 /** Convert a power-of-two size in bytes to NES 2.0's shift count. */
@@ -74,8 +79,8 @@ const TV_SYSTEM_BITS: Record<NesTvSystem, number> = {
  *   11    CHR-RAM (low nibble) / CHR-NVRAM (high nibble) shift counts
  *   12    TV system (bits 0-1)
  *   13    Vs./PlayChoice = 0
- *   14    Misc ROM count = 0
- *   15    Default expansion device = 1 (Standard NES Controller)
+ *   14    Misc ROM count (bits 0-1)
+ *   15    Default expansion device = 0 (unspecified)
  */
 export function buildNes2Header(p: Nes2HeaderInputs): Uint8Array {
   const h = new Uint8Array(16);
@@ -135,8 +140,9 @@ export function buildNes2Header(p: Nes2HeaderInputs): Uint8Array {
   // Byte 13: Vs. / PlayChoice = 0 (not relevant for our scope).
   h[13] = 0;
 
-  // Byte 14: Miscellaneous ROMs = 0 (none).
-  h[14] = 0;
+  // Byte 14: number of miscellaneous ROMs appended after CHR. Only
+  // bits 0-1 are defined.
+  h[14] = (p.miscRoms ?? 0) & 0x03;
 
   // Byte 15: Default expansion device. 0 = unspecified — we don't
   // know what controller(s) the cart expects.

--- a/src/lib/systems/nes/nes-system-handler.test.ts
+++ b/src/lib/systems/nes/nes-system-handler.test.ts
@@ -18,7 +18,8 @@ describe("NES config sizing", () => {
       const actualBytes =
         16 +
         (cfg.params.prgSizeBytes as number) +
-        (cfg.params.chrSizeBytes as number);
+        (cfg.params.chrSizeBytes as number) +
+        ((cfg.params.miscSizeBytes as number) ?? 0);
       expect(handler.estimateDumpSize(values)).toBe(actualBytes);
     },
   );
@@ -89,5 +90,58 @@ describe("NES computed-header PRG-RAM declarations (buildOutputFile)", () => {
         (o) => !o.disabled,
       ),
     ).toBe(true);
+  });
+});
+
+describe("NES miscellaneous-ROM area (mapper 413)", () => {
+  const handler = new NESSystemHandler();
+
+  it("carries the fixed 8 MiB misc section through config, estimate, and header", () => {
+    const cfg = handler.buildReadConfig({ mapper: 413 });
+    expect(cfg.params.miscSizeBytes).toBe(8192 * 1024);
+    expect(cfg.params.mirroring).toBe("vertical");
+    expect(handler.estimateDumpSize({ mapper: 413 })).toBe(
+      16 + (256 + 256 + 8192) * 1024,
+    );
+    const out = handler.buildOutputFile(new Uint8Array(16), cfg);
+    expect(out.data[14]).toBe(1); // header byte 14: one misc ROM follows CHR
+    expect(out.meta?.["Misc ROM"]).toBe("8192 KB");
+  });
+
+  it("declares no misc ROM for ordinary mappers", () => {
+    const cfg = handler.buildReadConfig({ mapper: 4 });
+    expect(cfg.params.miscSizeBytes).toBe(0);
+    const out = handler.buildOutputFile(new Uint8Array(16), cfg);
+    expect(out.data[14]).toBe(0);
+    expect(out.meta?.["Misc ROM"]).toBeUndefined();
+  });
+});
+
+describe("NES misc-ROM dump analysis (analyzeDump)", () => {
+  const handler = new NESSystemHandler();
+  const cfg = handler.buildReadConfig({ mapper: 413 });
+  const contentBytes = (512 + 8192) * 1024; // PRG + CHR + misc, headerless
+
+  it("flags a miscellaneous ROM that read back as one uniform byte", () => {
+    const content = new Uint8Array(contentBytes); // misc = all 0x00
+    const notes = handler.analyzeDump(content, cfg);
+    expect(notes).toHaveLength(1);
+    expect(notes[0]).toMatch(/miscellaneous ROM/);
+    expect(notes[0]).toMatch(/0x00/);
+  });
+
+  it("stays quiet for non-uniform misc data", () => {
+    const content = new Uint8Array(contentBytes);
+    content[512 * 1024 + 12345] = 0xa7; // one byte of variation in misc
+    expect(handler.analyzeDump(content, cfg)).toHaveLength(0);
+  });
+
+  it("ignores mappers without a misc section", () => {
+    const mmc3Cfg = handler.buildReadConfig({ mapper: 4 });
+    const content = new Uint8Array(
+      (mmc3Cfg.params.prgSizeBytes as number) +
+        (mmc3Cfg.params.chrSizeBytes as number),
+    );
+    expect(handler.analyzeDump(content, mmc3Cfg)).toHaveLength(0);
   });
 });

--- a/src/lib/systems/nes/nes-system-handler.ts
+++ b/src/lib/systems/nes/nes-system-handler.ts
@@ -74,7 +74,8 @@ export class NESSystemHandler implements SystemHandler {
             : `PRG: ${m.prgSizesKB.join("/")}KB` +
               (m.chrSizesKB.some((c) => c > 0)
                 ? ` · CHR: ${m.chrSizesKB.filter((c) => c > 0).join("/")}KB`
-                : " · CHR RAM"),
+                : " · CHR RAM") +
+              (m.miscRomKB ? ` · Misc ROM: ${m.miscRomKB / 1024}MB` : ""),
           disabled,
         };
       }),
@@ -164,7 +165,7 @@ export class NESSystemHandler implements SystemHandler {
   estimateDumpSize(values: ConfigValues): number {
     const def = getMapperDef((values.mapper as number) ?? 0);
     const { prgKB, chrKB } = resolveSizesKB(values, def);
-    return 16 + (prgKB + chrKB) * 1024;
+    return 16 + (prgKB + chrKB + (def?.miscRomKB ?? 0)) * 1024;
   }
 
   validate(values: ConfigValues): ValidationResult {
@@ -224,6 +225,9 @@ export class NESSystemHandler implements SystemHandler {
         mapper,
         prgSizeBytes: prgSizeKB * 1024,
         chrSizeBytes: chrSizeKB * 1024,
+        // Fixed per board (never user-selectable); 0 for all but
+        // mapper 413's sample flash.
+        miscSizeBytes: (mapperDef?.miscRomKB ?? 0) * 1024,
         // Mirroring isn't user-set; default per the mapper. It doesn't
         // affect the dumped bytes, and a No-Intro match restamps the
         // canonical header regardless.
@@ -249,6 +253,7 @@ export class NESSystemHandler implements SystemHandler {
     const p = config.params;
     const prgBytes = p.prgSizeBytes as number;
     const chrBytes = p.chrSizeBytes as number;
+    const miscBytes = (p.miscSizeBytes as number) ?? 0;
     const mapper = p.mapper as number;
     const mirroring = p.mirroring as NesMirroring;
     const battery = p.battery as boolean;
@@ -290,6 +295,7 @@ export class NESSystemHandler implements SystemHandler {
           chrRamKB,
           prgRamKB,
           prgNvramKB,
+          miscRoms: miscBytes > 0 ? 1 : 0,
         });
 
     const output = new Uint8Array(header.length + rawData.length);
@@ -315,6 +321,7 @@ export class NESSystemHandler implements SystemHandler {
             : chrRamKB > 0
               ? `None (${chrRamKB} KB CHR-RAM)`
               : "None",
+        ...(miscBytes > 0 ? { "Misc ROM": `${miscBytes / 1024} KB` } : {}),
         Mirroring: mirroring,
         Battery: battery ? "Yes" : "No",
       },
@@ -323,8 +330,11 @@ export class NESSystemHandler implements SystemHandler {
 
   async computeHashes(rawData: Uint8Array): Promise<VerificationHashes> {
     // No-Intro NES DATs are "Headered" — hash includes the 16-byte iNES header.
-    // rawData here is PRG+CHR without header, but buildOutputFile prepends it.
-    // We hash the raw data for now; verify() will try both raw and headered.
+    // rawData here is the headerless content in NES 2.0 file order —
+    // PRG+CHR, plus the miscellaneous-ROM area when the board has one
+    // (mapper 413) — and buildOutputFile prepends the header. DAT entries
+    // hash the whole headered file, so misc data belongs in the content
+    // hash; verify() reconstructs header+content for the exact match.
     const [sha1, sha256] = await Promise.all([
       sha1Hex(rawData),
       sha256Hex(rawData),
@@ -395,12 +405,14 @@ export class NESSystemHandler implements SystemHandler {
    * recovers them.
    */
   analyzeDump(content: Uint8Array, config: ReadConfig): string[] {
+    const notes = this.analyzeMiscRom(content, config);
+
     const PRG_BANK = 8 * 1024;
     const prgBytes = (config.params.prgSizeBytes as number) ?? 0;
-    if (prgBytes <= 0 || prgBytes > content.length) return [];
+    if (prgBytes <= 0 || prgBytes > content.length) return notes;
 
     const numBanks = Math.floor(prgBytes / PRG_BANK);
-    if (numBanks < 2) return [];
+    if (numBanks < 2) return notes;
 
     const prg = content.subarray(0, prgBytes);
     const bank0 = prg.subarray(0, PRG_BANK);
@@ -409,7 +421,7 @@ export class NESSystemHandler implements SystemHandler {
     // "identical to bank 0" meaningless: that's a blank/dead read, a
     // different signal. Skip rather than cry wolf. Same predicate the
     // in-dump retry uses — see mappers/bank-reliability.
-    if (isUniformFill(bank0)) return [];
+    if (isUniformFill(bank0)) return notes;
 
     let dup = 0;
     for (let i = 1; i < numBanks; i++) {
@@ -417,10 +429,37 @@ export class NESSystemHandler implements SystemHandler {
       if (bytesEqual(prg.subarray(start, start + PRG_BANK), bank0)) dup++;
     }
 
-    if (dup === 0) return [];
+    if (dup === 0) return notes;
     return [
+      ...notes,
       `${dup} of ${numBanks} PRG banks (8 KiB) are byte-identical to bank 0 — ` +
         "if unexpected, this can indicate a bank-switch latch failure; re-dumping may recover them.",
+    ];
+  }
+
+  /**
+   * Flag a miscellaneous-ROM area that came back as one uniform byte.
+   * The in-dump port probe (see mappers/batmap) cannot tell a dead
+   * data port from genuinely uniform stream data — both satisfy its
+   * overlap check — so this is the post-dump half of that trade-off:
+   * the one board we dump misc ROM from carries minutes of speech, and
+   * a whole section of a single byte value is a dead/misread port, not
+   * plausible content. Trailing erased-flash fill is normal; an entire
+   * uniform section is the signal.
+   */
+  private analyzeMiscRom(content: Uint8Array, config: ReadConfig): string[] {
+    const prgBytes = (config.params.prgSizeBytes as number) ?? 0;
+    const chrBytes = (config.params.chrSizeBytes as number) ?? 0;
+    const miscBytes = (config.params.miscSizeBytes as number) ?? 0;
+    const start = prgBytes + chrBytes;
+    if (miscBytes <= 0 || start + miscBytes > content.length) return [];
+
+    const misc = content.subarray(start, start + miscBytes);
+    if (!isUniformFill(misc)) return [];
+    return [
+      `The ${miscBytes / 1024} KB miscellaneous ROM read back as a single ` +
+        `repeated byte (0x${misc[0].toString(16).padStart(2, "0").toUpperCase()}) — ` +
+        "that is a dead or misread data port, not plausible sample data; re-seat the cart and re-dump.",
     ];
   }
 }


### PR DESCRIPTION
Adds the BATMAP board (mapper 413) to the shared, device-neutral NES mapper catalog.

- **PRG + CHR** (256 KiB each) walk through the board's single value-addressed bank port.
- **8 MiB serial sample flash** dumps as the NES 2.0 miscellaneous-ROM file section (header byte 14). It's a transparent CPLD-to-SPI bridge — an arm pulse on `$D000` bit 0, a raw 32-bit READ frame bit-banged via `$C000` writes, one SPI clock per `/ROMSEL` read — behind an optional `readSpiDataPort` bus capability. Each 1 MiB block re-opens its own frame (retry/abort-safe), and a pre-flight probe (deterministic re-read + a shifted-overlap read from address 4) rejects a dead or misclocked port before the multi-minute dump.
- Plumbs the misc-ROM section through the header builder, the dump config/estimate/output, and the system handler (which flags an all-uniform misc result — the one failure the probe can't see).

**Not selectable on the INL Retro.** The INL drives the board's registers and dumps PRG/CHR fine, but reading the serial flash needs the firmware's `NESCPU_SPI413` memtype to pace eight cart-ROM clocks per byte, which isn't in a released firmware yet (the flash reads as solid `0xFF`). The read path is implemented and left dormant behind the INL's unsupported-mapper entry; deleting that entry re-enables it once the upstream firmware lands: https://gitlab.com/InfiniteNesLives/INL-retro-progdump/-/merge_requests/45